### PR TITLE
[Missing Geographies] Fixed filter to fit new json format

### DIFF
--- a/index.php
+++ b/index.php
@@ -7675,17 +7675,26 @@ schema.innerText = '';
 	});	// onclick get_EEO_data	
 
 	async function fetchMSAComps(msaName) {
+		//TODO: process msaName to be lowercase 
+
 		//process the json
 		let msaPromise = new Promise(function(res, rej) {
 			let countyEquivs = $.getJSON('msa-components-2018.json', function(json) {
-				console.log(json);
+				// console.log(json);
+				
 				//filter to include only designated MSA 
-				let componentsArr = Object.values(json).filter(msa => msa[0]['CBSA Title'] === msaName)[0];
+				let componentsArr = json[msaName];
+				// let componentsArr = Object.values(json).filter(msa => msa[0]['CBSA Title'] === msaName)[0];
+				console.log(componentsArr);
+				
+				//return all the county components
 				let countyEquivArr = [];
-				componentsArr.forEach((comp) => {
-					countyEquivArr.push(comp['County']['County Equivalent']);
-				});
-				// console.log('The components in', msaName, 'are', countyEquivArr);
+				if (componentsArr.length > 0) {
+					componentsArr.forEach((comp) => {
+						countyEquivArr.push(comp['County']['County Equivalent']);
+					});
+					console.log('The components in', msaName, 'are', countyEquivArr);
+				}
 				res(countyEquivArr);
 			});
 		});

--- a/msa-components-2018.csv
+++ b/msa-components-2018.csv
@@ -1,1255 +1,1916 @@
-﻿CBSA Title,CBSA Code,Metropolitan Division Code,CSA Code,Metropolitan Division Title,CSA Title,County/County Equivalent,State Name,FIPS State Code,FIPS County Code,Central/Outlying County
-"Abilene, TX",10180,,,,,Callahan County,Texas,48,059,Outlying
-"Abilene, TX",10180,,,,,Jones County,Texas,48,253,Outlying
-"Abilene, TX",10180,,,,,Taylor County,Texas,48,441,Central
-"Aguadilla-Isabela, PR",10380,,,,,Aguada Municipio,Puerto Rico,72,003,Central
-"Aguadilla-Isabela, PR",10380,,,,,Aguadilla Municipio,Puerto Rico,72,005,Central
-"Aguadilla-Isabela, PR",10380,,,,,Añasco Municipio,Puerto Rico,72,011,Central
-"Aguadilla-Isabela, PR",10380,,,,,Isabela Municipio,Puerto Rico,72,071,Central
-"Aguadilla-Isabela, PR",10380,,,,,Lares Municipio,Puerto Rico,72,081,Central
-"Aguadilla-Isabela, PR",10380,,,,,Moca Municipio,Puerto Rico,72,099,Central
-"Aguadilla-Isabela, PR",10380,,,,,Rincón Municipio,Puerto Rico,72,117,Central
-"Aguadilla-Isabela, PR",10380,,,,,San Sebastián Municipio,Puerto Rico,72,131,Central
-"Aguadilla-Isabela, PR",10380,,,,,Utuado Municipio,Puerto Rico,72,141,Central
-"Akron, OH",10420,,184,,"Cleveland-Akron-Canton, OH",Portage County,Ohio,39,133,Central
-"Akron, OH",10420,,184,,"Cleveland-Akron-Canton, OH",Summit County,Ohio,39,153,Central
-"Albany, GA",10500,,,,,Dougherty County,Georgia,13,095,Central
-"Albany, GA",10500,,,,,Lee County,Georgia,13,177,Central
-"Albany, GA",10500,,,,,Terrell County,Georgia,13,273,Outlying
-"Albany, GA",10500,,,,,Worth County,Georgia,13,321,Outlying
-"Albany-Lebanon, OR",10540,,440,,"Portland-Vancouver-Salem, OR-WA",Linn County,Oregon,41,043,Central
-"Albany-Schenectady-Troy, NY",10580,,104,,"Albany-Schenectady, NY",Albany County,New York,36,001,Central
-"Albany-Schenectady-Troy, NY",10580,,104,,"Albany-Schenectady, NY",Rensselaer County,New York,36,083,Central
-"Albany-Schenectady-Troy, NY",10580,,104,,"Albany-Schenectady, NY",Saratoga County,New York,36,091,Central
-"Albany-Schenectady-Troy, NY",10580,,104,,"Albany-Schenectady, NY",Schenectady County,New York,36,093,Central
-"Albany-Schenectady-Troy, NY",10580,,104,,"Albany-Schenectady, NY",Schoharie County,New York,36,095,Outlying
-"Albuquerque, NM",10740,,106,,"Albuquerque-Santa Fe-Las Vegas, NM",Bernalillo County,New Mexico,35,001,Central
-"Albuquerque, NM",10740,,106,,"Albuquerque-Santa Fe-Las Vegas, NM",Sandoval County,New Mexico,35,043,Central
-"Albuquerque, NM",10740,,106,,"Albuquerque-Santa Fe-Las Vegas, NM",Torrance County,New Mexico,35,057,Outlying
-"Albuquerque, NM",10740,,106,,"Albuquerque-Santa Fe-Las Vegas, NM",Valencia County,New Mexico,35,061,Outlying
-"Alexandria, LA",10780,,,,,Grant Parish,Louisiana,22,043,Outlying
-"Alexandria, LA",10780,,,,,Rapides Parish,Louisiana,22,079,Central
-"Allentown-Bethlehem-Easton, PA-NJ",10900,,,,,Warren County,New Jersey,34,041,Central
-"Allentown-Bethlehem-Easton, PA-NJ",10900,,,,,Carbon County,Pennsylvania,42,025,Central
-"Allentown-Bethlehem-Easton, PA-NJ",10900,,,,,Lehigh County,Pennsylvania,42,077,Central
-"Allentown-Bethlehem-Easton, PA-NJ",10900,,,,,Northampton County,Pennsylvania,42,095,Central
-"Altoona, PA",11020,,107,,"Altoona-Huntingdon, PA",Blair County,Pennsylvania,42,013,Central
-"Amarillo, TX",11100,,108,,"Amarillo-Pampa-Borger, TX",Armstrong County,Texas,48,011,Outlying
-"Amarillo, TX",11100,,108,,"Amarillo-Pampa-Borger, TX",Carson County,Texas,48,065,Outlying
-"Amarillo, TX",11100,,108,,"Amarillo-Pampa-Borger, TX",Oldham County,Texas,48,359,Outlying
-"Amarillo, TX",11100,,108,,"Amarillo-Pampa-Borger, TX",Potter County,Texas,48,375,Central
-"Amarillo, TX",11100,,108,,"Amarillo-Pampa-Borger, TX",Randall County,Texas,48,381,Central
-"Ames, IA",11180,,218,,"Des Moines-Ames-West Des Moines, IA",Boone County,Iowa,19,015,Outlying
-"Ames, IA",11180,,218,,"Des Moines-Ames-West Des Moines, IA",Story County,Iowa,19,169,Central
-"Anchorage, AK",11260,,,,,Anchorage Municipality,Alaska,02,020,Central
-"Anchorage, AK",11260,,,,,Matanuska-Susitna Borough,Alaska,02,170,Outlying
-"Ann Arbor, MI",11460,,220,,"Detroit-Warren-Ann Arbor, MI",Washtenaw County,Michigan,26,161,Central
-"Anniston-Oxford, AL",11500,,,,,Calhoun County,Alabama,01,015,Central
-"Appleton, WI",11540,,118,,"Appleton-Oshkosh-Neenah, WI",Calumet County,Wisconsin,55,015,Central
-"Appleton, WI",11540,,118,,"Appleton-Oshkosh-Neenah, WI",Outagamie County,Wisconsin,55,087,Central
-"Arecibo, PR",11640,,490,,"San Juan-Bayamón, PR",Arecibo Municipio,Puerto Rico,72,013,Central
-"Arecibo, PR",11640,,490,,"San Juan-Bayamón, PR",Camuy Municipio,Puerto Rico,72,027,Central
-"Arecibo, PR",11640,,490,,"San Juan-Bayamón, PR",Hatillo Municipio,Puerto Rico,72,065,Central
-"Arecibo, PR",11640,,490,,"San Juan-Bayamón, PR",Quebradillas Municipio,Puerto Rico,72,115,Central
-"Asheville, NC",11700,,120,,"Asheville-Marion-Brevard, NC",Buncombe County,North Carolina,37,021,Central
-"Asheville, NC",11700,,120,,"Asheville-Marion-Brevard, NC",Haywood County,North Carolina,37,087,Central
-"Asheville, NC",11700,,120,,"Asheville-Marion-Brevard, NC",Henderson County,North Carolina,37,089,Central
-"Asheville, NC",11700,,120,,"Asheville-Marion-Brevard, NC",Madison County,North Carolina,37,115,Outlying
-"Athens-Clarke County, GA",12020,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Clarke County,Georgia,13,059,Central
-"Athens-Clarke County, GA",12020,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Madison County,Georgia,13,195,Outlying
-"Athens-Clarke County, GA",12020,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Oconee County,Georgia,13,219,Central
-"Athens-Clarke County, GA",12020,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Oglethorpe County,Georgia,13,221,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Barrow County,Georgia,13,013,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Bartow County,Georgia,13,015,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Butts County,Georgia,13,035,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Carroll County,Georgia,13,045,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Cherokee County,Georgia,13,057,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Clayton County,Georgia,13,063,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Cobb County,Georgia,13,067,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Coweta County,Georgia,13,077,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Dawson County,Georgia,13,085,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",DeKalb County,Georgia,13,089,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Douglas County,Georgia,13,097,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Fayette County,Georgia,13,113,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Forsyth County,Georgia,13,117,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Fulton County,Georgia,13,121,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Gwinnett County,Georgia,13,135,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Haralson County,Georgia,13,143,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Heard County,Georgia,13,149,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Henry County,Georgia,13,151,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Jasper County,Georgia,13,159,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Lamar County,Georgia,13,171,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Meriwether County,Georgia,13,199,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Morgan County,Georgia,13,211,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Newton County,Georgia,13,217,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Paulding County,Georgia,13,223,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Pickens County,Georgia,13,227,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Pike County,Georgia,13,231,Outlying
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Rockdale County,Georgia,13,247,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Spalding County,Georgia,13,255,Central
-"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Walton County,Georgia,13,297,Central
-"Atlantic City-Hammonton, NJ",12100,,428,,"Philadelphia-Reading-Camden, PA-NJ-DE-MD",Atlantic County,New Jersey,34,001,Central
-"Auburn-Opelika, AL",12220,,194,,"Columbus-Auburn-Opelika, GA-AL",Lee County,Alabama,01,081,Central
-"Augusta-Richmond County, GA-SC",12260,,,,,Burke County,Georgia,13,033,Outlying
-"Augusta-Richmond County, GA-SC",12260,,,,,Columbia County,Georgia,13,073,Central
-"Augusta-Richmond County, GA-SC",12260,,,,,Lincoln County,Georgia,13,181,Outlying
-"Augusta-Richmond County, GA-SC",12260,,,,,McDuffie County,Georgia,13,189,Outlying
-"Augusta-Richmond County, GA-SC",12260,,,,,Richmond County,Georgia,13,245,Central
-"Augusta-Richmond County, GA-SC",12260,,,,,Aiken County,South Carolina,45,003,Central
-"Augusta-Richmond County, GA-SC",12260,,,,,Edgefield County,South Carolina,45,037,Outlying
-"Austin-Round Rock-Georgetown, TX",12420,,,,,Bastrop County,Texas,48,021,Outlying
-"Austin-Round Rock-Georgetown, TX",12420,,,,,Caldwell County,Texas,48,055,Outlying
-"Austin-Round Rock-Georgetown, TX",12420,,,,,Hays County,Texas,48,209,Central
-"Austin-Round Rock-Georgetown, TX",12420,,,,,Travis County,Texas,48,453,Central
-"Austin-Round Rock-Georgetown, TX",12420,,,,,Williamson County,Texas,48,491,Central
-"Bakersfield, CA",12540,,,,,Kern County,California,06,029,Central
-"Baltimore-Columbia-Towson, MD",12580,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Anne Arundel County,Maryland,24,003,Central
-"Baltimore-Columbia-Towson, MD",12580,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Baltimore County,Maryland,24,005,Central
-"Baltimore-Columbia-Towson, MD",12580,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Carroll County,Maryland,24,013,Outlying
-"Baltimore-Columbia-Towson, MD",12580,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Harford County,Maryland,24,025,Outlying
-"Baltimore-Columbia-Towson, MD",12580,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Howard County,Maryland,24,027,Central
-"Baltimore-Columbia-Towson, MD",12580,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Queen Anne's County,Maryland,24,035,Central
-"Baltimore-Columbia-Towson, MD",12580,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Baltimore city,Maryland,24,510,Central
-"Bangor, ME",12620,,,,,Penobscot County,Maine,23,019,Central
-"Barnstable Town, MA",12700,,148,,"Boston-Worcester-Providence, MA-RI-NH-CT",Barnstable County,Massachusetts,25,001,Central
-"Baton Rouge, LA",12940,,,,,Ascension Parish,Louisiana,22,005,Central
-"Baton Rouge, LA",12940,,,,,Assumption Parish,Louisiana,22,007,Outlying
-"Baton Rouge, LA",12940,,,,,East Baton Rouge Parish,Louisiana,22,033,Central
-"Baton Rouge, LA",12940,,,,,East Feliciana Parish,Louisiana,22,037,Outlying
-"Baton Rouge, LA",12940,,,,,Iberville Parish,Louisiana,22,047,Central
-"Baton Rouge, LA",12940,,,,,Livingston Parish,Louisiana,22,063,Central
-"Baton Rouge, LA",12940,,,,,Pointe Coupee Parish,Louisiana,22,077,Outlying
-"Baton Rouge, LA",12940,,,,,St. Helena Parish,Louisiana,22,091,Outlying
-"Baton Rouge, LA",12940,,,,,West Baton Rouge Parish,Louisiana,22,121,Central
-"Baton Rouge, LA",12940,,,,,West Feliciana Parish,Louisiana,22,125,Outlying
-"Battle Creek, MI",12980,,310,,"Kalamazoo-Battle Creek-Portage, MI",Calhoun County,Michigan,26,025,Central
-"Bay City, MI",13020,,474,,"Saginaw-Midland-Bay City, MI",Bay County,Michigan,26,017,Central
-"Beaumont-Port Arthur, TX",13140,,,,,Hardin County,Texas,48,199,Outlying
-"Beaumont-Port Arthur, TX",13140,,,,,Jefferson County,Texas,48,245,Central
-"Beaumont-Port Arthur, TX",13140,,,,,Orange County,Texas,48,361,Central
-"Beckley, WV",13220,,,,,Fayette County,West Virginia,54,019,Central
-"Beckley, WV",13220,,,,,Raleigh County,West Virginia,54,081,Central
-"Bellingham, WA",13380,,,,,Whatcom County,Washington,53,073,Central
-"Bend, OR",13460,,140,,"Bend-Prineville, OR",Deschutes County,Oregon,41,017,Central
-"Billings, MT",13740,,,,,Carbon County,Montana,30,009,Outlying
-"Billings, MT",13740,,,,,Stillwater County,Montana,30,095,Outlying
-"Billings, MT",13740,,,,,Yellowstone County,Montana,30,111,Central
-"Binghamton, NY",13780,,,,,Broome County,New York,36,007,Central
-"Binghamton, NY",13780,,,,,Tioga County,New York,36,107,Central
-"Birmingham-Hoover, AL",13820,,142,,"Birmingham-Hoover-Talladega, AL",Bibb County,Alabama,01,007,Outlying
-"Birmingham-Hoover, AL",13820,,142,,"Birmingham-Hoover-Talladega, AL",Blount County,Alabama,01,009,Outlying
-"Birmingham-Hoover, AL",13820,,142,,"Birmingham-Hoover-Talladega, AL",Chilton County,Alabama,01,021,Outlying
-"Birmingham-Hoover, AL",13820,,142,,"Birmingham-Hoover-Talladega, AL",Jefferson County,Alabama,01,073,Central
-"Birmingham-Hoover, AL",13820,,142,,"Birmingham-Hoover-Talladega, AL",St. Clair County,Alabama,01,115,Outlying
-"Birmingham-Hoover, AL",13820,,142,,"Birmingham-Hoover-Talladega, AL",Shelby County,Alabama,01,117,Central
-"Bismarck, ND",13900,,,,,Burleigh County,North Dakota,38,015,Central
-"Bismarck, ND",13900,,,,,Morton County,North Dakota,38,059,Central
-"Bismarck, ND",13900,,,,,Oliver County,North Dakota,38,065,Outlying
-"Blacksburg-Christiansburg, VA",13980,,,,,Giles County,Virginia,51,071,Outlying
-"Blacksburg-Christiansburg, VA",13980,,,,,Montgomery County,Virginia,51,121,Central
-"Blacksburg-Christiansburg, VA",13980,,,,,Pulaski County,Virginia,51,155,Outlying
-"Blacksburg-Christiansburg, VA",13980,,,,,Radford city,Virginia,51,750,Central
-"Bloomington, IL",14010,,145,,"Bloomington-Pontiac, IL",McLean County,Illinois,17,113,Central
-"Bloomington, IN",14020,,144,,"Bloomington-Bedford, IN",Monroe County,Indiana,18,105,Central
-"Bloomington, IN",14020,,144,,"Bloomington-Bedford, IN",Owen County,Indiana,18,119,Outlying
-"Bloomsburg-Berwick, PA",14100,,146,,"Bloomsburg-Berwick-Sunbury, PA",Columbia County,Pennsylvania,42,037,Central
-"Bloomsburg-Berwick, PA",14100,,146,,"Bloomsburg-Berwick-Sunbury, PA",Montour County,Pennsylvania,42,093,Central
-"Boise City, ID",14260,,147,,"Boise City-Mountain Home-Ontario, ID-OR",Ada County,Idaho,16,001,Central
-"Boise City, ID",14260,,147,,"Boise City-Mountain Home-Ontario, ID-OR",Boise County,Idaho,16,015,Outlying
-"Boise City, ID",14260,,147,,"Boise City-Mountain Home-Ontario, ID-OR",Canyon County,Idaho,16,027,Outlying
-"Boise City, ID",14260,,147,,"Boise City-Mountain Home-Ontario, ID-OR",Gem County,Idaho,16,045,Outlying
-"Boise City, ID",14260,,147,,"Boise City-Mountain Home-Ontario, ID-OR",Owyhee County,Idaho,16,073,Outlying
-"Boston-Cambridge-Newton, MA-NH",14460,14454,148,"Boston, MA","Boston-Worcester-Providence, MA-RI-NH-CT",Norfolk County,Massachusetts,25,021,Central
-"Boston-Cambridge-Newton, MA-NH",14460,14454,148,"Boston, MA","Boston-Worcester-Providence, MA-RI-NH-CT",Plymouth County,Massachusetts,25,023,Central
-"Boston-Cambridge-Newton, MA-NH",14460,14454,148,"Boston, MA","Boston-Worcester-Providence, MA-RI-NH-CT",Suffolk County,Massachusetts,25,025,Central
-"Boston-Cambridge-Newton, MA-NH",14460,15764,148,"Cambridge-Newton-Framingham, MA","Boston-Worcester-Providence, MA-RI-NH-CT",Essex County,Massachusetts,25,009,Central
-"Boston-Cambridge-Newton, MA-NH",14460,15764,148,"Cambridge-Newton-Framingham, MA","Boston-Worcester-Providence, MA-RI-NH-CT",Middlesex County,Massachusetts,25,017,Central
-"Boston-Cambridge-Newton, MA-NH",14460,40484,148,"Rockingham County-Strafford County, NH","Boston-Worcester-Providence, MA-RI-NH-CT",Rockingham County,New Hampshire,33,015,Central
-"Boston-Cambridge-Newton, MA-NH",14460,40484,148,"Rockingham County-Strafford County, NH","Boston-Worcester-Providence, MA-RI-NH-CT",Strafford County,New Hampshire,33,017,Outlying
-"Boulder, CO",14500,,216,,"Denver-Aurora, CO",Boulder County,Colorado,08,013,Central
-"Bowling Green, KY",14540,,150,,"Bowling Green-Glasgow, KY",Allen County,Kentucky,21,003,Outlying
-"Bowling Green, KY",14540,,150,,"Bowling Green-Glasgow, KY",Butler County,Kentucky,21,031,Outlying
-"Bowling Green, KY",14540,,150,,"Bowling Green-Glasgow, KY",Edmonson County,Kentucky,21,061,Outlying
-"Bowling Green, KY",14540,,150,,"Bowling Green-Glasgow, KY",Warren County,Kentucky,21,227,Central
-"Bremerton-Silverdale-Port Orchard, WA",14740,,500,,"Seattle-Tacoma, WA",Kitsap County,Washington,53,035,Central
-"Bridgeport-Stamford-Norwalk, CT",14860,,408,,"New York-Newark, NY-NJ-CT-PA",Fairfield County,Connecticut,09,001,Central
-"Brownsville-Harlingen, TX",15180,,154,,"Brownsville-Harlingen-Raymondville, TX",Cameron County,Texas,48,061,Central
-"Brunswick, GA",15260,,,,,Brantley County,Georgia,13,025,Outlying
-"Brunswick, GA",15260,,,,,Glynn County,Georgia,13,127,Central
-"Brunswick, GA",15260,,,,,McIntosh County,Georgia,13,191,Outlying
-"Buffalo-Cheektowaga, NY",15380,,160,,"Buffalo-Cheektowaga-Olean, NY",Erie County,New York,36,029,Central
-"Buffalo-Cheektowaga, NY",15380,,160,,"Buffalo-Cheektowaga-Olean, NY",Niagara County,New York,36,063,Central
-"Burlington, NC",15500,,268,,"Greensboro--Winston-Salem--High Point, NC",Alamance County,North Carolina,37,001,Central
-"Burlington-South Burlington, VT",15540,,162,,"Burlington-South Burlington-Barre, VT",Chittenden County,Vermont,50,007,Central
-"Burlington-South Burlington, VT",15540,,162,,"Burlington-South Burlington-Barre, VT",Franklin County,Vermont,50,011,Outlying
-"Burlington-South Burlington, VT",15540,,162,,"Burlington-South Burlington-Barre, VT",Grand Isle County,Vermont,50,013,Outlying
-"California-Lexington Park, MD",15680,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",St. Mary's County,Maryland,24,037,Central
-"Canton-Massillon, OH",15940,,184,,"Cleveland-Akron-Canton, OH",Carroll County,Ohio,39,019,Outlying
-"Canton-Massillon, OH",15940,,184,,"Cleveland-Akron-Canton, OH",Stark County,Ohio,39,151,Central
-"Cape Coral-Fort Myers, FL",15980,,163,,"Cape Coral-Fort Myers-Naples, FL",Lee County,Florida,12,071,Central
-"Cape Girardeau, MO-IL",16020,,164,,"Cape Girardeau-Sikeston, MO-IL",Alexander County,Illinois,17,003,Outlying
-"Cape Girardeau, MO-IL",16020,,164,,"Cape Girardeau-Sikeston, MO-IL",Bollinger County,Missouri,29,017,Outlying
-"Cape Girardeau, MO-IL",16020,,164,,"Cape Girardeau-Sikeston, MO-IL",Cape Girardeau County,Missouri,29,031,Central
-"Carbondale-Marion, IL",16060,,,,,Jackson County,Illinois,17,077,Central
-"Carbondale-Marion, IL",16060,,,,,Johnson County,Illinois,17,087,Outlying
-"Carbondale-Marion, IL",16060,,,,,Williamson County,Illinois,17,199,Central
-"Carson City, NV",16180,,456,,"Reno-Carson City-Fernley, NV",Carson City,Nevada,32,510,Central
-"Casper, WY",16220,,,,,Natrona County,Wyoming,56,025,Central
-"Cedar Rapids, IA",16300,,168,,"Cedar Rapids-Iowa City, IA",Benton County,Iowa,19,011,Outlying
-"Cedar Rapids, IA",16300,,168,,"Cedar Rapids-Iowa City, IA",Jones County,Iowa,19,105,Outlying
-"Cedar Rapids, IA",16300,,168,,"Cedar Rapids-Iowa City, IA",Linn County,Iowa,19,113,Central
-"Chambersburg-Waynesboro, PA",16540,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Franklin County,Pennsylvania,42,055,Central
-"Champaign-Urbana, IL",16580,,,,,Champaign County,Illinois,17,019,Central
-"Champaign-Urbana, IL",16580,,,,,Piatt County,Illinois,17,147,Outlying
-"Charleston, WV",16620,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Boone County,West Virginia,54,005,Outlying
-"Charleston, WV",16620,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Clay County,West Virginia,54,015,Outlying
-"Charleston, WV",16620,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Jackson County,West Virginia,54,035,Outlying
-"Charleston, WV",16620,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Kanawha County,West Virginia,54,039,Central
-"Charleston, WV",16620,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Lincoln County,West Virginia,54,043,Outlying
-"Charleston-North Charleston, SC",16700,,,,,Berkeley County,South Carolina,45,015,Central
-"Charleston-North Charleston, SC",16700,,,,,Charleston County,South Carolina,45,019,Central
-"Charleston-North Charleston, SC",16700,,,,,Dorchester County,South Carolina,45,035,Central
-"Charlotte-Concord-Gastonia, NC-SC",16740,,172,,"Charlotte-Concord, NC-SC",Anson County,North Carolina,37,007,Outlying
-"Charlotte-Concord-Gastonia, NC-SC",16740,,172,,"Charlotte-Concord, NC-SC",Cabarrus County,North Carolina,37,025,Outlying
-"Charlotte-Concord-Gastonia, NC-SC",16740,,172,,"Charlotte-Concord, NC-SC",Gaston County,North Carolina,37,071,Outlying
-"Charlotte-Concord-Gastonia, NC-SC",16740,,172,,"Charlotte-Concord, NC-SC",Iredell County,North Carolina,37,097,Central
-"Charlotte-Concord-Gastonia, NC-SC",16740,,172,,"Charlotte-Concord, NC-SC",Lincoln County,North Carolina,37,109,Outlying
-"Charlotte-Concord-Gastonia, NC-SC",16740,,172,,"Charlotte-Concord, NC-SC",Mecklenburg County,North Carolina,37,119,Central
-"Charlotte-Concord-Gastonia, NC-SC",16740,,172,,"Charlotte-Concord, NC-SC",Rowan County,North Carolina,37,159,Outlying
-"Charlotte-Concord-Gastonia, NC-SC",16740,,172,,"Charlotte-Concord, NC-SC",Union County,North Carolina,37,179,Central
-"Charlotte-Concord-Gastonia, NC-SC",16740,,172,,"Charlotte-Concord, NC-SC",Chester County,South Carolina,45,023,Outlying
-"Charlotte-Concord-Gastonia, NC-SC",16740,,172,,"Charlotte-Concord, NC-SC",Lancaster County,South Carolina,45,057,Outlying
-"Charlotte-Concord-Gastonia, NC-SC",16740,,172,,"Charlotte-Concord, NC-SC",York County,South Carolina,45,091,Outlying
-"Charlottesville, VA",16820,,,,,Albemarle County,Virginia,51,003,Central
-"Charlottesville, VA",16820,,,,,Fluvanna County,Virginia,51,065,Outlying
-"Charlottesville, VA",16820,,,,,Greene County,Virginia,51,079,Outlying
-"Charlottesville, VA",16820,,,,,Nelson County,Virginia,51,125,Outlying
-"Charlottesville, VA",16820,,,,,Charlottesville city,Virginia,51,540,Central
-"Chattanooga, TN-GA",16860,,174,,"Chattanooga-Cleveland-Dalton, TN-GA",Catoosa County,Georgia,13,047,Central
-"Chattanooga, TN-GA",16860,,174,,"Chattanooga-Cleveland-Dalton, TN-GA",Dade County,Georgia,13,083,Outlying
-"Chattanooga, TN-GA",16860,,174,,"Chattanooga-Cleveland-Dalton, TN-GA",Walker County,Georgia,13,295,Central
-"Chattanooga, TN-GA",16860,,174,,"Chattanooga-Cleveland-Dalton, TN-GA",Hamilton County,Tennessee,47,065,Central
-"Chattanooga, TN-GA",16860,,174,,"Chattanooga-Cleveland-Dalton, TN-GA",Marion County,Tennessee,47,115,Outlying
-"Chattanooga, TN-GA",16860,,174,,"Chattanooga-Cleveland-Dalton, TN-GA",Sequatchie County,Tennessee,47,153,Outlying
-"Cheyenne, WY",16940,,,,,Laramie County,Wyoming,56,021,Central
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,16984,176,"Chicago-Naperville-Evanston, IL","Chicago-Naperville, IL-IN-WI",Cook County,Illinois,17,031,Central
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,16984,176,"Chicago-Naperville-Evanston, IL","Chicago-Naperville, IL-IN-WI",DuPage County,Illinois,17,043,Central
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,16984,176,"Chicago-Naperville-Evanston, IL","Chicago-Naperville, IL-IN-WI",Grundy County,Illinois,17,063,Outlying
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,16984,176,"Chicago-Naperville-Evanston, IL","Chicago-Naperville, IL-IN-WI",McHenry County,Illinois,17,111,Central
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,16984,176,"Chicago-Naperville-Evanston, IL","Chicago-Naperville, IL-IN-WI",Will County,Illinois,17,197,Central
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,20994,176,"Elgin, IL","Chicago-Naperville, IL-IN-WI",DeKalb County,Illinois,17,037,Outlying
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,20994,176,"Elgin, IL","Chicago-Naperville, IL-IN-WI",Kane County,Illinois,17,089,Central
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,20994,176,"Elgin, IL","Chicago-Naperville, IL-IN-WI",Kendall County,Illinois,17,093,Central
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,23844,176,"Gary, IN","Chicago-Naperville, IL-IN-WI",Jasper County,Indiana,18,073,Outlying
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,23844,176,"Gary, IN","Chicago-Naperville, IL-IN-WI",Lake County,Indiana,18,089,Central
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,23844,176,"Gary, IN","Chicago-Naperville, IL-IN-WI",Newton County,Indiana,18,111,Outlying
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,23844,176,"Gary, IN","Chicago-Naperville, IL-IN-WI",Porter County,Indiana,18,127,Central
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,29404,176,"Lake County-Kenosha County, IL-WI","Chicago-Naperville, IL-IN-WI",Lake County,Illinois,17,097,Central
-"Chicago-Naperville-Elgin, IL-IN-WI",16980,29404,176,"Lake County-Kenosha County, IL-WI","Chicago-Naperville, IL-IN-WI",Kenosha County,Wisconsin,55,059,Outlying
-"Chico, CA",17020,,,,,Butte County,California,06,007,Central
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Dearborn County,Indiana,18,029,Outlying
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Franklin County,Indiana,18,047,Outlying
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Ohio County,Indiana,18,115,Outlying
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Union County,Indiana,18,161,Outlying
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Boone County,Kentucky,21,015,Central
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Bracken County,Kentucky,21,023,Outlying
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Campbell County,Kentucky,21,037,Central
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Gallatin County,Kentucky,21,077,Outlying
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Grant County,Kentucky,21,081,Outlying
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Kenton County,Kentucky,21,117,Central
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Pendleton County,Kentucky,21,191,Outlying
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Brown County,Ohio,39,015,Outlying
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Butler County,Ohio,39,017,Central
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Clermont County,Ohio,39,025,Central
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Hamilton County,Ohio,39,061,Central
-"Cincinnati, OH-KY-IN",17140,,178,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Warren County,Ohio,39,165,Central
-"Clarksville, TN-KY",17300,,,,,Christian County,Kentucky,21,047,Outlying
-"Clarksville, TN-KY",17300,,,,,Trigg County,Kentucky,21,221,Outlying
-"Clarksville, TN-KY",17300,,,,,Montgomery County,Tennessee,47,125,Central
-"Clarksville, TN-KY",17300,,,,,Stewart County,Tennessee,47,161,Outlying
-"Cleveland, TN",17420,,174,,"Chattanooga-Cleveland-Dalton, TN-GA",Bradley County,Tennessee,47,011,Central
-"Cleveland, TN",17420,,174,,"Chattanooga-Cleveland-Dalton, TN-GA",Polk County,Tennessee,47,139,Outlying
-"Cleveland-Elyria, OH",17460,,184,,"Cleveland-Akron-Canton, OH",Cuyahoga County,Ohio,39,035,Central
-"Cleveland-Elyria, OH",17460,,184,,"Cleveland-Akron-Canton, OH",Geauga County,Ohio,39,055,Central
-"Cleveland-Elyria, OH",17460,,184,,"Cleveland-Akron-Canton, OH",Lake County,Ohio,39,085,Central
-"Cleveland-Elyria, OH",17460,,184,,"Cleveland-Akron-Canton, OH",Lorain County,Ohio,39,093,Outlying
-"Cleveland-Elyria, OH",17460,,184,,"Cleveland-Akron-Canton, OH",Medina County,Ohio,39,103,Central
-"Coeur d'Alene, ID",17660,,518,,"Spokane-Spokane Valley-Coeur d'Alene, WA-ID",Kootenai County,Idaho,16,055,Central
-"College Station-Bryan, TX",17780,,,,,Brazos County,Texas,48,041,Central
-"College Station-Bryan, TX",17780,,,,,Burleson County,Texas,48,051,Outlying
-"College Station-Bryan, TX",17780,,,,,Robertson County,Texas,48,395,Outlying
-"Colorado Springs, CO",17820,,,,,El Paso County,Colorado,08,041,Central
-"Colorado Springs, CO",17820,,,,,Teller County,Colorado,08,119,Outlying
-"Columbia, MO",17860,,190,,"Columbia-Moberly-Mexico, MO",Boone County,Missouri,29,019,Central
-"Columbia, MO",17860,,190,,"Columbia-Moberly-Mexico, MO",Cooper County,Missouri,29,053,Outlying
-"Columbia, MO",17860,,190,,"Columbia-Moberly-Mexico, MO",Howard County,Missouri,29,089,Outlying
-"Columbia, SC",17900,,192,,"Columbia-Orangeburg-Newberry, SC",Calhoun County,South Carolina,45,017,Outlying
-"Columbia, SC",17900,,192,,"Columbia-Orangeburg-Newberry, SC",Fairfield County,South Carolina,45,039,Outlying
-"Columbia, SC",17900,,192,,"Columbia-Orangeburg-Newberry, SC",Kershaw County,South Carolina,45,055,Outlying
-"Columbia, SC",17900,,192,,"Columbia-Orangeburg-Newberry, SC",Lexington County,South Carolina,45,063,Central
-"Columbia, SC",17900,,192,,"Columbia-Orangeburg-Newberry, SC",Richland County,South Carolina,45,079,Central
-"Columbia, SC",17900,,192,,"Columbia-Orangeburg-Newberry, SC",Saluda County,South Carolina,45,081,Outlying
-"Columbus, GA-AL",17980,,194,,"Columbus-Auburn-Opelika, GA-AL",Russell County,Alabama,01,113,Central
-"Columbus, GA-AL",17980,,194,,"Columbus-Auburn-Opelika, GA-AL",Chattahoochee County,Georgia,13,053,Central
-"Columbus, GA-AL",17980,,194,,"Columbus-Auburn-Opelika, GA-AL",Harris County,Georgia,13,145,Outlying
-"Columbus, GA-AL",17980,,194,,"Columbus-Auburn-Opelika, GA-AL",Marion County,Georgia,13,197,Outlying
-"Columbus, GA-AL",17980,,194,,"Columbus-Auburn-Opelika, GA-AL",Muscogee County,Georgia,13,215,Central
-"Columbus, GA-AL",17980,,194,,"Columbus-Auburn-Opelika, GA-AL",Stewart County,Georgia,13,259,Outlying
-"Columbus, GA-AL",17980,,194,,"Columbus-Auburn-Opelika, GA-AL",Talbot County,Georgia,13,263,Outlying
-"Columbus, IN",18020,,294,,"Indianapolis-Carmel-Muncie, IN",Bartholomew County,Indiana,18,005,Central
-"Columbus, OH",18140,,198,,"Columbus-Marion-Zanesville, OH",Delaware County,Ohio,39,041,Central
-"Columbus, OH",18140,,198,,"Columbus-Marion-Zanesville, OH",Fairfield County,Ohio,39,045,Central
-"Columbus, OH",18140,,198,,"Columbus-Marion-Zanesville, OH",Franklin County,Ohio,39,049,Central
-"Columbus, OH",18140,,198,,"Columbus-Marion-Zanesville, OH",Hocking County,Ohio,39,073,Outlying
-"Columbus, OH",18140,,198,,"Columbus-Marion-Zanesville, OH",Licking County,Ohio,39,089,Outlying
-"Columbus, OH",18140,,198,,"Columbus-Marion-Zanesville, OH",Madison County,Ohio,39,097,Outlying
-"Columbus, OH",18140,,198,,"Columbus-Marion-Zanesville, OH",Morrow County,Ohio,39,117,Outlying
-"Columbus, OH",18140,,198,,"Columbus-Marion-Zanesville, OH",Perry County,Ohio,39,127,Outlying
-"Columbus, OH",18140,,198,,"Columbus-Marion-Zanesville, OH",Pickaway County,Ohio,39,129,Outlying
-"Columbus, OH",18140,,198,,"Columbus-Marion-Zanesville, OH",Union County,Ohio,39,159,Outlying
-"Corpus Christi, TX",18580,,204,,"Corpus Christi-Kingsville-Alice, TX",Nueces County,Texas,48,355,Central
-"Corpus Christi, TX",18580,,204,,"Corpus Christi-Kingsville-Alice, TX",San Patricio County,Texas,48,409,Central
-"Corvallis, OR",18700,,440,,"Portland-Vancouver-Salem, OR-WA",Benton County,Oregon,41,003,Central
-"Crestview-Fort Walton Beach-Destin, FL",18880,,,,,Okaloosa County,Florida,12,091,Central
-"Crestview-Fort Walton Beach-Destin, FL",18880,,,,,Walton County,Florida,12,131,Central
-"Cumberland, MD-WV",19060,,,,,Allegany County,Maryland,24,001,Central
-"Cumberland, MD-WV",19060,,,,,Mineral County,West Virginia,54,057,Outlying
-"Dallas-Fort Worth-Arlington, TX",19100,19124,206,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Collin County,Texas,48,085,Central
-"Dallas-Fort Worth-Arlington, TX",19100,19124,206,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Dallas County,Texas,48,113,Central
-"Dallas-Fort Worth-Arlington, TX",19100,19124,206,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Denton County,Texas,48,121,Outlying
-"Dallas-Fort Worth-Arlington, TX",19100,19124,206,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Ellis County,Texas,48,139,Central
-"Dallas-Fort Worth-Arlington, TX",19100,19124,206,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Hunt County,Texas,48,231,Outlying
-"Dallas-Fort Worth-Arlington, TX",19100,19124,206,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Kaufman County,Texas,48,257,Outlying
-"Dallas-Fort Worth-Arlington, TX",19100,19124,206,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Rockwall County,Texas,48,397,Central
-"Dallas-Fort Worth-Arlington, TX",19100,23104,206,"Fort Worth-Arlington-Grapevine, TX","Dallas-Fort Worth, TX-OK",Johnson County,Texas,48,251,Central
-"Dallas-Fort Worth-Arlington, TX",19100,23104,206,"Fort Worth-Arlington-Grapevine, TX","Dallas-Fort Worth, TX-OK",Parker County,Texas,48,367,Outlying
-"Dallas-Fort Worth-Arlington, TX",19100,23104,206,"Fort Worth-Arlington-Grapevine, TX","Dallas-Fort Worth, TX-OK",Tarrant County,Texas,48,439,Central
-"Dallas-Fort Worth-Arlington, TX",19100,23104,206,"Fort Worth-Arlington-Grapevine, TX","Dallas-Fort Worth, TX-OK",Wise County,Texas,48,497,Outlying
-"Dalton, GA",19140,,174,,"Chattanooga-Cleveland-Dalton, TN-GA",Murray County,Georgia,13,213,Central
-"Dalton, GA",19140,,174,,"Chattanooga-Cleveland-Dalton, TN-GA",Whitfield County,Georgia,13,313,Central
-"Danville, IL",19180,,,,,Vermilion County,Illinois,17,183,Central
-"Daphne-Fairhope-Foley, AL",19300,,380,,"Mobile-Daphne-Fairhope, AL",Baldwin County,Alabama,01,003,Central
-"Davenport-Moline-Rock Island, IA-IL",19340,,209,,"Davenport-Moline, IA-IL",Henry County,Illinois,17,073,Outlying
-"Davenport-Moline-Rock Island, IA-IL",19340,,209,,"Davenport-Moline, IA-IL",Mercer County,Illinois,17,131,Outlying
-"Davenport-Moline-Rock Island, IA-IL",19340,,209,,"Davenport-Moline, IA-IL",Rock Island County,Illinois,17,161,Central
-"Davenport-Moline-Rock Island, IA-IL",19340,,209,,"Davenport-Moline, IA-IL",Scott County,Iowa,19,163,Central
-"Dayton-Kettering, OH",19430,,212,,"Dayton-Springfield-Kettering, OH",Greene County,Ohio,39,057,Central
-"Dayton-Kettering, OH",19430,,212,,"Dayton-Springfield-Kettering, OH",Miami County,Ohio,39,109,Central
-"Dayton-Kettering, OH",19430,,212,,"Dayton-Springfield-Kettering, OH",Montgomery County,Ohio,39,113,Central
-"Decatur, AL",19460,,290,,"Huntsville-Decatur, AL",Lawrence County,Alabama,01,079,Outlying
-"Decatur, AL",19460,,290,,"Huntsville-Decatur, AL",Morgan County,Alabama,01,103,Central
-"Decatur, IL",19500,,,,,Macon County,Illinois,17,115,Central
-"Deltona-Daytona Beach-Ormond Beach, FL",19660,,422,,"Orlando-Lakeland-Deltona, FL",Flagler County,Florida,12,035,Central
-"Deltona-Daytona Beach-Ormond Beach, FL",19660,,422,,"Orlando-Lakeland-Deltona, FL",Volusia County,Florida,12,127,Central
-"Denver-Aurora-Lakewood, CO",19740,,216,,"Denver-Aurora, CO",Adams County,Colorado,08,001,Central
-"Denver-Aurora-Lakewood, CO",19740,,216,,"Denver-Aurora, CO",Arapahoe County,Colorado,08,005,Central
-"Denver-Aurora-Lakewood, CO",19740,,216,,"Denver-Aurora, CO",Broomfield County,Colorado,08,014,Central
-"Denver-Aurora-Lakewood, CO",19740,,216,,"Denver-Aurora, CO",Clear Creek County,Colorado,08,019,Outlying
-"Denver-Aurora-Lakewood, CO",19740,,216,,"Denver-Aurora, CO",Denver County,Colorado,08,031,Central
-"Denver-Aurora-Lakewood, CO",19740,,216,,"Denver-Aurora, CO",Douglas County,Colorado,08,035,Central
-"Denver-Aurora-Lakewood, CO",19740,,216,,"Denver-Aurora, CO",Elbert County,Colorado,08,039,Outlying
-"Denver-Aurora-Lakewood, CO",19740,,216,,"Denver-Aurora, CO",Gilpin County,Colorado,08,047,Outlying
-"Denver-Aurora-Lakewood, CO",19740,,216,,"Denver-Aurora, CO",Jefferson County,Colorado,08,059,Central
-"Denver-Aurora-Lakewood, CO",19740,,216,,"Denver-Aurora, CO",Park County,Colorado,08,093,Outlying
-"Des Moines-West Des Moines, IA",19780,,218,,"Des Moines-Ames-West Des Moines, IA",Dallas County,Iowa,19,049,Central
-"Des Moines-West Des Moines, IA",19780,,218,,"Des Moines-Ames-West Des Moines, IA",Guthrie County,Iowa,19,077,Outlying
-"Des Moines-West Des Moines, IA",19780,,218,,"Des Moines-Ames-West Des Moines, IA",Jasper County,Iowa,19,099,Outlying
-"Des Moines-West Des Moines, IA",19780,,218,,"Des Moines-Ames-West Des Moines, IA",Madison County,Iowa,19,121,Outlying
-"Des Moines-West Des Moines, IA",19780,,218,,"Des Moines-Ames-West Des Moines, IA",Polk County,Iowa,19,153,Central
-"Des Moines-West Des Moines, IA",19780,,218,,"Des Moines-Ames-West Des Moines, IA",Warren County,Iowa,19,181,Outlying
-"Detroit-Warren-Dearborn, MI",19820,19804,220,"Detroit-Dearborn-Livonia, MI","Detroit-Warren-Ann Arbor, MI",Wayne County,Michigan,26,163,Central
-"Detroit-Warren-Dearborn, MI",19820,47664,220,"Warren-Troy-Farmington Hills, MI","Detroit-Warren-Ann Arbor, MI",Lapeer County,Michigan,26,087,Outlying
-"Detroit-Warren-Dearborn, MI",19820,47664,220,"Warren-Troy-Farmington Hills, MI","Detroit-Warren-Ann Arbor, MI",Livingston County,Michigan,26,093,Outlying
-"Detroit-Warren-Dearborn, MI",19820,47664,220,"Warren-Troy-Farmington Hills, MI","Detroit-Warren-Ann Arbor, MI",Macomb County,Michigan,26,099,Central
-"Detroit-Warren-Dearborn, MI",19820,47664,220,"Warren-Troy-Farmington Hills, MI","Detroit-Warren-Ann Arbor, MI",Oakland County,Michigan,26,125,Central
-"Detroit-Warren-Dearborn, MI",19820,47664,220,"Warren-Troy-Farmington Hills, MI","Detroit-Warren-Ann Arbor, MI",St. Clair County,Michigan,26,147,Outlying
-"Dothan, AL",20020,,222,,"Dothan-Ozark, AL",Geneva County,Alabama,01,061,Outlying
-"Dothan, AL",20020,,222,,"Dothan-Ozark, AL",Henry County,Alabama,01,067,Outlying
-"Dothan, AL",20020,,222,,"Dothan-Ozark, AL",Houston County,Alabama,01,069,Central
-"Dover, DE",20100,,428,,"Philadelphia-Reading-Camden, PA-NJ-DE-MD",Kent County,Delaware,10,001,Central
-"Dubuque, IA",20220,,,,,Dubuque County,Iowa,19,061,Central
-"Duluth, MN-WI",20260,,,,,Carlton County,Minnesota,27,017,Outlying
-"Duluth, MN-WI",20260,,,,,Lake County,Minnesota,27,075,Outlying
-"Duluth, MN-WI",20260,,,,,St. Louis County,Minnesota,27,137,Central
-"Duluth, MN-WI",20260,,,,,Douglas County,Wisconsin,55,031,Central
-"Durham-Chapel Hill, NC",20500,,450,,"Raleigh-Durham-Cary, NC",Chatham County,North Carolina,37,037,Central
-"Durham-Chapel Hill, NC",20500,,450,,"Raleigh-Durham-Cary, NC",Durham County,North Carolina,37,063,Central
-"Durham-Chapel Hill, NC",20500,,450,,"Raleigh-Durham-Cary, NC",Granville County,North Carolina,37,077,Outlying
-"Durham-Chapel Hill, NC",20500,,450,,"Raleigh-Durham-Cary, NC",Orange County,North Carolina,37,135,Central
-"Durham-Chapel Hill, NC",20500,,450,,"Raleigh-Durham-Cary, NC",Person County,North Carolina,37,145,Outlying
-"East Stroudsburg, PA",20700,,408,,"New York-Newark, NY-NJ-CT-PA",Monroe County,Pennsylvania,42,089,Central
-"Eau Claire, WI",20740,,232,,"Eau Claire-Menomonie, WI",Chippewa County,Wisconsin,55,017,Central
-"Eau Claire, WI",20740,,232,,"Eau Claire-Menomonie, WI",Eau Claire County,Wisconsin,55,035,Central
-"El Centro, CA",20940,,,,,Imperial County,California,06,025,Central
-"Elizabethtown-Fort Knox, KY",21060,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Hardin County,Kentucky,21,093,Central
-"Elizabethtown-Fort Knox, KY",21060,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Larue County,Kentucky,21,123,Outlying
-"Elizabethtown-Fort Knox, KY",21060,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Meade County,Kentucky,21,163,Outlying
-"Elkhart-Goshen, IN",21140,,515,,"South Bend-Elkhart-Mishawaka, IN-MI",Elkhart County,Indiana,18,039,Central
-"Elmira, NY",21300,,236,,"Elmira-Corning, NY",Chemung County,New York,36,015,Central
-"El Paso, TX",21340,,238,,"El Paso-Las Cruces, TX-NM",El Paso County,Texas,48,141,Central
-"El Paso, TX",21340,,238,,"El Paso-Las Cruces, TX-NM",Hudspeth County,Texas,48,229,Outlying
-"Enid, OK",21420,,,,,Garfield County,Oklahoma,40,047,Central
-"Erie, PA",21500,,240,,"Erie-Meadville, PA",Erie County,Pennsylvania,42,049,Central
-"Eugene-Springfield, OR",21660,,,,,Lane County,Oregon,41,039,Central
-"Evansville, IN-KY",21780,,,,,Posey County,Indiana,18,129,Outlying
-"Evansville, IN-KY",21780,,,,,Vanderburgh County,Indiana,18,163,Central
-"Evansville, IN-KY",21780,,,,,Warrick County,Indiana,18,173,Central
-"Evansville, IN-KY",21780,,,,,Henderson County,Kentucky,21,101,Central
-"Fairbanks, AK",21820,,,,,Fairbanks North Star Borough,Alaska,02,090,Central
-"Fargo, ND-MN",22020,,244,,"Fargo-Wahpeton, ND-MN",Clay County,Minnesota,27,027,Central
-"Fargo, ND-MN",22020,,244,,"Fargo-Wahpeton, ND-MN",Cass County,North Dakota,38,017,Central
-"Farmington, NM",22140,,,,,San Juan County,New Mexico,35,045,Central
-"Fayetteville, NC",22180,,246,,"Fayetteville-Sanford-Lumberton, NC",Cumberland County,North Carolina,37,051,Central
-"Fayetteville, NC",22180,,246,,"Fayetteville-Sanford-Lumberton, NC",Harnett County,North Carolina,37,085,Outlying
-"Fayetteville, NC",22180,,246,,"Fayetteville-Sanford-Lumberton, NC",Hoke County,North Carolina,37,093,Central
-"Fayetteville-Springdale-Rogers, AR",22220,,,,,Benton County,Arkansas,05,007,Central
-"Fayetteville-Springdale-Rogers, AR",22220,,,,,Madison County,Arkansas,05,087,Outlying
-"Fayetteville-Springdale-Rogers, AR",22220,,,,,Washington County,Arkansas,05,143,Central
-"Flagstaff, AZ",22380,,,,,Coconino County,Arizona,04,005,Central
-"Flint, MI",22420,,220,,"Detroit-Warren-Ann Arbor, MI",Genesee County,Michigan,26,049,Central
-"Florence, SC",22500,,,,,Darlington County,South Carolina,45,031,Outlying
-"Florence, SC",22500,,,,,Florence County,South Carolina,45,041,Central
-"Florence-Muscle Shoals, AL",22520,,,,,Colbert County,Alabama,01,033,Central
-"Florence-Muscle Shoals, AL",22520,,,,,Lauderdale County,Alabama,01,077,Central
-"Fond du Lac, WI",22540,,,,,Fond du Lac County,Wisconsin,55,039,Central
-"Fort Collins, CO",22660,,,,,Larimer County,Colorado,08,069,Central
-"Fort Smith, AR-OK",22900,,,,,Crawford County,Arkansas,05,033,Central
-"Fort Smith, AR-OK",22900,,,,,Franklin County,Arkansas,05,047,Outlying
-"Fort Smith, AR-OK",22900,,,,,Sebastian County,Arkansas,05,131,Central
-"Fort Smith, AR-OK",22900,,,,,Sequoyah County,Oklahoma,40,135,Outlying
-"Fort Wayne, IN",23060,,258,,"Fort Wayne-Huntington-Auburn, IN",Allen County,Indiana,18,003,Central
-"Fort Wayne, IN",23060,,258,,"Fort Wayne-Huntington-Auburn, IN",Whitley County,Indiana,18,183,Outlying
-"Fresno, CA",23420,,260,,"Fresno-Madera-Hanford, CA",Fresno County,California,06,019,Central
-"Gadsden, AL",23460,,,,,Etowah County,Alabama,01,055,Central
-"Gainesville, FL",23540,,264,,"Gainesville-Lake City, FL",Alachua County,Florida,12,001,Central
-"Gainesville, FL",23540,,264,,"Gainesville-Lake City, FL",Gilchrist County,Florida,12,041,Outlying
-"Gainesville, FL",23540,,264,,"Gainesville-Lake City, FL",Levy County,Florida,12,075,Outlying
-"Gainesville, GA",23580,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Hall County,Georgia,13,139,Central
-"Gettysburg, PA",23900,,276,,"Harrisburg-York-Lebanon, PA",Adams County,Pennsylvania,42,001,Central
-"Glens Falls, NY",24020,,104,,"Albany-Schenectady, NY",Warren County,New York,36,113,Central
-"Glens Falls, NY",24020,,104,,"Albany-Schenectady, NY",Washington County,New York,36,115,Central
-"Goldsboro, NC",24140,,,,,Wayne County,North Carolina,37,191,Central
-"Grand Forks, ND-MN",24220,,,,,Polk County,Minnesota,27,119,Central
-"Grand Forks, ND-MN",24220,,,,,Grand Forks County,North Dakota,38,035,Central
-"Grand Island, NE",24260,,,,,Hall County,Nebraska,31,079,Central
-"Grand Island, NE",24260,,,,,Howard County,Nebraska,31,093,Outlying
-"Grand Island, NE",24260,,,,,Merrick County,Nebraska,31,121,Outlying
-"Grand Junction, CO",24300,,,,,Mesa County,Colorado,08,077,Central
-"Grand Rapids-Kentwood, MI",24340,,266,,"Grand Rapids-Kentwood-Muskegon, MI",Ionia County,Michigan,26,067,Outlying
-"Grand Rapids-Kentwood, MI",24340,,266,,"Grand Rapids-Kentwood-Muskegon, MI",Kent County,Michigan,26,081,Central
-"Grand Rapids-Kentwood, MI",24340,,266,,"Grand Rapids-Kentwood-Muskegon, MI",Montcalm County,Michigan,26,117,Outlying
-"Grand Rapids-Kentwood, MI",24340,,266,,"Grand Rapids-Kentwood-Muskegon, MI",Ottawa County,Michigan,26,139,Outlying
-"Grants Pass, OR",24420,,366,,"Medford-Grants Pass, OR",Josephine County,Oregon,41,033,Central
-"Great Falls, MT",24500,,,,,Cascade County,Montana,30,013,Central
-"Greeley, CO",24540,,216,,"Denver-Aurora, CO",Weld County,Colorado,08,123,Central
-"Green Bay, WI",24580,,267,,"Green Bay-Shawano, WI",Brown County,Wisconsin,55,009,Central
-"Green Bay, WI",24580,,267,,"Green Bay-Shawano, WI",Kewaunee County,Wisconsin,55,061,Outlying
-"Green Bay, WI",24580,,267,,"Green Bay-Shawano, WI",Oconto County,Wisconsin,55,083,Outlying
-"Greensboro-High Point, NC",24660,,268,,"Greensboro--Winston-Salem--High Point, NC",Guilford County,North Carolina,37,081,Central
-"Greensboro-High Point, NC",24660,,268,,"Greensboro--Winston-Salem--High Point, NC",Randolph County,North Carolina,37,151,Outlying
-"Greensboro-High Point, NC",24660,,268,,"Greensboro--Winston-Salem--High Point, NC",Rockingham County,North Carolina,37,157,Outlying
-"Greenville, NC",24780,,272,,"Greenville-Kinston-Washington, NC",Pitt County,North Carolina,37,147,Central
-"Greenville-Anderson, SC",24860,,273,,"Greenville-Spartanburg-Anderson, SC",Anderson County,South Carolina,45,007,Outlying
-"Greenville-Anderson, SC",24860,,273,,"Greenville-Spartanburg-Anderson, SC",Greenville County,South Carolina,45,045,Central
-"Greenville-Anderson, SC",24860,,273,,"Greenville-Spartanburg-Anderson, SC",Laurens County,South Carolina,45,059,Outlying
-"Greenville-Anderson, SC",24860,,273,,"Greenville-Spartanburg-Anderson, SC",Pickens County,South Carolina,45,077,Central
-"Guayama, PR",25020,,490,,"San Juan-Bayamón, PR",Arroyo Municipio,Puerto Rico,72,015,Central
-"Guayama, PR",25020,,490,,"San Juan-Bayamón, PR",Guayama Municipio,Puerto Rico,72,057,Central
-"Guayama, PR",25020,,490,,"San Juan-Bayamón, PR",Patillas Municipio,Puerto Rico,72,109,Central
-"Gulfport-Biloxi, MS",25060,,,,,Hancock County,Mississippi,28,045,Central
-"Gulfport-Biloxi, MS",25060,,,,,Harrison County,Mississippi,28,047,Central
-"Gulfport-Biloxi, MS",25060,,,,,Jackson County,Mississippi,28,059,Outlying
-"Gulfport-Biloxi, MS",25060,,,,,Stone County,Mississippi,28,131,Outlying
-"Hagerstown-Martinsburg, MD-WV",25180,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Washington County,Maryland,24,043,Central
-"Hagerstown-Martinsburg, MD-WV",25180,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Berkeley County,West Virginia,54,003,Central
-"Hagerstown-Martinsburg, MD-WV",25180,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Morgan County,West Virginia,54,065,Outlying
-"Hammond, LA",25220,,406,,"New Orleans-Metairie-Hammond, LA-MS",Tangipahoa Parish,Louisiana,22,105,Central
-"Hanford-Corcoran, CA",25260,,260,,"Fresno-Madera-Hanford, CA",Kings County,California,06,031,Central
-"Harrisburg-Carlisle, PA",25420,,276,,"Harrisburg-York-Lebanon, PA",Cumberland County,Pennsylvania,42,041,Central
-"Harrisburg-Carlisle, PA",25420,,276,,"Harrisburg-York-Lebanon, PA",Dauphin County,Pennsylvania,42,043,Central
-"Harrisburg-Carlisle, PA",25420,,276,,"Harrisburg-York-Lebanon, PA",Perry County,Pennsylvania,42,099,Outlying
-"Harrisonburg, VA",25500,,277,,"Harrisonburg-Staunton, VA",Rockingham County,Virginia,51,165,Central
-"Harrisonburg, VA",25500,,277,,"Harrisonburg-Staunton, VA",Harrisonburg city,Virginia,51,660,Central
-"Hartford-East Hartford-Middletown, CT",25540,,278,,"Hartford-East Hartford, CT",Hartford County,Connecticut,09,003,Central
-"Hartford-East Hartford-Middletown, CT",25540,,278,,"Hartford-East Hartford, CT",Middlesex County,Connecticut,09,007,Central
-"Hartford-East Hartford-Middletown, CT",25540,,278,,"Hartford-East Hartford, CT",Tolland County,Connecticut,09,013,Central
-"Hattiesburg, MS",25620,,279,,"Hattiesburg-Laurel, MS",Covington County,Mississippi,28,031,Outlying
-"Hattiesburg, MS",25620,,279,,"Hattiesburg-Laurel, MS",Forrest County,Mississippi,28,035,Central
-"Hattiesburg, MS",25620,,279,,"Hattiesburg-Laurel, MS",Lamar County,Mississippi,28,073,Central
-"Hattiesburg, MS",25620,,279,,"Hattiesburg-Laurel, MS",Perry County,Mississippi,28,111,Outlying
-"Hickory-Lenoir-Morganton, NC",25860,,,,,Alexander County,North Carolina,37,003,Outlying
-"Hickory-Lenoir-Morganton, NC",25860,,,,,Burke County,North Carolina,37,023,Central
-"Hickory-Lenoir-Morganton, NC",25860,,,,,Caldwell County,North Carolina,37,027,Central
-"Hickory-Lenoir-Morganton, NC",25860,,,,,Catawba County,North Carolina,37,035,Central
-"Hilton Head Island-Bluffton, SC",25940,,,,,Beaufort County,South Carolina,45,013,Central
-"Hilton Head Island-Bluffton, SC",25940,,,,,Jasper County,South Carolina,45,053,Outlying
-"Hinesville, GA",25980,,496,,"Savannah-Hinesville-Statesboro, GA",Liberty County,Georgia,13,179,Central
-"Hinesville, GA",25980,,496,,"Savannah-Hinesville-Statesboro, GA",Long County,Georgia,13,183,Outlying
-"Homosassa Springs, FL",26140,,,,,Citrus County,Florida,12,017,Central
-"Hot Springs, AR",26300,,284,,"Hot Springs-Malvern, AR",Garland County,Arkansas,05,051,Central
-"Houma-Thibodaux, LA",26380,,,,,Lafourche Parish,Louisiana,22,057,Central
-"Houma-Thibodaux, LA",26380,,,,,Terrebonne Parish,Louisiana,22,109,Central
-"Houston-The Woodlands-Sugar Land, TX",26420,,288,,"Houston-The Woodlands, TX",Austin County,Texas,48,015,Outlying
-"Houston-The Woodlands-Sugar Land, TX",26420,,288,,"Houston-The Woodlands, TX",Brazoria County,Texas,48,039,Central
-"Houston-The Woodlands-Sugar Land, TX",26420,,288,,"Houston-The Woodlands, TX",Chambers County,Texas,48,071,Central
-"Houston-The Woodlands-Sugar Land, TX",26420,,288,,"Houston-The Woodlands, TX",Fort Bend County,Texas,48,157,Central
-"Houston-The Woodlands-Sugar Land, TX",26420,,288,,"Houston-The Woodlands, TX",Galveston County,Texas,48,167,Central
-"Houston-The Woodlands-Sugar Land, TX",26420,,288,,"Houston-The Woodlands, TX",Harris County,Texas,48,201,Central
-"Houston-The Woodlands-Sugar Land, TX",26420,,288,,"Houston-The Woodlands, TX",Liberty County,Texas,48,291,Outlying
-"Houston-The Woodlands-Sugar Land, TX",26420,,288,,"Houston-The Woodlands, TX",Montgomery County,Texas,48,339,Outlying
-"Houston-The Woodlands-Sugar Land, TX",26420,,288,,"Houston-The Woodlands, TX",Waller County,Texas,48,473,Outlying
-"Huntington-Ashland, WV-KY-OH",26580,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Boyd County,Kentucky,21,019,Central
-"Huntington-Ashland, WV-KY-OH",26580,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Carter County,Kentucky,21,043,Outlying
-"Huntington-Ashland, WV-KY-OH",26580,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Greenup County,Kentucky,21,089,Central
-"Huntington-Ashland, WV-KY-OH",26580,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Lawrence County,Ohio,39,087,Central
-"Huntington-Ashland, WV-KY-OH",26580,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Cabell County,West Virginia,54,011,Central
-"Huntington-Ashland, WV-KY-OH",26580,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Putnam County,West Virginia,54,079,Central
-"Huntington-Ashland, WV-KY-OH",26580,,170,,"Charleston-Huntington-Ashland, WV-OH-KY",Wayne County,West Virginia,54,099,Central
-"Huntsville, AL",26620,,290,,"Huntsville-Decatur, AL",Limestone County,Alabama,01,083,Outlying
-"Huntsville, AL",26620,,290,,"Huntsville-Decatur, AL",Madison County,Alabama,01,089,Central
-"Idaho Falls, ID",26820,,292,,"Idaho Falls-Rexburg-Blackfoot, ID",Bonneville County,Idaho,16,019,Central
-"Idaho Falls, ID",26820,,292,,"Idaho Falls-Rexburg-Blackfoot, ID",Butte County,Idaho,16,023,Outlying
-"Idaho Falls, ID",26820,,292,,"Idaho Falls-Rexburg-Blackfoot, ID",Jefferson County,Idaho,16,051,Outlying
-"Indianapolis-Carmel-Anderson, IN",26900,,294,,"Indianapolis-Carmel-Muncie, IN",Boone County,Indiana,18,011,Central
-"Indianapolis-Carmel-Anderson, IN",26900,,294,,"Indianapolis-Carmel-Muncie, IN",Brown County,Indiana,18,013,Outlying
-"Indianapolis-Carmel-Anderson, IN",26900,,294,,"Indianapolis-Carmel-Muncie, IN",Hamilton County,Indiana,18,057,Central
-"Indianapolis-Carmel-Anderson, IN",26900,,294,,"Indianapolis-Carmel-Muncie, IN",Hancock County,Indiana,18,059,Central
-"Indianapolis-Carmel-Anderson, IN",26900,,294,,"Indianapolis-Carmel-Muncie, IN",Hendricks County,Indiana,18,063,Central
-"Indianapolis-Carmel-Anderson, IN",26900,,294,,"Indianapolis-Carmel-Muncie, IN",Johnson County,Indiana,18,081,Central
-"Indianapolis-Carmel-Anderson, IN",26900,,294,,"Indianapolis-Carmel-Muncie, IN",Madison County,Indiana,18,095,Outlying
-"Indianapolis-Carmel-Anderson, IN",26900,,294,,"Indianapolis-Carmel-Muncie, IN",Marion County,Indiana,18,097,Central
-"Indianapolis-Carmel-Anderson, IN",26900,,294,,"Indianapolis-Carmel-Muncie, IN",Morgan County,Indiana,18,109,Central
-"Indianapolis-Carmel-Anderson, IN",26900,,294,,"Indianapolis-Carmel-Muncie, IN",Putnam County,Indiana,18,133,Outlying
-"Indianapolis-Carmel-Anderson, IN",26900,,294,,"Indianapolis-Carmel-Muncie, IN",Shelby County,Indiana,18,145,Outlying
-"Iowa City, IA",26980,,168,,"Cedar Rapids-Iowa City, IA",Johnson County,Iowa,19,103,Central
-"Iowa City, IA",26980,,168,,"Cedar Rapids-Iowa City, IA",Washington County,Iowa,19,183,Outlying
-"Ithaca, NY",27060,,296,,"Ithaca-Cortland, NY",Tompkins County,New York,36,109,Central
-"Jackson, MI",27100,,,,,Jackson County,Michigan,26,075,Central
-"Jackson, MS",27140,,298,,"Jackson-Vicksburg-Brookhaven, MS",Copiah County,Mississippi,28,029,Outlying
-"Jackson, MS",27140,,298,,"Jackson-Vicksburg-Brookhaven, MS",Hinds County,Mississippi,28,049,Central
-"Jackson, MS",27140,,298,,"Jackson-Vicksburg-Brookhaven, MS",Holmes County,Mississippi,28,051,Outlying
-"Jackson, MS",27140,,298,,"Jackson-Vicksburg-Brookhaven, MS",Madison County,Mississippi,28,089,Central
-"Jackson, MS",27140,,298,,"Jackson-Vicksburg-Brookhaven, MS",Rankin County,Mississippi,28,121,Central
-"Jackson, MS",27140,,298,,"Jackson-Vicksburg-Brookhaven, MS",Simpson County,Mississippi,28,127,Outlying
-"Jackson, MS",27140,,298,,"Jackson-Vicksburg-Brookhaven, MS",Yazoo County,Mississippi,28,163,Outlying
-"Jackson, TN",27180,,297,,"Jackson-Brownsville, TN",Chester County,Tennessee,47,023,Outlying
-"Jackson, TN",27180,,297,,"Jackson-Brownsville, TN",Crockett County,Tennessee,47,033,Outlying
-"Jackson, TN",27180,,297,,"Jackson-Brownsville, TN",Gibson County,Tennessee,47,053,Outlying
-"Jackson, TN",27180,,297,,"Jackson-Brownsville, TN",Madison County,Tennessee,47,113,Central
-"Jacksonville, FL",27260,,300,,"Jacksonville-St. Marys-Palatka, FL-GA",Baker County,Florida,12,003,Outlying
-"Jacksonville, FL",27260,,300,,"Jacksonville-St. Marys-Palatka, FL-GA",Clay County,Florida,12,019,Central
-"Jacksonville, FL",27260,,300,,"Jacksonville-St. Marys-Palatka, FL-GA",Duval County,Florida,12,031,Central
-"Jacksonville, FL",27260,,300,,"Jacksonville-St. Marys-Palatka, FL-GA",Nassau County,Florida,12,089,Outlying
-"Jacksonville, FL",27260,,300,,"Jacksonville-St. Marys-Palatka, FL-GA",St. Johns County,Florida,12,109,Outlying
-"Jacksonville, NC",27340,,,,,Onslow County,North Carolina,37,133,Central
-"Janesville-Beloit, WI",27500,,357,,"Madison-Janesville-Beloit, WI",Rock County,Wisconsin,55,105,Central
-"Jefferson City, MO",27620,,,,,Callaway County,Missouri,29,027,Outlying
-"Jefferson City, MO",27620,,,,,Cole County,Missouri,29,051,Central
-"Jefferson City, MO",27620,,,,,Moniteau County,Missouri,29,135,Outlying
-"Jefferson City, MO",27620,,,,,Osage County,Missouri,29,151,Outlying
-"Johnson City, TN",27740,,304,,"Johnson City-Kingsport-Bristol, TN-VA",Carter County,Tennessee,47,019,Central
-"Johnson City, TN",27740,,304,,"Johnson City-Kingsport-Bristol, TN-VA",Unicoi County,Tennessee,47,171,Outlying
-"Johnson City, TN",27740,,304,,"Johnson City-Kingsport-Bristol, TN-VA",Washington County,Tennessee,47,179,Central
-"Johnstown, PA",27780,,306,,"Johnstown-Somerset, PA",Cambria County,Pennsylvania,42,021,Central
-"Jonesboro, AR",27860,,308,,"Jonesboro-Paragould, AR",Craighead County,Arkansas,05,031,Central
-"Jonesboro, AR",27860,,308,,"Jonesboro-Paragould, AR",Poinsett County,Arkansas,05,111,Outlying
-"Joplin, MO",27900,,309,,"Joplin-Miami, MO-OK",Jasper County,Missouri,29,097,Central
-"Joplin, MO",27900,,309,,"Joplin-Miami, MO-OK",Newton County,Missouri,29,145,Outlying
-"Kahului-Wailuku-Lahaina, HI",27980,,,,,Maui County,Hawaii,15,009,Central
-"Kalamazoo-Portage, MI",28020,,310,,"Kalamazoo-Battle Creek-Portage, MI",Kalamazoo County,Michigan,26,077,Central
-"Kankakee, IL",28100,,176,,"Chicago-Naperville, IL-IN-WI",Kankakee County,Illinois,17,091,Central
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Johnson County,Kansas,20,091,Central
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Leavenworth County,Kansas,20,103,Outlying
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Linn County,Kansas,20,107,Outlying
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Miami County,Kansas,20,121,Outlying
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Wyandotte County,Kansas,20,209,Central
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Bates County,Missouri,29,013,Outlying
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Caldwell County,Missouri,29,025,Outlying
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Cass County,Missouri,29,037,Central
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Clay County,Missouri,29,047,Central
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Clinton County,Missouri,29,049,Outlying
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Jackson County,Missouri,29,095,Central
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Lafayette County,Missouri,29,107,Outlying
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Platte County,Missouri,29,165,Central
-"Kansas City, MO-KS",28140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Ray County,Missouri,29,177,Outlying
-"Kennewick-Richland, WA",28420,,313,,"Kennewick-Richland-Walla Walla, WA",Benton County,Washington,53,005,Central
-"Kennewick-Richland, WA",28420,,313,,"Kennewick-Richland-Walla Walla, WA",Franklin County,Washington,53,021,Central
-"Killeen-Temple, TX",28660,,,,,Bell County,Texas,48,027,Central
-"Killeen-Temple, TX",28660,,,,,Coryell County,Texas,48,099,Central
-"Killeen-Temple, TX",28660,,,,,Lampasas County,Texas,48,281,Outlying
-"Kingsport-Bristol, TN-VA",28700,,304,,"Johnson City-Kingsport-Bristol, TN-VA",Hawkins County,Tennessee,47,073,Central
-"Kingsport-Bristol, TN-VA",28700,,304,,"Johnson City-Kingsport-Bristol, TN-VA",Sullivan County,Tennessee,47,163,Central
-"Kingsport-Bristol, TN-VA",28700,,304,,"Johnson City-Kingsport-Bristol, TN-VA",Scott County,Virginia,51,169,Outlying
-"Kingsport-Bristol, TN-VA",28700,,304,,"Johnson City-Kingsport-Bristol, TN-VA",Washington County,Virginia,51,191,Outlying
-"Kingsport-Bristol, TN-VA",28700,,304,,"Johnson City-Kingsport-Bristol, TN-VA",Bristol city,Virginia,51,520,Outlying
-"Kingston, NY",28740,,408,,"New York-Newark, NY-NJ-CT-PA",Ulster County,New York,36,111,Central
-"Knoxville, TN",28940,,315,,"Knoxville-Morristown-Sevierville, TN",Anderson County,Tennessee,47,001,Central
-"Knoxville, TN",28940,,315,,"Knoxville-Morristown-Sevierville, TN",Blount County,Tennessee,47,009,Central
-"Knoxville, TN",28940,,315,,"Knoxville-Morristown-Sevierville, TN",Campbell County,Tennessee,47,013,Outlying
-"Knoxville, TN",28940,,315,,"Knoxville-Morristown-Sevierville, TN",Knox County,Tennessee,47,093,Central
-"Knoxville, TN",28940,,315,,"Knoxville-Morristown-Sevierville, TN",Loudon County,Tennessee,47,105,Central
-"Knoxville, TN",28940,,315,,"Knoxville-Morristown-Sevierville, TN",Morgan County,Tennessee,47,129,Outlying
-"Knoxville, TN",28940,,315,,"Knoxville-Morristown-Sevierville, TN",Roane County,Tennessee,47,145,Outlying
-"Knoxville, TN",28940,,315,,"Knoxville-Morristown-Sevierville, TN",Union County,Tennessee,47,173,Outlying
-"Kokomo, IN",29020,,316,,"Kokomo-Peru, IN",Howard County,Indiana,18,067,Central
-"La Crosse-Onalaska, WI-MN",29100,,,,,Houston County,Minnesota,27,055,Central
-"La Crosse-Onalaska, WI-MN",29100,,,,,La Crosse County,Wisconsin,55,063,Central
-"Lafayette, LA",29180,,318,,"Lafayette-Opelousas-Morgan City, LA",Acadia Parish,Louisiana,22,001,Outlying
-"Lafayette, LA",29180,,318,,"Lafayette-Opelousas-Morgan City, LA",Iberia Parish,Louisiana,22,045,Central
-"Lafayette, LA",29180,,318,,"Lafayette-Opelousas-Morgan City, LA",Lafayette Parish,Louisiana,22,055,Central
-"Lafayette, LA",29180,,318,,"Lafayette-Opelousas-Morgan City, LA",St. Martin Parish,Louisiana,22,099,Outlying
-"Lafayette, LA",29180,,318,,"Lafayette-Opelousas-Morgan City, LA",Vermilion Parish,Louisiana,22,113,Outlying
-"Lafayette-West Lafayette, IN",29200,,320,,"Lafayette-West Lafayette-Frankfort, IN",Benton County,Indiana,18,007,Outlying
-"Lafayette-West Lafayette, IN",29200,,320,,"Lafayette-West Lafayette-Frankfort, IN",Carroll County,Indiana,18,015,Outlying
-"Lafayette-West Lafayette, IN",29200,,320,,"Lafayette-West Lafayette-Frankfort, IN",Tippecanoe County,Indiana,18,157,Central
-"Lafayette-West Lafayette, IN",29200,,320,,"Lafayette-West Lafayette-Frankfort, IN",Warren County,Indiana,18,171,Outlying
-"Lake Charles, LA",29340,,324,,"Lake Charles-Jennings, LA",Calcasieu Parish,Louisiana,22,019,Central
-"Lake Charles, LA",29340,,324,,"Lake Charles-Jennings, LA",Cameron Parish,Louisiana,22,023,Outlying
-"Lake Havasu City-Kingman, AZ",29420,,,,,Mohave County,Arizona,04,015,Central
-"Lakeland-Winter Haven, FL",29460,,422,,"Orlando-Lakeland-Deltona, FL",Polk County,Florida,12,105,Central
-"Lancaster, PA",29540,,,,,Lancaster County,Pennsylvania,42,071,Central
-"Lansing-East Lansing, MI",29620,,,,,Clinton County,Michigan,26,037,Central
-"Lansing-East Lansing, MI",29620,,,,,Eaton County,Michigan,26,045,Central
-"Lansing-East Lansing, MI",29620,,,,,Ingham County,Michigan,26,065,Central
-"Lansing-East Lansing, MI",29620,,,,,Shiawassee County,Michigan,26,155,Outlying
-"Laredo, TX",29700,,,,,Webb County,Texas,48,479,Central
-"Las Cruces, NM",29740,,238,,"El Paso-Las Cruces, TX-NM",Doña Ana County,New Mexico,35,013,Central
-"Las Vegas-Henderson-Paradise, NV",29820,,332,,"Las Vegas-Henderson, NV",Clark County,Nevada,32,003,Central
-"Lawrence, KS",29940,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Douglas County,Kansas,20,045,Central
-"Lawton, OK",30020,,,,,Comanche County,Oklahoma,40,031,Central
-"Lawton, OK",30020,,,,,Cotton County,Oklahoma,40,033,Outlying
-"Lebanon, PA",30140,,276,,"Harrisburg-York-Lebanon, PA",Lebanon County,Pennsylvania,42,075,Central
-"Lewiston, ID-WA",30300,,,,,Nez Perce County,Idaho,16,069,Central
-"Lewiston, ID-WA",30300,,,,,Asotin County,Washington,53,003,Central
-"Lewiston-Auburn, ME",30340,,438,,"Portland-Lewiston-South Portland, ME",Androscoggin County,Maine,23,001,Central
-"Lexington-Fayette, KY",30460,,336,,"Lexington-Fayette--Richmond--Frankfort, KY",Bourbon County,Kentucky,21,017,Outlying
-"Lexington-Fayette, KY",30460,,336,,"Lexington-Fayette--Richmond--Frankfort, KY",Clark County,Kentucky,21,049,Outlying
-"Lexington-Fayette, KY",30460,,336,,"Lexington-Fayette--Richmond--Frankfort, KY",Fayette County,Kentucky,21,067,Central
-"Lexington-Fayette, KY",30460,,336,,"Lexington-Fayette--Richmond--Frankfort, KY",Jessamine County,Kentucky,21,113,Outlying
-"Lexington-Fayette, KY",30460,,336,,"Lexington-Fayette--Richmond--Frankfort, KY",Scott County,Kentucky,21,209,Outlying
-"Lexington-Fayette, KY",30460,,336,,"Lexington-Fayette--Richmond--Frankfort, KY",Woodford County,Kentucky,21,239,Outlying
-"Lima, OH",30620,,338,,"Lima-Van Wert-Celina, OH",Allen County,Ohio,39,003,Central
-"Lincoln, NE",30700,,339,,"Lincoln-Beatrice, NE",Lancaster County,Nebraska,31,109,Central
-"Lincoln, NE",30700,,339,,"Lincoln-Beatrice, NE",Seward County,Nebraska,31,159,Outlying
-"Little Rock-North Little Rock-Conway, AR",30780,,340,,"Little Rock-North Little Rock, AR",Faulkner County,Arkansas,05,045,Outlying
-"Little Rock-North Little Rock-Conway, AR",30780,,340,,"Little Rock-North Little Rock, AR",Grant County,Arkansas,05,053,Outlying
-"Little Rock-North Little Rock-Conway, AR",30780,,340,,"Little Rock-North Little Rock, AR",Lonoke County,Arkansas,05,085,Central
-"Little Rock-North Little Rock-Conway, AR",30780,,340,,"Little Rock-North Little Rock, AR",Perry County,Arkansas,05,105,Outlying
-"Little Rock-North Little Rock-Conway, AR",30780,,340,,"Little Rock-North Little Rock, AR",Pulaski County,Arkansas,05,119,Central
-"Little Rock-North Little Rock-Conway, AR",30780,,340,,"Little Rock-North Little Rock, AR",Saline County,Arkansas,05,125,Central
-"Logan, UT-ID",30860,,,,,Franklin County,Idaho,16,041,Outlying
-"Logan, UT-ID",30860,,,,,Cache County,Utah,49,005,Central
-"Longview, TX",30980,,,,,Gregg County,Texas,48,183,Central
-"Longview, TX",30980,,,,,Harrison County,Texas,48,203,Outlying
-"Longview, TX",30980,,,,,Rusk County,Texas,48,401,Outlying
-"Longview, TX",30980,,,,,Upshur County,Texas,48,459,Outlying
-"Longview, WA",31020,,440,,"Portland-Vancouver-Salem, OR-WA",Cowlitz County,Washington,53,015,Central
-"Los Angeles-Long Beach-Anaheim, CA",31080,11244,348,"Anaheim-Santa Ana-Irvine, CA","Los Angeles-Long Beach, CA",Orange County,California,06,059,Central
-"Los Angeles-Long Beach-Anaheim, CA",31080,31084,348,"Los Angeles-Long Beach-Glendale, CA","Los Angeles-Long Beach, CA",Los Angeles County,California,06,037,Central
-"Louisville/Jefferson County, KY-IN",31140,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Clark County,Indiana,18,019,Central
-"Louisville/Jefferson County, KY-IN",31140,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Floyd County,Indiana,18,043,Central
-"Louisville/Jefferson County, KY-IN",31140,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Harrison County,Indiana,18,061,Outlying
-"Louisville/Jefferson County, KY-IN",31140,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Washington County,Indiana,18,175,Outlying
-"Louisville/Jefferson County, KY-IN",31140,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Bullitt County,Kentucky,21,029,Central
-"Louisville/Jefferson County, KY-IN",31140,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Henry County,Kentucky,21,103,Outlying
-"Louisville/Jefferson County, KY-IN",31140,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Jefferson County,Kentucky,21,111,Central
-"Louisville/Jefferson County, KY-IN",31140,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Oldham County,Kentucky,21,185,Central
-"Louisville/Jefferson County, KY-IN",31140,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Shelby County,Kentucky,21,211,Outlying
-"Louisville/Jefferson County, KY-IN",31140,,350,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Spencer County,Kentucky,21,215,Outlying
-"Lubbock, TX",31180,,352,,"Lubbock-Plainview-Levelland, TX",Crosby County,Texas,48,107,Outlying
-"Lubbock, TX",31180,,352,,"Lubbock-Plainview-Levelland, TX",Lubbock County,Texas,48,303,Central
-"Lubbock, TX",31180,,352,,"Lubbock-Plainview-Levelland, TX",Lynn County,Texas,48,305,Outlying
-"Lynchburg, VA",31340,,,,,Amherst County,Virginia,51,009,Central
-"Lynchburg, VA",31340,,,,,Appomattox County,Virginia,51,011,Outlying
-"Lynchburg, VA",31340,,,,,Bedford County,Virginia,51,019,Central
-"Lynchburg, VA",31340,,,,,Campbell County,Virginia,51,031,Central
-"Lynchburg, VA",31340,,,,,Lynchburg city,Virginia,51,680,Central
-"Macon-Bibb County, GA",31420,,356,,"Macon-Bibb County--Warner Robins, GA",Bibb County,Georgia,13,021,Central
-"Macon-Bibb County, GA",31420,,356,,"Macon-Bibb County--Warner Robins, GA",Crawford County,Georgia,13,079,Outlying
-"Macon-Bibb County, GA",31420,,356,,"Macon-Bibb County--Warner Robins, GA",Jones County,Georgia,13,169,Outlying
-"Macon-Bibb County, GA",31420,,356,,"Macon-Bibb County--Warner Robins, GA",Monroe County,Georgia,13,207,Outlying
-"Macon-Bibb County, GA",31420,,356,,"Macon-Bibb County--Warner Robins, GA",Twiggs County,Georgia,13,289,Outlying
-"Madera, CA",31460,,260,,"Fresno-Madera-Hanford, CA",Madera County,California,06,039,Central
-"Madison, WI",31540,,357,,"Madison-Janesville-Beloit, WI",Columbia County,Wisconsin,55,021,Outlying
-"Madison, WI",31540,,357,,"Madison-Janesville-Beloit, WI",Dane County,Wisconsin,55,025,Central
-"Madison, WI",31540,,357,,"Madison-Janesville-Beloit, WI",Green County,Wisconsin,55,045,Outlying
-"Madison, WI",31540,,357,,"Madison-Janesville-Beloit, WI",Iowa County,Wisconsin,55,049,Outlying
-"Manchester-Nashua, NH",31700,,148,,"Boston-Worcester-Providence, MA-RI-NH-CT",Hillsborough County,New Hampshire,33,011,Central
-"Manhattan, KS",31740,,,,,Geary County,Kansas,20,061,Outlying
-"Manhattan, KS",31740,,,,,Pottawatomie County,Kansas,20,149,Outlying
-"Manhattan, KS",31740,,,,,Riley County,Kansas,20,161,Central
-"Mankato, MN",31860,,359,,"Mankato-New Ulm, MN",Blue Earth County,Minnesota,27,013,Central
-"Mankato, MN",31860,,359,,"Mankato-New Ulm, MN",Nicollet County,Minnesota,27,103,Central
-"Mansfield, OH",31900,,360,,"Mansfield-Ashland-Bucyrus, OH",Richland County,Ohio,39,139,Central
-"Mayagüez, PR",32420,,364,,"Mayagüez-San Germán, PR",Hormigueros Municipio,Puerto Rico,72,067,Central
-"Mayagüez, PR",32420,,364,,"Mayagüez-San Germán, PR",Las Marías Municipio,Puerto Rico,72,083,Outlying
-"Mayagüez, PR",32420,,364,,"Mayagüez-San Germán, PR",Mayagüez Municipio,Puerto Rico,72,097,Central
-"McAllen-Edinburg-Mission, TX",32580,,365,,"McAllen-Edinburg, TX",Hidalgo County,Texas,48,215,Central
-"Medford, OR",32780,,366,,"Medford-Grants Pass, OR",Jackson County,Oregon,41,029,Central
-"Memphis, TN-MS-AR",32820,,368,,"Memphis-Forrest City, TN-MS-AR",Crittenden County,Arkansas,05,035,Central
-"Memphis, TN-MS-AR",32820,,368,,"Memphis-Forrest City, TN-MS-AR",DeSoto County,Mississippi,28,033,Central
-"Memphis, TN-MS-AR",32820,,368,,"Memphis-Forrest City, TN-MS-AR",Marshall County,Mississippi,28,093,Outlying
-"Memphis, TN-MS-AR",32820,,368,,"Memphis-Forrest City, TN-MS-AR",Tate County,Mississippi,28,137,Outlying
-"Memphis, TN-MS-AR",32820,,368,,"Memphis-Forrest City, TN-MS-AR",Tunica County,Mississippi,28,143,Outlying
-"Memphis, TN-MS-AR",32820,,368,,"Memphis-Forrest City, TN-MS-AR",Fayette County,Tennessee,47,047,Outlying
-"Memphis, TN-MS-AR",32820,,368,,"Memphis-Forrest City, TN-MS-AR",Shelby County,Tennessee,47,157,Central
-"Memphis, TN-MS-AR",32820,,368,,"Memphis-Forrest City, TN-MS-AR",Tipton County,Tennessee,47,167,Outlying
-"Merced, CA",32900,,488,,"San Jose-San Francisco-Oakland, CA",Merced County,California,06,047,Central
-"Miami-Fort Lauderdale-Pompano Beach, FL",33100,22744,370,"Fort Lauderdale-Pompano Beach-Sunrise, FL","Miami-Port St. Lucie-Fort Lauderdale, FL",Broward County,Florida,12,011,Central
-"Miami-Fort Lauderdale-Pompano Beach, FL",33100,33124,370,"Miami-Miami Beach-Kendall, FL","Miami-Port St. Lucie-Fort Lauderdale, FL",Miami-Dade County,Florida,12,086,Central
-"Miami-Fort Lauderdale-Pompano Beach, FL",33100,48424,370,"West Palm Beach-Boca Raton-Boynton Beach, FL","Miami-Port St. Lucie-Fort Lauderdale, FL",Palm Beach County,Florida,12,099,Central
-"Michigan City-La Porte, IN",33140,,176,,"Chicago-Naperville, IL-IN-WI",LaPorte County,Indiana,18,091,Central
-"Midland, MI",33220,,474,,"Saginaw-Midland-Bay City, MI",Midland County,Michigan,26,111,Central
-"Midland, TX",33260,,372,,"Midland-Odessa, TX",Martin County,Texas,48,317,Outlying
-"Midland, TX",33260,,372,,"Midland-Odessa, TX",Midland County,Texas,48,329,Central
-"Milwaukee-Waukesha, WI",33340,,376,,"Milwaukee-Racine-Waukesha, WI",Milwaukee County,Wisconsin,55,079,Central
-"Milwaukee-Waukesha, WI",33340,,376,,"Milwaukee-Racine-Waukesha, WI",Ozaukee County,Wisconsin,55,089,Central
-"Milwaukee-Waukesha, WI",33340,,376,,"Milwaukee-Racine-Waukesha, WI",Washington County,Wisconsin,55,131,Outlying
-"Milwaukee-Waukesha, WI",33340,,376,,"Milwaukee-Racine-Waukesha, WI",Waukesha County,Wisconsin,55,133,Central
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Anoka County,Minnesota,27,003,Central
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Carver County,Minnesota,27,019,Central
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Chisago County,Minnesota,27,025,Outlying
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Dakota County,Minnesota,27,037,Central
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Hennepin County,Minnesota,27,053,Central
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Isanti County,Minnesota,27,059,Outlying
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Le Sueur County,Minnesota,27,079,Outlying
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Mille Lacs County,Minnesota,27,095,Outlying
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Ramsey County,Minnesota,27,123,Central
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Scott County,Minnesota,27,139,Central
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Sherburne County,Minnesota,27,141,Central
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Washington County,Minnesota,27,163,Central
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Wright County,Minnesota,27,171,Central
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",Pierce County,Wisconsin,55,093,Outlying
-"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,,"Minneapolis-St. Paul, MN-WI",St. Croix County,Wisconsin,55,109,Outlying
-"Missoula, MT",33540,,,,,Missoula County,Montana,30,063,Central
-"Mobile, AL",33660,,380,,"Mobile-Daphne-Fairhope, AL",Mobile County,Alabama,01,097,Central
-"Mobile, AL",33660,,380,,"Mobile-Daphne-Fairhope, AL",Washington County,Alabama,01,129,Outlying
-"Modesto, CA",33700,,488,,"San Jose-San Francisco-Oakland, CA",Stanislaus County,California,06,099,Central
-"Monroe, LA",33740,,384,,"Monroe-Ruston, LA",Morehouse Parish,Louisiana,22,067,Outlying
-"Monroe, LA",33740,,384,,"Monroe-Ruston, LA",Ouachita Parish,Louisiana,22,073,Central
-"Monroe, LA",33740,,384,,"Monroe-Ruston, LA",Union Parish,Louisiana,22,111,Outlying
-"Monroe, MI",33780,,220,,"Detroit-Warren-Ann Arbor, MI",Monroe County,Michigan,26,115,Central
-"Montgomery, AL",33860,,388,,"Montgomery-Selma-Alexander City, AL",Autauga County,Alabama,01,001,Central
-"Montgomery, AL",33860,,388,,"Montgomery-Selma-Alexander City, AL",Elmore County,Alabama,01,051,Central
-"Montgomery, AL",33860,,388,,"Montgomery-Selma-Alexander City, AL",Lowndes County,Alabama,01,085,Outlying
-"Montgomery, AL",33860,,388,,"Montgomery-Selma-Alexander City, AL",Montgomery County,Alabama,01,101,Central
-"Morgantown, WV",34060,,390,,"Morgantown-Fairmont, WV",Monongalia County,West Virginia,54,061,Central
-"Morgantown, WV",34060,,390,,"Morgantown-Fairmont, WV",Preston County,West Virginia,54,077,Outlying
-"Morristown, TN",34100,,315,,"Knoxville-Morristown-Sevierville, TN",Grainger County,Tennessee,47,057,Outlying
-"Morristown, TN",34100,,315,,"Knoxville-Morristown-Sevierville, TN",Hamblen County,Tennessee,47,063,Central
-"Morristown, TN",34100,,315,,"Knoxville-Morristown-Sevierville, TN",Jefferson County,Tennessee,47,089,Central
-"Mount Vernon-Anacortes, WA",34580,,500,,"Seattle-Tacoma, WA",Skagit County,Washington,53,057,Central
-"Muncie, IN",34620,,294,,"Indianapolis-Carmel-Muncie, IN",Delaware County,Indiana,18,035,Central
-"Muskegon, MI",34740,,266,,"Grand Rapids-Kentwood-Muskegon, MI",Muskegon County,Michigan,26,121,Central
-"Myrtle Beach-Conway-North Myrtle Beach, SC-NC",34820,,396,,"Myrtle Beach-Conway, SC-NC",Brunswick County,North Carolina,37,019,Central
-"Myrtle Beach-Conway-North Myrtle Beach, SC-NC",34820,,396,,"Myrtle Beach-Conway, SC-NC",Horry County,South Carolina,45,051,Central
-"Napa, CA",34900,,488,,"San Jose-San Francisco-Oakland, CA",Napa County,California,06,055,Central
-"Naples-Marco Island, FL",34940,,163,,"Cape Coral-Fort Myers-Naples, FL",Collier County,Florida,12,021,Central
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Cannon County,Tennessee,47,015,Outlying
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Cheatham County,Tennessee,47,021,Outlying
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Davidson County,Tennessee,47,037,Central
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Dickson County,Tennessee,47,043,Outlying
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Macon County,Tennessee,47,111,Outlying
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Maury County,Tennessee,47,119,Outlying
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Robertson County,Tennessee,47,147,Outlying
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Rutherford County,Tennessee,47,149,Outlying
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Smith County,Tennessee,47,159,Outlying
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Sumner County,Tennessee,47,165,Central
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Trousdale County,Tennessee,47,169,Outlying
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Williamson County,Tennessee,47,187,Central
-"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,,"Nashville-Davidson--Murfreesboro, TN",Wilson County,Tennessee,47,189,Central
-"New Bern, NC",35100,,404,,"New Bern-Morehead City, NC",Craven County,North Carolina,37,049,Central
-"New Bern, NC",35100,,404,,"New Bern-Morehead City, NC",Jones County,North Carolina,37,103,Outlying
-"New Bern, NC",35100,,404,,"New Bern-Morehead City, NC",Pamlico County,North Carolina,37,137,Outlying
-"New Haven-Milford, CT",35300,,408,,"New York-Newark, NY-NJ-CT-PA",New Haven County,Connecticut,09,009,Central
-"New Orleans-Metairie, LA",35380,,406,,"New Orleans-Metairie-Hammond, LA-MS",Jefferson Parish,Louisiana,22,051,Central
-"New Orleans-Metairie, LA",35380,,406,,"New Orleans-Metairie-Hammond, LA-MS",Orleans Parish,Louisiana,22,071,Central
-"New Orleans-Metairie, LA",35380,,406,,"New Orleans-Metairie-Hammond, LA-MS",Plaquemines Parish,Louisiana,22,075,Central
-"New Orleans-Metairie, LA",35380,,406,,"New Orleans-Metairie-Hammond, LA-MS",St. Bernard Parish,Louisiana,22,087,Central
-"New Orleans-Metairie, LA",35380,,406,,"New Orleans-Metairie-Hammond, LA-MS",St. Charles Parish,Louisiana,22,089,Central
-"New Orleans-Metairie, LA",35380,,406,,"New Orleans-Metairie-Hammond, LA-MS",St. James Parish,Louisiana,22,093,Outlying
-"New Orleans-Metairie, LA",35380,,406,,"New Orleans-Metairie-Hammond, LA-MS",St. John the Baptist Parish,Louisiana,22,095,Central
-"New Orleans-Metairie, LA",35380,,406,,"New Orleans-Metairie-Hammond, LA-MS",St. Tammany Parish,Louisiana,22,103,Outlying
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35004,408,"Nassau County-Suffolk County, NY","New York-Newark, NY-NJ-CT-PA",Nassau County,New York,36,059,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35004,408,"Nassau County-Suffolk County, NY","New York-Newark, NY-NJ-CT-PA",Suffolk County,New York,36,103,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Essex County,New Jersey,34,013,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Hunterdon County,New Jersey,34,019,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Morris County,New Jersey,34,027,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Sussex County,New Jersey,34,037,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Union County,New Jersey,34,039,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Pike County,Pennsylvania,42,103,Outlying
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35154,408,"New Brunswick-Lakewood, NJ","New York-Newark, NY-NJ-CT-PA",Middlesex County,New Jersey,34,023,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35154,408,"New Brunswick-Lakewood, NJ","New York-Newark, NY-NJ-CT-PA",Monmouth County,New Jersey,34,025,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35154,408,"New Brunswick-Lakewood, NJ","New York-Newark, NY-NJ-CT-PA",Ocean County,New Jersey,34,029,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35154,408,"New Brunswick-Lakewood, NJ","New York-Newark, NY-NJ-CT-PA",Somerset County,New Jersey,34,035,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Bergen County,New Jersey,34,003,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Hudson County,New Jersey,34,017,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Passaic County,New Jersey,34,031,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Bronx County,New York,36,005,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Kings County,New York,36,047,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",New York County,New York,36,061,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Putnam County,New York,36,079,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Queens County,New York,36,081,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Richmond County,New York,36,085,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Rockland County,New York,36,087,Central
-"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Westchester County,New York,36,119,Central
-"Niles, MI",35660,,515,,"South Bend-Elkhart-Mishawaka, IN-MI",Berrien County,Michigan,26,021,Central
-"North Port-Sarasota-Bradenton, FL",35840,,412,,"North Port-Sarasota, FL",Manatee County,Florida,12,081,Central
-"North Port-Sarasota-Bradenton, FL",35840,,412,,"North Port-Sarasota, FL",Sarasota County,Florida,12,115,Central
-"Norwich-New London, CT",35980,,278,,"Hartford-East Hartford, CT",New London County,Connecticut,09,011,Central
-"Ocala, FL",36100,,,,,Marion County,Florida,12,083,Central
-"Ocean City, NJ",36140,,428,,"Philadelphia-Reading-Camden, PA-NJ-DE-MD",Cape May County,New Jersey,34,009,Central
-"Odessa, TX",36220,,372,,"Midland-Odessa, TX",Ector County,Texas,48,135,Central
-"Ogden-Clearfield, UT",36260,,482,,"Salt Lake City-Provo-Orem, UT",Box Elder County,Utah,49,003,Central
-"Ogden-Clearfield, UT",36260,,482,,"Salt Lake City-Provo-Orem, UT",Davis County,Utah,49,011,Central
-"Ogden-Clearfield, UT",36260,,482,,"Salt Lake City-Provo-Orem, UT",Morgan County,Utah,49,029,Outlying
-"Ogden-Clearfield, UT",36260,,482,,"Salt Lake City-Provo-Orem, UT",Weber County,Utah,49,057,Central
-"Oklahoma City, OK",36420,,416,,"Oklahoma City-Shawnee, OK",Canadian County,Oklahoma,40,017,Central
-"Oklahoma City, OK",36420,,416,,"Oklahoma City-Shawnee, OK",Cleveland County,Oklahoma,40,027,Central
-"Oklahoma City, OK",36420,,416,,"Oklahoma City-Shawnee, OK",Grady County,Oklahoma,40,051,Outlying
-"Oklahoma City, OK",36420,,416,,"Oklahoma City-Shawnee, OK",Lincoln County,Oklahoma,40,081,Outlying
-"Oklahoma City, OK",36420,,416,,"Oklahoma City-Shawnee, OK",Logan County,Oklahoma,40,083,Central
-"Oklahoma City, OK",36420,,416,,"Oklahoma City-Shawnee, OK",McClain County,Oklahoma,40,087,Outlying
-"Oklahoma City, OK",36420,,416,,"Oklahoma City-Shawnee, OK",Oklahoma County,Oklahoma,40,109,Central
-"Olympia-Lacey-Tumwater, WA",36500,,500,,"Seattle-Tacoma, WA",Thurston County,Washington,53,067,Central
-"Omaha-Council Bluffs, NE-IA",36540,,420,,"Omaha-Council Bluffs-Fremont, NE-IA",Harrison County,Iowa,19,085,Outlying
-"Omaha-Council Bluffs, NE-IA",36540,,420,,"Omaha-Council Bluffs-Fremont, NE-IA",Mills County,Iowa,19,129,Outlying
-"Omaha-Council Bluffs, NE-IA",36540,,420,,"Omaha-Council Bluffs-Fremont, NE-IA",Pottawattamie County,Iowa,19,155,Central
-"Omaha-Council Bluffs, NE-IA",36540,,420,,"Omaha-Council Bluffs-Fremont, NE-IA",Cass County,Nebraska,31,025,Outlying
-"Omaha-Council Bluffs, NE-IA",36540,,420,,"Omaha-Council Bluffs-Fremont, NE-IA",Douglas County,Nebraska,31,055,Central
-"Omaha-Council Bluffs, NE-IA",36540,,420,,"Omaha-Council Bluffs-Fremont, NE-IA",Sarpy County,Nebraska,31,153,Central
-"Omaha-Council Bluffs, NE-IA",36540,,420,,"Omaha-Council Bluffs-Fremont, NE-IA",Saunders County,Nebraska,31,155,Outlying
-"Omaha-Council Bluffs, NE-IA",36540,,420,,"Omaha-Council Bluffs-Fremont, NE-IA",Washington County,Nebraska,31,177,Outlying
-"Orlando-Kissimmee-Sanford, FL",36740,,422,,"Orlando-Lakeland-Deltona, FL",Lake County,Florida,12,069,Outlying
-"Orlando-Kissimmee-Sanford, FL",36740,,422,,"Orlando-Lakeland-Deltona, FL",Orange County,Florida,12,095,Central
-"Orlando-Kissimmee-Sanford, FL",36740,,422,,"Orlando-Lakeland-Deltona, FL",Osceola County,Florida,12,097,Outlying
-"Orlando-Kissimmee-Sanford, FL",36740,,422,,"Orlando-Lakeland-Deltona, FL",Seminole County,Florida,12,117,Central
-"Oshkosh-Neenah, WI",36780,,118,,"Appleton-Oshkosh-Neenah, WI",Winnebago County,Wisconsin,55,139,Central
-"Owensboro, KY",36980,,,,,Daviess County,Kentucky,21,059,Central
-"Owensboro, KY",36980,,,,,Hancock County,Kentucky,21,091,Outlying
-"Owensboro, KY",36980,,,,,McLean County,Kentucky,21,149,Outlying
-"Oxnard-Thousand Oaks-Ventura, CA",37100,,348,,"Los Angeles-Long Beach, CA",Ventura County,California,06,111,Central
-"Palm Bay-Melbourne-Titusville, FL",37340,,,,,Brevard County,Florida,12,009,Central
-"Panama City, FL",37460,,,,,Bay County,Florida,12,005,Central
-"Parkersburg-Vienna, WV",37620,,425,,"Parkersburg-Marietta-Vienna, WV-OH",Wirt County,West Virginia,54,105,Outlying
-"Parkersburg-Vienna, WV",37620,,425,,"Parkersburg-Marietta-Vienna, WV-OH",Wood County,West Virginia,54,107,Central
-"Pensacola-Ferry Pass-Brent, FL",37860,,426,,"Pensacola-Ferry Pass, FL-AL",Escambia County,Florida,12,033,Central
-"Pensacola-Ferry Pass-Brent, FL",37860,,426,,"Pensacola-Ferry Pass, FL-AL",Santa Rosa County,Florida,12,113,Central
-"Peoria, IL",37900,,,,,Fulton County,Illinois,17,057,Outlying
-"Peoria, IL",37900,,,,,Marshall County,Illinois,17,123,Outlying
-"Peoria, IL",37900,,,,,Peoria County,Illinois,17,143,Central
-"Peoria, IL",37900,,,,,Stark County,Illinois,17,175,Outlying
-"Peoria, IL",37900,,,,,Tazewell County,Illinois,17,179,Central
-"Peoria, IL",37900,,,,,Woodford County,Illinois,17,203,Central
-"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,15804,428,"Camden, NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Burlington County,New Jersey,34,005,Central
-"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,15804,428,"Camden, NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Camden County,New Jersey,34,007,Central
-"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,15804,428,"Camden, NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Gloucester County,New Jersey,34,015,Central
-"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,33874,428,"Montgomery County-Bucks County-Chester County, PA","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Bucks County,Pennsylvania,42,017,Central
-"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,33874,428,"Montgomery County-Bucks County-Chester County, PA","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Chester County,Pennsylvania,42,029,Central
-"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,33874,428,"Montgomery County-Bucks County-Chester County, PA","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Montgomery County,Pennsylvania,42,091,Central
-"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,37964,428,"Philadelphia, PA","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Delaware County,Pennsylvania,42,045,Central
-"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,37964,428,"Philadelphia, PA","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Philadelphia County,Pennsylvania,42,101,Central
-"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,48864,428,"Wilmington, DE-MD-NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",New Castle County,Delaware,10,003,Central
-"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,48864,428,"Wilmington, DE-MD-NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Cecil County,Maryland,24,015,Central
-"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,48864,428,"Wilmington, DE-MD-NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Salem County,New Jersey,34,033,Central
-"Phoenix-Mesa-Chandler, AZ",38060,,429,,"Phoenix-Mesa, AZ",Maricopa County,Arizona,04,013,Central
-"Phoenix-Mesa-Chandler, AZ",38060,,429,,"Phoenix-Mesa, AZ",Pinal County,Arizona,04,021,Central
-"Pine Bluff, AR",38220,,340,,"Little Rock-North Little Rock, AR",Cleveland County,Arkansas,05,025,Outlying
-"Pine Bluff, AR",38220,,340,,"Little Rock-North Little Rock, AR",Jefferson County,Arkansas,05,069,Central
-"Pine Bluff, AR",38220,,340,,"Little Rock-North Little Rock, AR",Lincoln County,Arkansas,05,079,Outlying
-"Pittsburgh, PA",38300,,430,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Allegheny County,Pennsylvania,42,003,Central
-"Pittsburgh, PA",38300,,430,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Armstrong County,Pennsylvania,42,005,Outlying
-"Pittsburgh, PA",38300,,430,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Beaver County,Pennsylvania,42,007,Central
-"Pittsburgh, PA",38300,,430,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Butler County,Pennsylvania,42,019,Central
-"Pittsburgh, PA",38300,,430,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Fayette County,Pennsylvania,42,051,Outlying
-"Pittsburgh, PA",38300,,430,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Washington County,Pennsylvania,42,125,Central
-"Pittsburgh, PA",38300,,430,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Westmoreland County,Pennsylvania,42,129,Central
-"Pittsfield, MA",38340,,,,,Berkshire County,Massachusetts,25,003,Central
-"Pocatello, ID",38540,,,,,Bannock County,Idaho,16,005,Central
-"Pocatello, ID",38540,,,,,Power County,Idaho,16,077,Outlying
-"Ponce, PR",38660,,434,,"Ponce-Yauco-Coamo, PR",Adjuntas Municipio,Puerto Rico,72,001,Outlying
-"Ponce, PR",38660,,434,,"Ponce-Yauco-Coamo, PR",Juana Díaz Municipio,Puerto Rico,72,075,Outlying
-"Ponce, PR",38660,,434,,"Ponce-Yauco-Coamo, PR",Ponce Municipio,Puerto Rico,72,113,Central
-"Ponce, PR",38660,,434,,"Ponce-Yauco-Coamo, PR",Villalba Municipio,Puerto Rico,72,149,Outlying
-"Portland-South Portland, ME",38860,,438,,"Portland-Lewiston-South Portland, ME",Cumberland County,Maine,23,005,Central
-"Portland-South Portland, ME",38860,,438,,"Portland-Lewiston-South Portland, ME",Sagadahoc County,Maine,23,023,Outlying
-"Portland-South Portland, ME",38860,,438,,"Portland-Lewiston-South Portland, ME",York County,Maine,23,031,Central
-"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,,"Portland-Vancouver-Salem, OR-WA",Clackamas County,Oregon,41,005,Central
-"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,,"Portland-Vancouver-Salem, OR-WA",Columbia County,Oregon,41,009,Outlying
-"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,,"Portland-Vancouver-Salem, OR-WA",Multnomah County,Oregon,41,051,Central
-"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,,"Portland-Vancouver-Salem, OR-WA",Washington County,Oregon,41,067,Central
-"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,,"Portland-Vancouver-Salem, OR-WA",Yamhill County,Oregon,41,071,Outlying
-"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,,"Portland-Vancouver-Salem, OR-WA",Clark County,Washington,53,011,Central
-"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,,"Portland-Vancouver-Salem, OR-WA",Skamania County,Washington,53,059,Outlying
-"Port St. Lucie, FL",38940,,370,,"Miami-Port St. Lucie-Fort Lauderdale, FL",Martin County,Florida,12,085,Central
-"Port St. Lucie, FL",38940,,370,,"Miami-Port St. Lucie-Fort Lauderdale, FL",St. Lucie County,Florida,12,111,Central
-"Poughkeepsie-Newburgh-Middletown, NY",39100,,408,,"New York-Newark, NY-NJ-CT-PA",Dutchess County,New York,36,027,Central
-"Poughkeepsie-Newburgh-Middletown, NY",39100,,408,,"New York-Newark, NY-NJ-CT-PA",Orange County,New York,36,071,Central
-"Prescott Valley-Prescott, AZ",39150,,,,,Yavapai County,Arizona,04,025,Central
-"Providence-Warwick, RI-MA",39300,,148,,"Boston-Worcester-Providence, MA-RI-NH-CT",Bristol County,Massachusetts,25,005,Central
-"Providence-Warwick, RI-MA",39300,,148,,"Boston-Worcester-Providence, MA-RI-NH-CT",Bristol County,Rhode Island,44,001,Central
-"Providence-Warwick, RI-MA",39300,,148,,"Boston-Worcester-Providence, MA-RI-NH-CT",Kent County,Rhode Island,44,003,Central
-"Providence-Warwick, RI-MA",39300,,148,,"Boston-Worcester-Providence, MA-RI-NH-CT",Newport County,Rhode Island,44,005,Central
-"Providence-Warwick, RI-MA",39300,,148,,"Boston-Worcester-Providence, MA-RI-NH-CT",Providence County,Rhode Island,44,007,Central
-"Providence-Warwick, RI-MA",39300,,148,,"Boston-Worcester-Providence, MA-RI-NH-CT",Washington County,Rhode Island,44,009,Central
-"Provo-Orem, UT",39340,,482,,"Salt Lake City-Provo-Orem, UT",Juab County,Utah,49,023,Outlying
-"Provo-Orem, UT",39340,,482,,"Salt Lake City-Provo-Orem, UT",Utah County,Utah,49,049,Central
-"Pueblo, CO",39380,,444,,"Pueblo-Cañon City, CO",Pueblo County,Colorado,08,101,Central
-"Punta Gorda, FL",39460,,412,,"North Port-Sarasota, FL",Charlotte County,Florida,12,015,Central
-"Racine, WI",39540,,376,,"Milwaukee-Racine-Waukesha, WI",Racine County,Wisconsin,55,101,Central
-"Raleigh-Cary, NC",39580,,450,,"Raleigh-Durham-Cary, NC",Franklin County,North Carolina,37,069,Outlying
-"Raleigh-Cary, NC",39580,,450,,"Raleigh-Durham-Cary, NC",Johnston County,North Carolina,37,101,Central
-"Raleigh-Cary, NC",39580,,450,,"Raleigh-Durham-Cary, NC",Wake County,North Carolina,37,183,Central
-"Rapid City, SD",39660,,452,,"Rapid City-Spearfish, SD",Meade County,South Dakota,46,093,Central
-"Rapid City, SD",39660,,452,,"Rapid City-Spearfish, SD",Pennington County,South Dakota,46,103,Central
-"Reading, PA",39740,,428,,"Philadelphia-Reading-Camden, PA-NJ-DE-MD",Berks County,Pennsylvania,42,011,Central
-"Redding, CA",39820,,454,,"Redding-Red Bluff, CA",Shasta County,California,06,089,Central
-"Reno, NV",39900,,456,,"Reno-Carson City-Fernley, NV",Storey County,Nevada,32,029,Outlying
-"Reno, NV",39900,,456,,"Reno-Carson City-Fernley, NV",Washoe County,Nevada,32,031,Central
-"Richmond, VA",40060,,,,,Amelia County,Virginia,51,007,Outlying
-"Richmond, VA",40060,,,,,Charles City County,Virginia,51,036,Outlying
-"Richmond, VA",40060,,,,,Chesterfield County,Virginia,51,041,Central
-"Richmond, VA",40060,,,,,Dinwiddie County,Virginia,51,053,Central
-"Richmond, VA",40060,,,,,Goochland County,Virginia,51,075,Outlying
-"Richmond, VA",40060,,,,,Hanover County,Virginia,51,085,Central
-"Richmond, VA",40060,,,,,Henrico County,Virginia,51,087,Central
-"Richmond, VA",40060,,,,,King and Queen County,Virginia,51,097,Outlying
-"Richmond, VA",40060,,,,,King William County,Virginia,51,101,Outlying
-"Richmond, VA",40060,,,,,New Kent County,Virginia,51,127,Outlying
-"Richmond, VA",40060,,,,,Powhatan County,Virginia,51,145,Outlying
-"Richmond, VA",40060,,,,,Prince George County,Virginia,51,149,Central
-"Richmond, VA",40060,,,,,Sussex County,Virginia,51,183,Outlying
-"Richmond, VA",40060,,,,,Colonial Heights city,Virginia,51,570,Central
-"Richmond, VA",40060,,,,,Hopewell city,Virginia,51,670,Central
-"Richmond, VA",40060,,,,,Petersburg city,Virginia,51,730,Central
-"Richmond, VA",40060,,,,,Richmond city,Virginia,51,760,Central
-"Riverside-San Bernardino-Ontario, CA",40140,,348,,"Los Angeles-Long Beach, CA",Riverside County,California,06,065,Central
-"Riverside-San Bernardino-Ontario, CA",40140,,348,,"Los Angeles-Long Beach, CA",San Bernardino County,California,06,071,Central
-"Roanoke, VA",40220,,,,,Botetourt County,Virginia,51,023,Central
-"Roanoke, VA",40220,,,,,Craig County,Virginia,51,045,Outlying
-"Roanoke, VA",40220,,,,,Franklin County,Virginia,51,067,Outlying
-"Roanoke, VA",40220,,,,,Roanoke County,Virginia,51,161,Central
-"Roanoke, VA",40220,,,,,Roanoke city,Virginia,51,770,Central
-"Roanoke, VA",40220,,,,,Salem city,Virginia,51,775,Central
-"Rochester, MN",40340,,462,,"Rochester-Austin, MN",Dodge County,Minnesota,27,039,Outlying
-"Rochester, MN",40340,,462,,"Rochester-Austin, MN",Fillmore County,Minnesota,27,045,Outlying
-"Rochester, MN",40340,,462,,"Rochester-Austin, MN",Olmsted County,Minnesota,27,109,Central
-"Rochester, MN",40340,,462,,"Rochester-Austin, MN",Wabasha County,Minnesota,27,157,Outlying
-"Rochester, NY",40380,,464,,"Rochester-Batavia-Seneca Falls, NY",Livingston County,New York,36,051,Outlying
-"Rochester, NY",40380,,464,,"Rochester-Batavia-Seneca Falls, NY",Monroe County,New York,36,055,Central
-"Rochester, NY",40380,,464,,"Rochester-Batavia-Seneca Falls, NY",Ontario County,New York,36,069,Central
-"Rochester, NY",40380,,464,,"Rochester-Batavia-Seneca Falls, NY",Orleans County,New York,36,073,Outlying
-"Rochester, NY",40380,,464,,"Rochester-Batavia-Seneca Falls, NY",Wayne County,New York,36,117,Outlying
-"Rochester, NY",40380,,464,,"Rochester-Batavia-Seneca Falls, NY",Yates County,New York,36,123,Outlying
-"Rockford, IL",40420,,466,,"Rockford-Freeport-Rochelle, IL",Boone County,Illinois,17,007,Central
-"Rockford, IL",40420,,466,,"Rockford-Freeport-Rochelle, IL",Winnebago County,Illinois,17,201,Central
-"Rocky Mount, NC",40580,,468,,"Rocky Mount-Wilson-Roanoke Rapids, NC",Edgecombe County,North Carolina,37,065,Central
-"Rocky Mount, NC",40580,,468,,"Rocky Mount-Wilson-Roanoke Rapids, NC",Nash County,North Carolina,37,127,Central
-"Rome, GA",40660,,122,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Floyd County,Georgia,13,115,Central
-"Sacramento-Roseville-Folsom, CA",40900,,472,,"Sacramento-Roseville, CA",El Dorado County,California,06,017,Central
-"Sacramento-Roseville-Folsom, CA",40900,,472,,"Sacramento-Roseville, CA",Placer County,California,06,061,Central
-"Sacramento-Roseville-Folsom, CA",40900,,472,,"Sacramento-Roseville, CA",Sacramento County,California,06,067,Central
-"Sacramento-Roseville-Folsom, CA",40900,,472,,"Sacramento-Roseville, CA",Yolo County,California,06,113,Outlying
-"Saginaw, MI",40980,,474,,"Saginaw-Midland-Bay City, MI",Saginaw County,Michigan,26,145,Central
-"St. Cloud, MN",41060,,378,,"Minneapolis-St. Paul, MN-WI",Benton County,Minnesota,27,009,Central
-"St. Cloud, MN",41060,,378,,"Minneapolis-St. Paul, MN-WI",Stearns County,Minnesota,27,145,Central
-"St. George, UT",41100,,,,,Washington County,Utah,49,053,Central
-"St. Joseph, MO-KS",41140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Doniphan County,Kansas,20,043,Outlying
-"St. Joseph, MO-KS",41140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Andrew County,Missouri,29,003,Outlying
-"St. Joseph, MO-KS",41140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",Buchanan County,Missouri,29,021,Central
-"St. Joseph, MO-KS",41140,,312,,"Kansas City-Overland Park-Kansas City, MO-KS",DeKalb County,Missouri,29,063,Outlying
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",Bond County,Illinois,17,005,Outlying
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",Calhoun County,Illinois,17,013,Outlying
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",Clinton County,Illinois,17,027,Outlying
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",Jersey County,Illinois,17,083,Outlying
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",Macoupin County,Illinois,17,117,Outlying
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",Madison County,Illinois,17,119,Central
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",Monroe County,Illinois,17,133,Central
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",St. Clair County,Illinois,17,163,Central
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",Franklin County,Missouri,29,071,Outlying
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",Jefferson County,Missouri,29,099,Central
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",Lincoln County,Missouri,29,113,Outlying
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",St. Charles County,Missouri,29,183,Central
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",St. Louis County,Missouri,29,189,Central
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",Warren County,Missouri,29,219,Outlying
-"St. Louis, MO-IL",41180,,476,,"St. Louis-St. Charles-Farmington, MO-IL",St. Louis city,Missouri,29,510,Central
-"Salem, OR",41420,,440,,"Portland-Vancouver-Salem, OR-WA",Marion County,Oregon,41,047,Central
-"Salem, OR",41420,,440,,"Portland-Vancouver-Salem, OR-WA",Polk County,Oregon,41,053,Central
-"Salinas, CA",41500,,,,,Monterey County,California,06,053,Central
-"Salisbury, MD-DE",41540,,480,,"Salisbury-Cambridge, MD-DE",Sussex County,Delaware,10,005,Central
-"Salisbury, MD-DE",41540,,480,,"Salisbury-Cambridge, MD-DE",Somerset County,Maryland,24,039,Outlying
-"Salisbury, MD-DE",41540,,480,,"Salisbury-Cambridge, MD-DE",Wicomico County,Maryland,24,045,Central
-"Salisbury, MD-DE",41540,,480,,"Salisbury-Cambridge, MD-DE",Worcester County,Maryland,24,047,Outlying
-"Salt Lake City, UT",41620,,482,,"Salt Lake City-Provo-Orem, UT",Salt Lake County,Utah,49,035,Central
-"Salt Lake City, UT",41620,,482,,"Salt Lake City-Provo-Orem, UT",Tooele County,Utah,49,045,Outlying
-"San Angelo, TX",41660,,,,,Irion County,Texas,48,235,Outlying
-"San Angelo, TX",41660,,,,,Sterling County,Texas,48,431,Outlying
-"San Angelo, TX",41660,,,,,Tom Green County,Texas,48,451,Central
-"San Antonio-New Braunfels, TX",41700,,484,,"San Antonio-New Braunfels-Pearsall, TX",Atascosa County,Texas,48,013,Outlying
-"San Antonio-New Braunfels, TX",41700,,484,,"San Antonio-New Braunfels-Pearsall, TX",Bandera County,Texas,48,019,Outlying
-"San Antonio-New Braunfels, TX",41700,,484,,"San Antonio-New Braunfels-Pearsall, TX",Bexar County,Texas,48,029,Central
-"San Antonio-New Braunfels, TX",41700,,484,,"San Antonio-New Braunfels-Pearsall, TX",Comal County,Texas,48,091,Central
-"San Antonio-New Braunfels, TX",41700,,484,,"San Antonio-New Braunfels-Pearsall, TX",Guadalupe County,Texas,48,187,Central
-"San Antonio-New Braunfels, TX",41700,,484,,"San Antonio-New Braunfels-Pearsall, TX",Kendall County,Texas,48,259,Outlying
-"San Antonio-New Braunfels, TX",41700,,484,,"San Antonio-New Braunfels-Pearsall, TX",Medina County,Texas,48,325,Outlying
-"San Antonio-New Braunfels, TX",41700,,484,,"San Antonio-New Braunfels-Pearsall, TX",Wilson County,Texas,48,493,Outlying
-"San Diego-Chula Vista-Carlsbad, CA",41740,,,,,San Diego County,California,06,073,Central
-"San Francisco-Oakland-Berkeley, CA",41860,36084,488,"Oakland-Berkeley-Livermore, CA","San Jose-San Francisco-Oakland, CA",Alameda County,California,06,001,Central
-"San Francisco-Oakland-Berkeley, CA",41860,36084,488,"Oakland-Berkeley-Livermore, CA","San Jose-San Francisco-Oakland, CA",Contra Costa County,California,06,013,Outlying
-"San Francisco-Oakland-Berkeley, CA",41860,41884,488,"San Francisco-San Mateo-Redwood City, CA","San Jose-San Francisco-Oakland, CA",San Francisco County,California,06,075,Central
-"San Francisco-Oakland-Berkeley, CA",41860,41884,488,"San Francisco-San Mateo-Redwood City, CA","San Jose-San Francisco-Oakland, CA",San Mateo County,California,06,081,Central
-"San Francisco-Oakland-Berkeley, CA",41860,42034,488,"San Rafael, CA","San Jose-San Francisco-Oakland, CA",Marin County,California,06,041,Central
-"San Germán, PR",41900,,364,,"Mayagüez-San Germán, PR",Cabo Rojo Municipio,Puerto Rico,72,023,Central
-"San Germán, PR",41900,,364,,"Mayagüez-San Germán, PR",Lajas Municipio,Puerto Rico,72,079,Central
-"San Germán, PR",41900,,364,,"Mayagüez-San Germán, PR",Sabana Grande Municipio,Puerto Rico,72,121,Central
-"San Germán, PR",41900,,364,,"Mayagüez-San Germán, PR",San Germán Municipio,Puerto Rico,72,125,Central
-"San Jose-Sunnyvale-Santa Clara, CA",41940,,488,,"San Jose-San Francisco-Oakland, CA",San Benito County,California,06,069,Outlying
-"San Jose-Sunnyvale-Santa Clara, CA",41940,,488,,"San Jose-San Francisco-Oakland, CA",Santa Clara County,California,06,085,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Aguas Buenas Municipio,Puerto Rico,72,007,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Aibonito Municipio,Puerto Rico,72,009,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Barceloneta Municipio,Puerto Rico,72,017,Outlying
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Barranquitas Municipio,Puerto Rico,72,019,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Bayamón Municipio,Puerto Rico,72,021,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Caguas Municipio,Puerto Rico,72,025,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Canóvanas Municipio,Puerto Rico,72,029,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Carolina Municipio,Puerto Rico,72,031,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Cataño Municipio,Puerto Rico,72,033,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Cayey Municipio,Puerto Rico,72,035,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Ceiba Municipio,Puerto Rico,72,037,Outlying
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Ciales Municipio,Puerto Rico,72,039,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Cidra Municipio,Puerto Rico,72,041,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Comerío Municipio,Puerto Rico,72,045,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Corozal Municipio,Puerto Rico,72,047,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Dorado Municipio,Puerto Rico,72,051,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Fajardo Municipio,Puerto Rico,72,053,Outlying
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Florida Municipio,Puerto Rico,72,054,Outlying
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Guaynabo Municipio,Puerto Rico,72,061,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Gurabo Municipio,Puerto Rico,72,063,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Humacao Municipio,Puerto Rico,72,069,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Juncos Municipio,Puerto Rico,72,077,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Las Piedras Municipio,Puerto Rico,72,085,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Loíza Municipio,Puerto Rico,72,087,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Luquillo Municipio,Puerto Rico,72,089,Outlying
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Manatí Municipio,Puerto Rico,72,091,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Maunabo Municipio,Puerto Rico,72,095,Outlying
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Morovis Municipio,Puerto Rico,72,101,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Naguabo Municipio,Puerto Rico,72,103,Outlying
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Naranjito Municipio,Puerto Rico,72,105,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Orocovis Municipio,Puerto Rico,72,107,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Río Grande Municipio,Puerto Rico,72,119,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",San Juan Municipio,Puerto Rico,72,127,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",San Lorenzo Municipio,Puerto Rico,72,129,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Toa Alta Municipio,Puerto Rico,72,135,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Toa Baja Municipio,Puerto Rico,72,137,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Trujillo Alto Municipio,Puerto Rico,72,139,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Vega Alta Municipio,Puerto Rico,72,143,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Vega Baja Municipio,Puerto Rico,72,145,Central
-"San Juan-Bayamón-Caguas, PR",41980,,490,,"San Juan-Bayamón, PR",Yabucoa Municipio,Puerto Rico,72,151,Central
-"San Luis Obispo-Paso Robles, CA",42020,,,,,San Luis Obispo County,California,06,079,Central
-"Santa Cruz-Watsonville, CA",42100,,488,,"San Jose-San Francisco-Oakland, CA",Santa Cruz County,California,06,087,Central
-"Santa Fe, NM",42140,,106,,"Albuquerque-Santa Fe-Las Vegas, NM",Santa Fe County,New Mexico,35,049,Central
-"Santa Maria-Santa Barbara, CA",42200,,,,,Santa Barbara County,California,06,083,Central
-"Santa Rosa-Petaluma, CA",42220,,488,,"San Jose-San Francisco-Oakland, CA",Sonoma County,California,06,097,Central
-"Savannah, GA",42340,,496,,"Savannah-Hinesville-Statesboro, GA",Bryan County,Georgia,13,029,Central
-"Savannah, GA",42340,,496,,"Savannah-Hinesville-Statesboro, GA",Chatham County,Georgia,13,051,Central
-"Savannah, GA",42340,,496,,"Savannah-Hinesville-Statesboro, GA",Effingham County,Georgia,13,103,Outlying
-"Scranton--Wilkes-Barre, PA",42540,,,,,Lackawanna County,Pennsylvania,42,069,Central
-"Scranton--Wilkes-Barre, PA",42540,,,,,Luzerne County,Pennsylvania,42,079,Central
-"Scranton--Wilkes-Barre, PA",42540,,,,,Wyoming County,Pennsylvania,42,131,Outlying
-"Seattle-Tacoma-Bellevue, WA",42660,42644,500,"Seattle-Bellevue-Kent, WA","Seattle-Tacoma, WA",King County,Washington,53,033,Central
-"Seattle-Tacoma-Bellevue, WA",42660,42644,500,"Seattle-Bellevue-Kent, WA","Seattle-Tacoma, WA",Snohomish County,Washington,53,061,Central
-"Seattle-Tacoma-Bellevue, WA",42660,45104,500,"Tacoma-Lakewood, WA","Seattle-Tacoma, WA",Pierce County,Washington,53,053,Central
-"Sebastian-Vero Beach, FL",42680,,370,,"Miami-Port St. Lucie-Fort Lauderdale, FL",Indian River County,Florida,12,061,Central
-"Sebring-Avon Park, FL",42700,,,,,Highlands County,Florida,12,055,Central
-"Sheboygan, WI",43100,,,,,Sheboygan County,Wisconsin,55,117,Central
-"Sherman-Denison, TX",43300,,206,,"Dallas-Fort Worth, TX-OK",Grayson County,Texas,48,181,Central
-"Shreveport-Bossier City, LA",43340,,508,,"Shreveport-Bossier City-Minden, LA",Bossier Parish,Louisiana,22,015,Central
-"Shreveport-Bossier City, LA",43340,,508,,"Shreveport-Bossier City-Minden, LA",Caddo Parish,Louisiana,22,017,Central
-"Shreveport-Bossier City, LA",43340,,508,,"Shreveport-Bossier City-Minden, LA",De Soto Parish,Louisiana,22,031,Outlying
-"Sierra Vista-Douglas, AZ",43420,,,,,Cochise County,Arizona,04,003,Central
-"Sioux City, IA-NE-SD",43580,,,,,Woodbury County,Iowa,19,193,Central
-"Sioux City, IA-NE-SD",43580,,,,,Dakota County,Nebraska,31,043,Central
-"Sioux City, IA-NE-SD",43580,,,,,Dixon County,Nebraska,31,051,Outlying
-"Sioux City, IA-NE-SD",43580,,,,,Union County,South Dakota,46,127,Central
-"Sioux Falls, SD",43620,,,,,Lincoln County,South Dakota,46,083,Central
-"Sioux Falls, SD",43620,,,,,McCook County,South Dakota,46,087,Outlying
-"Sioux Falls, SD",43620,,,,,Minnehaha County,South Dakota,46,099,Central
-"Sioux Falls, SD",43620,,,,,Turner County,South Dakota,46,125,Outlying
-"South Bend-Mishawaka, IN-MI",43780,,515,,"South Bend-Elkhart-Mishawaka, IN-MI",St. Joseph County,Indiana,18,141,Central
-"South Bend-Mishawaka, IN-MI",43780,,515,,"South Bend-Elkhart-Mishawaka, IN-MI",Cass County,Michigan,26,027,Central
-"Spartanburg, SC",43900,,273,,"Greenville-Spartanburg-Anderson, SC",Spartanburg County,South Carolina,45,083,Central
-"Spokane-Spokane Valley, WA",44060,,518,,"Spokane-Spokane Valley-Coeur d'Alene, WA-ID",Spokane County,Washington,53,063,Central
-"Spokane-Spokane Valley, WA",44060,,518,,"Spokane-Spokane Valley-Coeur d'Alene, WA-ID",Stevens County,Washington,53,065,Outlying
-"Springfield, IL",44100,,522,,"Springfield-Jacksonville-Lincoln, IL",Menard County,Illinois,17,129,Outlying
-"Springfield, IL",44100,,522,,"Springfield-Jacksonville-Lincoln, IL",Sangamon County,Illinois,17,167,Central
-"Springfield, MA",44140,,,,,Franklin County,Massachusetts,25,011,Outlying
-"Springfield, MA",44140,,,,,Hampden County,Massachusetts,25,013,Central
-"Springfield, MA",44140,,,,,Hampshire County,Massachusetts,25,015,Central
-"Springfield, MO",44180,,,,,Christian County,Missouri,29,043,Central
-"Springfield, MO",44180,,,,,Dallas County,Missouri,29,059,Outlying
-"Springfield, MO",44180,,,,,Greene County,Missouri,29,077,Central
-"Springfield, MO",44180,,,,,Polk County,Missouri,29,167,Outlying
-"Springfield, MO",44180,,,,,Webster County,Missouri,29,225,Outlying
-"Springfield, OH",44220,,212,,"Dayton-Springfield-Kettering, OH",Clark County,Ohio,39,023,Central
-"State College, PA",44300,,524,,"State College-DuBois, PA",Centre County,Pennsylvania,42,027,Central
-"Staunton, VA",44420,,277,,"Harrisonburg-Staunton, VA",Augusta County,Virginia,51,015,Central
-"Staunton, VA",44420,,277,,"Harrisonburg-Staunton, VA",Staunton city,Virginia,51,790,Central
-"Staunton, VA",44420,,277,,"Harrisonburg-Staunton, VA",Waynesboro city,Virginia,51,820,Central
-"Stockton, CA",44700,,488,,"San Jose-San Francisco-Oakland, CA",San Joaquin County,California,06,077,Central
-"Sumter, SC",44940,,,,,Clarendon County,South Carolina,45,027,Outlying
-"Sumter, SC",44940,,,,,Sumter County,South Carolina,45,085,Central
-"Syracuse, NY",45060,,532,,"Syracuse-Auburn, NY",Madison County,New York,36,053,Outlying
-"Syracuse, NY",45060,,532,,"Syracuse-Auburn, NY",Onondaga County,New York,36,067,Central
-"Syracuse, NY",45060,,532,,"Syracuse-Auburn, NY",Oswego County,New York,36,075,Outlying
-"Tallahassee, FL",45220,,,,,Gadsden County,Florida,12,039,Outlying
-"Tallahassee, FL",45220,,,,,Jefferson County,Florida,12,065,Outlying
-"Tallahassee, FL",45220,,,,,Leon County,Florida,12,073,Central
-"Tallahassee, FL",45220,,,,,Wakulla County,Florida,12,129,Outlying
-"Tampa-St. Petersburg-Clearwater, FL",45300,,,,,Hernando County,Florida,12,053,Outlying
-"Tampa-St. Petersburg-Clearwater, FL",45300,,,,,Hillsborough County,Florida,12,057,Central
-"Tampa-St. Petersburg-Clearwater, FL",45300,,,,,Pasco County,Florida,12,101,Central
-"Tampa-St. Petersburg-Clearwater, FL",45300,,,,,Pinellas County,Florida,12,103,Central
-"Terre Haute, IN",45460,,,,,Clay County,Indiana,18,021,Central
-"Terre Haute, IN",45460,,,,,Parke County,Indiana,18,121,Outlying
-"Terre Haute, IN",45460,,,,,Sullivan County,Indiana,18,153,Outlying
-"Terre Haute, IN",45460,,,,,Vermillion County,Indiana,18,165,Outlying
-"Terre Haute, IN",45460,,,,,Vigo County,Indiana,18,167,Central
-"Texarkana, TX-AR",45500,,,,,Little River County,Arkansas,05,081,Outlying
-"Texarkana, TX-AR",45500,,,,,Miller County,Arkansas,05,091,Central
-"Texarkana, TX-AR",45500,,,,,Bowie County,Texas,48,037,Central
-"The Villages, FL",45540,,422,,"Orlando-Lakeland-Deltona, FL",Sumter County,Florida,12,119,Central
-"Toledo, OH",45780,,534,,"Toledo-Findlay-Tiffin, OH",Fulton County,Ohio,39,051,Outlying
-"Toledo, OH",45780,,534,,"Toledo-Findlay-Tiffin, OH",Lucas County,Ohio,39,095,Central
-"Toledo, OH",45780,,534,,"Toledo-Findlay-Tiffin, OH",Ottawa County,Ohio,39,123,Outlying
-"Toledo, OH",45780,,534,,"Toledo-Findlay-Tiffin, OH",Wood County,Ohio,39,173,Central
-"Topeka, KS",45820,,,,,Jackson County,Kansas,20,085,Outlying
-"Topeka, KS",45820,,,,,Jefferson County,Kansas,20,087,Outlying
-"Topeka, KS",45820,,,,,Osage County,Kansas,20,139,Outlying
-"Topeka, KS",45820,,,,,Shawnee County,Kansas,20,177,Central
-"Topeka, KS",45820,,,,,Wabaunsee County,Kansas,20,197,Outlying
-"Trenton-Princeton, NJ",45940,,408,,"New York-Newark, NY-NJ-CT-PA",Mercer County,New Jersey,34,021,Central
-"Tucson, AZ",46060,,536,,"Tucson-Nogales, AZ",Pima County,Arizona,04,019,Central
-"Tulsa, OK",46140,,538,,"Tulsa-Muskogee-Bartlesville, OK",Creek County,Oklahoma,40,037,Central
-"Tulsa, OK",46140,,538,,"Tulsa-Muskogee-Bartlesville, OK",Okmulgee County,Oklahoma,40,111,Outlying
-"Tulsa, OK",46140,,538,,"Tulsa-Muskogee-Bartlesville, OK",Osage County,Oklahoma,40,113,Central
-"Tulsa, OK",46140,,538,,"Tulsa-Muskogee-Bartlesville, OK",Pawnee County,Oklahoma,40,117,Outlying
-"Tulsa, OK",46140,,538,,"Tulsa-Muskogee-Bartlesville, OK",Rogers County,Oklahoma,40,131,Outlying
-"Tulsa, OK",46140,,538,,"Tulsa-Muskogee-Bartlesville, OK",Tulsa County,Oklahoma,40,143,Central
-"Tulsa, OK",46140,,538,,"Tulsa-Muskogee-Bartlesville, OK",Wagoner County,Oklahoma,40,145,Central
-"Tuscaloosa, AL",46220,,,,,Greene County,Alabama,01,063,Outlying
-"Tuscaloosa, AL",46220,,,,,Hale County,Alabama,01,065,Outlying
-"Tuscaloosa, AL",46220,,,,,Pickens County,Alabama,01,107,Outlying
-"Tuscaloosa, AL",46220,,,,,Tuscaloosa County,Alabama,01,125,Central
-"Twin Falls, ID",46300,,,,,Jerome County,Idaho,16,053,Outlying
-"Twin Falls, ID",46300,,,,,Twin Falls County,Idaho,16,083,Central
-"Tyler, TX",46340,,540,,"Tyler-Jacksonville, TX",Smith County,Texas,48,423,Central
-"Urban Honolulu, HI",46520,,,,,Honolulu County,Hawaii,15,003,Central
-"Utica-Rome, NY",46540,,,,,Herkimer County,New York,36,043,Outlying
-"Utica-Rome, NY",46540,,,,,Oneida County,New York,36,065,Central
-"Valdosta, GA",46660,,,,,Brooks County,Georgia,13,027,Outlying
-"Valdosta, GA",46660,,,,,Echols County,Georgia,13,101,Outlying
-"Valdosta, GA",46660,,,,,Lanier County,Georgia,13,173,Outlying
-"Valdosta, GA",46660,,,,,Lowndes County,Georgia,13,185,Central
-"Vallejo, CA",46700,,488,,"San Jose-San Francisco-Oakland, CA",Solano County,California,06,095,Central
-"Victoria, TX",47020,,544,,"Victoria-Port Lavaca, TX",Goliad County,Texas,48,175,Outlying
-"Victoria, TX",47020,,544,,"Victoria-Port Lavaca, TX",Victoria County,Texas,48,469,Central
-"Vineland-Bridgeton, NJ",47220,,428,,"Philadelphia-Reading-Camden, PA-NJ-DE-MD",Cumberland County,New Jersey,34,011,Central
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Camden County,North Carolina,37,029,Outlying
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Currituck County,North Carolina,37,053,Outlying
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Gates County,North Carolina,37,073,Outlying
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Gloucester County,Virginia,51,073,Central
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Isle of Wight County,Virginia,51,093,Outlying
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",James City County,Virginia,51,095,Outlying
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Mathews County,Virginia,51,115,Outlying
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Southampton County,Virginia,51,175,Outlying
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",York County,Virginia,51,199,Central
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Chesapeake city,Virginia,51,550,Central
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Franklin city,Virginia,51,620,Outlying
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Hampton city,Virginia,51,650,Central
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Newport News city,Virginia,51,700,Central
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Norfolk city,Virginia,51,710,Central
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Poquoson city,Virginia,51,735,Central
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Portsmouth city,Virginia,51,740,Central
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Suffolk city,Virginia,51,800,Central
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Virginia Beach city,Virginia,51,810,Central
-"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,,"Virginia Beach-Norfolk, VA-NC",Williamsburg city,Virginia,51,830,Outlying
-"Visalia, CA",47300,,,,,Tulare County,California,06,107,Central
-"Waco, TX",47380,,,,,Falls County,Texas,48,145,Outlying
-"Waco, TX",47380,,,,,McLennan County,Texas,48,309,Central
-"Walla Walla, WA",47460,,313,,"Kennewick-Richland-Walla Walla, WA",Walla Walla County,Washington,53,071,Central
-"Warner Robins, GA",47580,,356,,"Macon-Bibb County--Warner Robins, GA",Houston County,Georgia,13,153,Central
-"Warner Robins, GA",47580,,356,,"Macon-Bibb County--Warner Robins, GA",Peach County,Georgia,13,225,Outlying
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,23224,548,"Frederick-Gaithersburg-Rockville, MD","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Frederick County,Maryland,24,021,Outlying
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,23224,548,"Frederick-Gaithersburg-Rockville, MD","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Montgomery County,Maryland,24,031,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",District of Columbia,District of Columbia,11,001,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Calvert County,Maryland,24,009,Outlying
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Charles County,Maryland,24,017,Outlying
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Prince George's County,Maryland,24,033,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Arlington County,Virginia,51,013,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Clarke County,Virginia,51,043,Outlying
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Culpeper County,Virginia,51,047,Outlying
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Fairfax County,Virginia,51,059,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Fauquier County,Virginia,51,061,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Loudoun County,Virginia,51,107,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Madison County,Virginia,51,113,Outlying
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Prince William County,Virginia,51,153,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Rappahannock County,Virginia,51,157,Outlying
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Spotsylvania County,Virginia,51,177,Outlying
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Stafford County,Virginia,51,179,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Warren County,Virginia,51,187,Outlying
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Alexandria city,Virginia,51,510,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Fairfax city,Virginia,51,600,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Falls Church city,Virginia,51,610,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Fredericksburg city,Virginia,51,630,Outlying
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Manassas city,Virginia,51,683,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Manassas Park city,Virginia,51,685,Central
-"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Jefferson County,West Virginia,54,037,Outlying
-"Waterloo-Cedar Falls, IA",47940,,,,,Black Hawk County,Iowa,19,013,Central
-"Waterloo-Cedar Falls, IA",47940,,,,,Bremer County,Iowa,19,017,Outlying
-"Waterloo-Cedar Falls, IA",47940,,,,,Grundy County,Iowa,19,075,Outlying
-"Watertown-Fort Drum, NY",48060,,,,,Jefferson County,New York,36,045,Central
-"Wausau-Weston, WI",48140,,554,,"Wausau-Stevens Point-Wisconsin Rapids, WI",Lincoln County,Wisconsin,55,069,Outlying
-"Wausau-Weston, WI",48140,,554,,"Wausau-Stevens Point-Wisconsin Rapids, WI",Marathon County,Wisconsin,55,073,Central
-"Weirton-Steubenville, WV-OH",48260,,430,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Jefferson County,Ohio,39,081,Central
-"Weirton-Steubenville, WV-OH",48260,,430,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Brooke County,West Virginia,54,009,Central
-"Weirton-Steubenville, WV-OH",48260,,430,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Hancock County,West Virginia,54,029,Central
-"Wenatchee, WA",48300,,,,,Chelan County,Washington,53,007,Central
-"Wenatchee, WA",48300,,,,,Douglas County,Washington,53,017,Central
-"Wheeling, WV-OH",48540,,,,,Belmont County,Ohio,39,013,Central
-"Wheeling, WV-OH",48540,,,,,Marshall County,West Virginia,54,051,Central
-"Wheeling, WV-OH",48540,,,,,Ohio County,West Virginia,54,069,Central
-"Wichita, KS",48620,,556,,"Wichita-Winfield, KS",Butler County,Kansas,20,015,Outlying
-"Wichita, KS",48620,,556,,"Wichita-Winfield, KS",Harvey County,Kansas,20,079,Outlying
-"Wichita, KS",48620,,556,,"Wichita-Winfield, KS",Sedgwick County,Kansas,20,173,Central
-"Wichita, KS",48620,,556,,"Wichita-Winfield, KS",Sumner County,Kansas,20,191,Outlying
-"Wichita Falls, TX",48660,,,,,Archer County,Texas,48,009,Outlying
-"Wichita Falls, TX",48660,,,,,Clay County,Texas,48,077,Outlying
-"Wichita Falls, TX",48660,,,,,Wichita County,Texas,48,485,Central
-"Williamsport, PA",48700,,558,,"Williamsport-Lock Haven, PA",Lycoming County,Pennsylvania,42,081,Central
-"Wilmington, NC",48900,,,,,New Hanover County,North Carolina,37,129,Central
-"Wilmington, NC",48900,,,,,Pender County,North Carolina,37,141,Outlying
-"Winchester, VA-WV",49020,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Frederick County,Virginia,51,069,Central
-"Winchester, VA-WV",49020,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Winchester city,Virginia,51,840,Central
-"Winchester, VA-WV",49020,,548,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Hampshire County,West Virginia,54,027,Outlying
-"Winston-Salem, NC",49180,,268,,"Greensboro--Winston-Salem--High Point, NC",Davidson County,North Carolina,37,057,Central
-"Winston-Salem, NC",49180,,268,,"Greensboro--Winston-Salem--High Point, NC",Davie County,North Carolina,37,059,Central
-"Winston-Salem, NC",49180,,268,,"Greensboro--Winston-Salem--High Point, NC",Forsyth County,North Carolina,37,067,Central
-"Winston-Salem, NC",49180,,268,,"Greensboro--Winston-Salem--High Point, NC",Stokes County,North Carolina,37,169,Central
-"Winston-Salem, NC",49180,,268,,"Greensboro--Winston-Salem--High Point, NC",Yadkin County,North Carolina,37,197,Outlying
-"Worcester, MA-CT",49340,,148,,"Boston-Worcester-Providence, MA-RI-NH-CT",Windham County,Connecticut,09,015,Central
-"Worcester, MA-CT",49340,,148,,"Boston-Worcester-Providence, MA-RI-NH-CT",Worcester County,Massachusetts,25,027,Central
-"Yakima, WA",49420,,,,,Yakima County,Washington,53,077,Central
-"Yauco, PR",49500,,434,,"Ponce-Yauco-Coamo, PR",Guánica Municipio,Puerto Rico,72,055,Central
-"Yauco, PR",49500,,434,,"Ponce-Yauco-Coamo, PR",Guayanilla Municipio,Puerto Rico,72,059,Central
-"Yauco, PR",49500,,434,,"Ponce-Yauco-Coamo, PR",Peñuelas Municipio,Puerto Rico,72,111,Central
-"Yauco, PR",49500,,434,,"Ponce-Yauco-Coamo, PR",Yauco Municipio,Puerto Rico,72,153,Central
-"York-Hanover, PA",49620,,276,,"Harrisburg-York-Lebanon, PA",York County,Pennsylvania,42,133,Central
-"Youngstown-Warren-Boardman, OH-PA",49660,,566,,"Youngstown-Warren, OH-PA",Mahoning County,Ohio,39,099,Central
-"Youngstown-Warren-Boardman, OH-PA",49660,,566,,"Youngstown-Warren, OH-PA",Trumbull County,Ohio,39,155,Central
-"Youngstown-Warren-Boardman, OH-PA",49660,,566,,"Youngstown-Warren, OH-PA",Mercer County,Pennsylvania,42,085,Central
-"Yuba City, CA",49700,,472,,"Sacramento-Roseville, CA",Sutter County,California,06,101,Central
-"Yuba City, CA",49700,,472,,"Sacramento-Roseville, CA",Yuba County,California,06,115,Central
-"Yuma, AZ",49740,,,,,Yuma County,Arizona,04,027,Central
-,,,,,,,,,,
-,,,,,,,,,,
-,,,,,,,,,,
+CBSA Title,CBSA Code,Metropolitan Division Code,CSA Code,Metropolitan/Micropolitan Statistical Area,Metropolitan Division Title,CSA Title,County/County Equivalent,State Name,FIPS State Code,FIPS County Code,Central/Outlying County,,
+"Aberdeen, SD",10100,,,Micropolitan Statistical Area,,,Brown County,South Dakota,46,013,Central,,
+"Aberdeen, SD",10100,,,Micropolitan Statistical Area,,,Edmunds County,South Dakota,46,045,Outlying,,
+"Aberdeen, WA",10140,,,Micropolitan Statistical Area,,,Grays Harbor County,Washington,53,027,Central,,
+"Abilene, TX",10180,,,Metropolitan Statistical Area,,,Callahan County,Texas,48,059,Outlying,,
+"Abilene, TX",10180,,,Metropolitan Statistical Area,,,Jones County,Texas,48,253,Outlying,,
+"Abilene, TX",10180,,,Metropolitan Statistical Area,,,Taylor County,Texas,48,441,Central,,
+"Ada, OK",10220,,,Micropolitan Statistical Area,,,Pontotoc County,Oklahoma,40,123,Central,,
+"Adrian, MI",10300,,220,Micropolitan Statistical Area,,"Detroit-Warren-Ann Arbor, MI",Lenawee County,Michigan,26,091,Central,,
+"Aguadilla-Isabela, PR",10380,,,Metropolitan Statistical Area,,,Aguada Municipio,Puerto Rico,72,003,Central,,
+"Aguadilla-Isabela, PR",10380,,,Metropolitan Statistical Area,,,Aguadilla Municipio,Puerto Rico,72,005,Central,,
+"Aguadilla-Isabela, PR",10380,,,Metropolitan Statistical Area,,,A�asco Municipio,Puerto Rico,72,011,Central,,
+"Aguadilla-Isabela, PR",10380,,,Metropolitan Statistical Area,,,Isabela Municipio,Puerto Rico,72,071,Central,,
+"Aguadilla-Isabela, PR",10380,,,Metropolitan Statistical Area,,,Lares Municipio,Puerto Rico,72,081,Central,,
+"Aguadilla-Isabela, PR",10380,,,Metropolitan Statistical Area,,,Moca Municipio,Puerto Rico,72,099,Central,,
+"Aguadilla-Isabela, PR",10380,,,Metropolitan Statistical Area,,,Rinc�n Municipio,Puerto Rico,72,117,Central,,
+"Aguadilla-Isabela, PR",10380,,,Metropolitan Statistical Area,,,San Sebasti�n Municipio,Puerto Rico,72,131,Central,,
+"Aguadilla-Isabela, PR",10380,,,Metropolitan Statistical Area,,,Utuado Municipio,Puerto Rico,72,141,Central,,
+"Akron, OH",10420,,184,Metropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Portage County,Ohio,39,133,Central,,
+"Akron, OH",10420,,184,Metropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Summit County,Ohio,39,153,Central,,
+"Alamogordo, NM",10460,,,Micropolitan Statistical Area,,,Otero County,New Mexico,35,035,Central,,
+"Albany, GA",10500,,,Metropolitan Statistical Area,,,Dougherty County,Georgia,13,095,Central,,
+"Albany, GA",10500,,,Metropolitan Statistical Area,,,Lee County,Georgia,13,177,Central,,
+"Albany, GA",10500,,,Metropolitan Statistical Area,,,Terrell County,Georgia,13,273,Outlying,,
+"Albany, GA",10500,,,Metropolitan Statistical Area,,,Worth County,Georgia,13,321,Outlying,,
+"Albany-Lebanon, OR",10540,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Linn County,Oregon,41,043,Central,,
+"Albany-Schenectady-Troy, NY",10580,,104,Metropolitan Statistical Area,,"Albany-Schenectady, NY",Albany County,New York,36,001,Central,,
+"Albany-Schenectady-Troy, NY",10580,,104,Metropolitan Statistical Area,,"Albany-Schenectady, NY",Rensselaer County,New York,36,083,Central,,
+"Albany-Schenectady-Troy, NY",10580,,104,Metropolitan Statistical Area,,"Albany-Schenectady, NY",Saratoga County,New York,36,091,Central,,
+"Albany-Schenectady-Troy, NY",10580,,104,Metropolitan Statistical Area,,"Albany-Schenectady, NY",Schenectady County,New York,36,093,Central,,
+"Albany-Schenectady-Troy, NY",10580,,104,Metropolitan Statistical Area,,"Albany-Schenectady, NY",Schoharie County,New York,36,095,Outlying,,
+"Albemarle, NC",10620,,172,Micropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Stanly County,North Carolina,37,167,Central,,
+"Albert Lea, MN",10660,,,Micropolitan Statistical Area,,,Freeborn County,Minnesota,27,047,Central,,
+"Albertville, AL",10700,,,Micropolitan Statistical Area,,,Marshall County,Alabama,01,095,Central,,
+"Albuquerque, NM",10740,,106,Metropolitan Statistical Area,,"Albuquerque-Santa Fe-Las Vegas, NM",Bernalillo County,New Mexico,35,001,Central,,
+"Albuquerque, NM",10740,,106,Metropolitan Statistical Area,,"Albuquerque-Santa Fe-Las Vegas, NM",Sandoval County,New Mexico,35,043,Central,,
+"Albuquerque, NM",10740,,106,Metropolitan Statistical Area,,"Albuquerque-Santa Fe-Las Vegas, NM",Torrance County,New Mexico,35,057,Outlying,,
+"Albuquerque, NM",10740,,106,Metropolitan Statistical Area,,"Albuquerque-Santa Fe-Las Vegas, NM",Valencia County,New Mexico,35,061,Outlying,,
+"Alexander City, AL",10760,,388,Micropolitan Statistical Area,,"Montgomery-Selma-Alexander City, AL",Coosa County,Alabama,01,037,Outlying,,
+"Alexander City, AL",10760,,388,Micropolitan Statistical Area,,"Montgomery-Selma-Alexander City, AL",Tallapoosa County,Alabama,01,123,Central,,
+"Alexandria, LA",10780,,,Metropolitan Statistical Area,,,Grant Parish,Louisiana,22,043,Outlying,,
+"Alexandria, LA",10780,,,Metropolitan Statistical Area,,,Rapides Parish,Louisiana,22,079,Central,,
+"Alexandria, MN",10820,,,Micropolitan Statistical Area,,,Douglas County,Minnesota,27,041,Central,,
+"Alice, TX",10860,,204,Micropolitan Statistical Area,,"Corpus Christi-Kingsville-Alice, TX",Duval County,Texas,48,131,Outlying,,
+"Alice, TX",10860,,204,Micropolitan Statistical Area,,"Corpus Christi-Kingsville-Alice, TX",Jim Wells County,Texas,48,249,Central,,
+"Allentown-Bethlehem-Easton, PA-NJ",10900,,,Metropolitan Statistical Area,,,Warren County,New Jersey,34,041,Central,,
+"Allentown-Bethlehem-Easton, PA-NJ",10900,,,Metropolitan Statistical Area,,,Carbon County,Pennsylvania,42,025,Central,,
+"Allentown-Bethlehem-Easton, PA-NJ",10900,,,Metropolitan Statistical Area,,,Lehigh County,Pennsylvania,42,077,Central,,
+"Allentown-Bethlehem-Easton, PA-NJ",10900,,,Metropolitan Statistical Area,,,Northampton County,Pennsylvania,42,095,Central,,
+"Alma, MI",10940,,394,Micropolitan Statistical Area,,"Mount Pleasant-Alma, MI",Gratiot County,Michigan,26,057,Central,,
+"Alpena, MI",10980,,,Micropolitan Statistical Area,,,Alpena County,Michigan,26,007,Central,,
+"Altoona, PA",11020,,107,Metropolitan Statistical Area,,"Altoona-Huntingdon, PA",Blair County,Pennsylvania,42,013,Central,,
+"Altus, OK",11060,,,Micropolitan Statistical Area,,,Jackson County,Oklahoma,40,065,Central,,
+"Amarillo, TX",11100,,108,Metropolitan Statistical Area,,"Amarillo-Pampa-Borger, TX",Armstrong County,Texas,48,011,Outlying,,
+"Amarillo, TX",11100,,108,Metropolitan Statistical Area,,"Amarillo-Pampa-Borger, TX",Carson County,Texas,48,065,Outlying,,
+"Amarillo, TX",11100,,108,Metropolitan Statistical Area,,"Amarillo-Pampa-Borger, TX",Oldham County,Texas,48,359,Outlying,,
+"Amarillo, TX",11100,,108,Metropolitan Statistical Area,,"Amarillo-Pampa-Borger, TX",Potter County,Texas,48,375,Central,,
+"Amarillo, TX",11100,,108,Metropolitan Statistical Area,,"Amarillo-Pampa-Borger, TX",Randall County,Texas,48,381,Central,,
+"Americus, GA",11140,,,Micropolitan Statistical Area,,,Schley County,Georgia,13,249,Outlying,,
+"Americus, GA",11140,,,Micropolitan Statistical Area,,,Sumter County,Georgia,13,261,Central,,
+"Ames, IA",11180,,218,Metropolitan Statistical Area,,"Des Moines-Ames-West Des Moines, IA",Boone County,Iowa,19,015,Outlying,,
+"Ames, IA",11180,,218,Metropolitan Statistical Area,,"Des Moines-Ames-West Des Moines, IA",Story County,Iowa,19,169,Central,,
+"Amsterdam, NY",11220,,104,Micropolitan Statistical Area,,"Albany-Schenectady, NY",Montgomery County,New York,36,057,Central,,
+"Anchorage, AK",11260,,,Metropolitan Statistical Area,,,Anchorage Municipality,Alaska,02,020,Central,,
+"Anchorage, AK",11260,,,Metropolitan Statistical Area,,,Matanuska-Susitna Borough,Alaska,02,170,Outlying,,
+"Andrews, TX",11380,,,Micropolitan Statistical Area,,,Andrews County,Texas,48,003,Central,,
+"Angola, IN",11420,,258,Micropolitan Statistical Area,,"Fort Wayne-Huntington-Auburn, IN",Steuben County,Indiana,18,151,Central,,
+"Ann Arbor, MI",11460,,220,Metropolitan Statistical Area,,"Detroit-Warren-Ann Arbor, MI",Washtenaw County,Michigan,26,161,Central,,
+"Anniston-Oxford, AL",11500,,,Metropolitan Statistical Area,,,Calhoun County,Alabama,01,015,Central,,
+"Appleton, WI",11540,,118,Metropolitan Statistical Area,,"Appleton-Oshkosh-Neenah, WI",Calumet County,Wisconsin,55,015,Central,,
+"Appleton, WI",11540,,118,Metropolitan Statistical Area,,"Appleton-Oshkosh-Neenah, WI",Outagamie County,Wisconsin,55,087,Central,,
+"Arcadia, FL",11580,,412,Micropolitan Statistical Area,,"North Port-Sarasota, FL",DeSoto County,Florida,12,027,Central,,
+"Ardmore, OK",11620,,,Micropolitan Statistical Area,,,Carter County,Oklahoma,40,019,Central,,
+"Ardmore, OK",11620,,,Micropolitan Statistical Area,,,Love County,Oklahoma,40,085,Outlying,,
+"Arecibo, PR",11640,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Arecibo Municipio,Puerto Rico,72,013,Central,,
+"Arecibo, PR",11640,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Camuy Municipio,Puerto Rico,72,027,Central,,
+"Arecibo, PR",11640,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Hatillo Municipio,Puerto Rico,72,065,Central,,
+"Arecibo, PR",11640,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Quebradillas Municipio,Puerto Rico,72,115,Central,,
+"Arkadelphia, AR",11660,,,Micropolitan Statistical Area,,,Clark County,Arkansas,05,019,Central,,
+"Asheville, NC",11700,,120,Metropolitan Statistical Area,,"Asheville-Marion-Brevard, NC",Buncombe County,North Carolina,37,021,Central,,
+"Asheville, NC",11700,,120,Metropolitan Statistical Area,,"Asheville-Marion-Brevard, NC",Haywood County,North Carolina,37,087,Central,,
+"Asheville, NC",11700,,120,Metropolitan Statistical Area,,"Asheville-Marion-Brevard, NC",Henderson County,North Carolina,37,089,Central,,
+"Asheville, NC",11700,,120,Metropolitan Statistical Area,,"Asheville-Marion-Brevard, NC",Madison County,North Carolina,37,115,Outlying,,
+"Ashland, OH",11740,,360,Micropolitan Statistical Area,,"Mansfield-Ashland-Bucyrus, OH",Ashland County,Ohio,39,005,Central,,
+"Ashtabula, OH",11780,,184,Micropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Ashtabula County,Ohio,39,007,Central,,
+"Astoria, OR",11820,,,Micropolitan Statistical Area,,,Clatsop County,Oregon,41,007,Central,,
+"Atchison, KS",11860,,312,Micropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Atchison County,Kansas,20,005,Central,,
+"Athens, OH",11900,,,Micropolitan Statistical Area,,,Athens County,Ohio,39,009,Central,,
+"Athens, TN",11940,,174,Micropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",McMinn County,Tennessee,47,107,Central,,
+"Athens, TX",11980,,206,Micropolitan Statistical Area,,"Dallas-Fort Worth, TX-OK",Henderson County,Texas,48,213,Central,,
+"Athens-Clarke County, GA",12020,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Clarke County,Georgia,13,059,Central,,
+"Athens-Clarke County, GA",12020,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Madison County,Georgia,13,195,Outlying,,
+"Athens-Clarke County, GA",12020,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Oconee County,Georgia,13,219,Central,,
+"Athens-Clarke County, GA",12020,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Oglethorpe County,Georgia,13,221,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Barrow County,Georgia,13,013,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Bartow County,Georgia,13,015,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Butts County,Georgia,13,035,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Carroll County,Georgia,13,045,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Cherokee County,Georgia,13,057,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Clayton County,Georgia,13,063,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Cobb County,Georgia,13,067,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Coweta County,Georgia,13,077,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Dawson County,Georgia,13,085,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",DeKalb County,Georgia,13,089,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Douglas County,Georgia,13,097,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Fayette County,Georgia,13,113,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Forsyth County,Georgia,13,117,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Fulton County,Georgia,13,121,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Gwinnett County,Georgia,13,135,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Haralson County,Georgia,13,143,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Heard County,Georgia,13,149,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Henry County,Georgia,13,151,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Jasper County,Georgia,13,159,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Lamar County,Georgia,13,171,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Meriwether County,Georgia,13,199,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Morgan County,Georgia,13,211,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Newton County,Georgia,13,217,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Paulding County,Georgia,13,223,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Pickens County,Georgia,13,227,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Pike County,Georgia,13,231,Outlying,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Rockdale County,Georgia,13,247,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Spalding County,Georgia,13,255,Central,,
+"Atlanta-Sandy Springs-Alpharetta, GA",12060,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Walton County,Georgia,13,297,Central,,
+"Atlantic City-Hammonton, NJ",12100,,428,Metropolitan Statistical Area,,"Philadelphia-Reading-Camden, PA-NJ-DE-MD",Atlantic County,New Jersey,34,001,Central,,
+"Atmore, AL",12120,,426,Micropolitan Statistical Area,,"Pensacola-Ferry Pass, FL-AL",Escambia County,Alabama,01,053,Central,,
+"Auburn, IN",12140,,258,Micropolitan Statistical Area,,"Fort Wayne-Huntington-Auburn, IN",DeKalb County,Indiana,18,033,Central,,
+"Auburn, NY",12180,,532,Micropolitan Statistical Area,,"Syracuse-Auburn, NY",Cayuga County,New York,36,011,Central,,
+"Auburn-Opelika, AL",12220,,194,Metropolitan Statistical Area,,"Columbus-Auburn-Opelika, GA-AL",Lee County,Alabama,01,081,Central,,
+"Augusta-Richmond County, GA-SC",12260,,,Metropolitan Statistical Area,,,Burke County,Georgia,13,033,Outlying,,
+"Augusta-Richmond County, GA-SC",12260,,,Metropolitan Statistical Area,,,Columbia County,Georgia,13,073,Central,,
+"Augusta-Richmond County, GA-SC",12260,,,Metropolitan Statistical Area,,,Lincoln County,Georgia,13,181,Outlying,,
+"Augusta-Richmond County, GA-SC",12260,,,Metropolitan Statistical Area,,,McDuffie County,Georgia,13,189,Outlying,,
+"Augusta-Richmond County, GA-SC",12260,,,Metropolitan Statistical Area,,,Richmond County,Georgia,13,245,Central,,
+"Augusta-Richmond County, GA-SC",12260,,,Metropolitan Statistical Area,,,Aiken County,South Carolina,45,003,Central,,
+"Augusta-Richmond County, GA-SC",12260,,,Metropolitan Statistical Area,,,Edgefield County,South Carolina,45,037,Outlying,,
+"Augusta-Waterville, ME",12300,,,Micropolitan Statistical Area,,,Kennebec County,Maine,23,011,Central,,
+"Austin, MN",12380,,462,Micropolitan Statistical Area,,"Rochester-Austin, MN",Mower County,Minnesota,27,099,Central,,
+"Austin-Round Rock-Georgetown, TX",12420,,,Metropolitan Statistical Area,,,Bastrop County,Texas,48,021,Outlying,,
+"Austin-Round Rock-Georgetown, TX",12420,,,Metropolitan Statistical Area,,,Caldwell County,Texas,48,055,Outlying,,
+"Austin-Round Rock-Georgetown, TX",12420,,,Metropolitan Statistical Area,,,Hays County,Texas,48,209,Central,,
+"Austin-Round Rock-Georgetown, TX",12420,,,Metropolitan Statistical Area,,,Travis County,Texas,48,453,Central,,
+"Austin-Round Rock-Georgetown, TX",12420,,,Metropolitan Statistical Area,,,Williamson County,Texas,48,491,Central,,
+"Bainbridge, GA",12460,,,Micropolitan Statistical Area,,,Decatur County,Georgia,13,087,Central,,
+"Bakersfield, CA",12540,,,Metropolitan Statistical Area,,,Kern County,California,06,029,Central,,
+"Baltimore-Columbia-Towson, MD",12580,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Anne Arundel County,Maryland,24,003,Central,,
+"Baltimore-Columbia-Towson, MD",12580,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Baltimore County,Maryland,24,005,Central,,
+"Baltimore-Columbia-Towson, MD",12580,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Carroll County,Maryland,24,013,Outlying,,
+"Baltimore-Columbia-Towson, MD",12580,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Harford County,Maryland,24,025,Outlying,,
+"Baltimore-Columbia-Towson, MD",12580,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Howard County,Maryland,24,027,Central,,
+"Baltimore-Columbia-Towson, MD",12580,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Queen Anne's County,Maryland,24,035,Central,,
+"Baltimore-Columbia-Towson, MD",12580,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Baltimore city,Maryland,24,510,Central,,
+"Bangor, ME",12620,,,Metropolitan Statistical Area,,,Penobscot County,Maine,23,019,Central,,
+"Baraboo, WI",12660,,357,Micropolitan Statistical Area,,"Madison-Janesville-Beloit, WI",Sauk County,Wisconsin,55,111,Central,,
+"Bardstown, KY",12680,,350,Micropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Nelson County,Kentucky,21,179,Central,,
+"Barnstable Town, MA",12700,,148,Metropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Barnstable County,Massachusetts,25,001,Central,,
+"Barre, VT",12740,,162,Micropolitan Statistical Area,,"Burlington-South Burlington-Barre, VT",Washington County,Vermont,50,023,Central,,
+"Bartlesville, OK",12780,,538,Micropolitan Statistical Area,,"Tulsa-Muskogee-Bartlesville, OK",Washington County,Oklahoma,40,147,Central,,
+"Batavia, NY",12860,,464,Micropolitan Statistical Area,,"Rochester-Batavia-Seneca Falls, NY",Genesee County,New York,36,037,Central,,
+"Batesville, AR",12900,,,Micropolitan Statistical Area,,,Independence County,Arkansas,05,063,Central,,
+"Batesville, AR",12900,,,Micropolitan Statistical Area,,,Sharp County,Arkansas,05,135,Outlying,,
+"Baton Rouge, LA",12940,,,Metropolitan Statistical Area,,,Ascension Parish,Louisiana,22,005,Central,,
+"Baton Rouge, LA",12940,,,Metropolitan Statistical Area,,,Assumption Parish,Louisiana,22,007,Outlying,,
+"Baton Rouge, LA",12940,,,Metropolitan Statistical Area,,,East Baton Rouge Parish,Louisiana,22,033,Central,,
+"Baton Rouge, LA",12940,,,Metropolitan Statistical Area,,,East Feliciana Parish,Louisiana,22,037,Outlying,,
+"Baton Rouge, LA",12940,,,Metropolitan Statistical Area,,,Iberville Parish,Louisiana,22,047,Central,,
+"Baton Rouge, LA",12940,,,Metropolitan Statistical Area,,,Livingston Parish,Louisiana,22,063,Central,,
+"Baton Rouge, LA",12940,,,Metropolitan Statistical Area,,,Pointe Coupee Parish,Louisiana,22,077,Outlying,,
+"Baton Rouge, LA",12940,,,Metropolitan Statistical Area,,,St. Helena Parish,Louisiana,22,091,Outlying,,
+"Baton Rouge, LA",12940,,,Metropolitan Statistical Area,,,West Baton Rouge Parish,Louisiana,22,121,Central,,
+"Baton Rouge, LA",12940,,,Metropolitan Statistical Area,,,West Feliciana Parish,Louisiana,22,125,Outlying,,
+"Battle Creek, MI",12980,,310,Metropolitan Statistical Area,,"Kalamazoo-Battle Creek-Portage, MI",Calhoun County,Michigan,26,025,Central,,
+"Bay City, MI",13020,,474,Metropolitan Statistical Area,,"Saginaw-Midland-Bay City, MI",Bay County,Michigan,26,017,Central,,
+"Bay City, TX",13060,,288,Micropolitan Statistical Area,,"Houston-The Woodlands, TX",Matagorda County,Texas,48,321,Central,,
+"Beatrice, NE",13100,,339,Micropolitan Statistical Area,,"Lincoln-Beatrice, NE",Gage County,Nebraska,31,067,Central,,
+"Beaumont-Port Arthur, TX",13140,,,Metropolitan Statistical Area,,,Hardin County,Texas,48,199,Outlying,,
+"Beaumont-Port Arthur, TX",13140,,,Metropolitan Statistical Area,,,Jefferson County,Texas,48,245,Central,,
+"Beaumont-Port Arthur, TX",13140,,,Metropolitan Statistical Area,,,Orange County,Texas,48,361,Central,,
+"Beaver Dam, WI",13180,,376,Micropolitan Statistical Area,,"Milwaukee-Racine-Waukesha, WI",Dodge County,Wisconsin,55,027,Central,,
+"Beckley, WV",13220,,,Metropolitan Statistical Area,,,Fayette County,West Virginia,54,019,Central,,
+"Beckley, WV",13220,,,Metropolitan Statistical Area,,,Raleigh County,West Virginia,54,081,Central,,
+"Bedford, IN",13260,,144,Micropolitan Statistical Area,,"Bloomington-Bedford, IN",Lawrence County,Indiana,18,093,Central,,
+"Beeville, TX",13300,,,Micropolitan Statistical Area,,,Bee County,Texas,48,025,Central,,
+"Bellefontaine, OH",13340,,198,Micropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Logan County,Ohio,39,091,Central,,
+"Bellingham, WA",13380,,,Metropolitan Statistical Area,,,Whatcom County,Washington,53,073,Central,,
+"Bemidji, MN",13420,,,Micropolitan Statistical Area,,,Beltrami County,Minnesota,27,007,Central,,
+"Bend, OR",13460,,140,Metropolitan Statistical Area,,"Bend-Prineville, OR",Deschutes County,Oregon,41,017,Central,,
+"Bennettsville, SC",13500,,,Micropolitan Statistical Area,,,Marlboro County,South Carolina,45,069,Central,,
+"Bennington, VT",13540,,,Micropolitan Statistical Area,,,Bennington County,Vermont,50,003,Central,,
+"Berlin, NH",13620,,,Micropolitan Statistical Area,,,Coos County,New Hampshire,33,007,Central,,
+"Big Rapids, MI",13660,,266,Micropolitan Statistical Area,,"Grand Rapids-Kentwood-Muskegon, MI",Mecosta County,Michigan,26,107,Central,,
+"Big Spring, TX",13700,,,Micropolitan Statistical Area,,,Howard County,Texas,48,227,Central,,
+"Big Stone Gap, VA",13720,,,Micropolitan Statistical Area,,,Wise County,Virginia,51,195,Central,,
+"Big Stone Gap, VA",13720,,,Micropolitan Statistical Area,,,Norton city,Virginia,51,720,Central,,
+"Billings, MT",13740,,,Metropolitan Statistical Area,,,Carbon County,Montana,30,009,Outlying,,
+"Billings, MT",13740,,,Metropolitan Statistical Area,,,Stillwater County,Montana,30,095,Outlying,,
+"Billings, MT",13740,,,Metropolitan Statistical Area,,,Yellowstone County,Montana,30,111,Central,,
+"Binghamton, NY",13780,,,Metropolitan Statistical Area,,,Broome County,New York,36,007,Central,,
+"Binghamton, NY",13780,,,Metropolitan Statistical Area,,,Tioga County,New York,36,107,Central,,
+"Birmingham-Hoover, AL",13820,,142,Metropolitan Statistical Area,,"Birmingham-Hoover-Talladega, AL",Bibb County,Alabama,01,007,Outlying,,
+"Birmingham-Hoover, AL",13820,,142,Metropolitan Statistical Area,,"Birmingham-Hoover-Talladega, AL",Blount County,Alabama,01,009,Outlying,,
+"Birmingham-Hoover, AL",13820,,142,Metropolitan Statistical Area,,"Birmingham-Hoover-Talladega, AL",Chilton County,Alabama,01,021,Outlying,,
+"Birmingham-Hoover, AL",13820,,142,Metropolitan Statistical Area,,"Birmingham-Hoover-Talladega, AL",Jefferson County,Alabama,01,073,Central,,
+"Birmingham-Hoover, AL",13820,,142,Metropolitan Statistical Area,,"Birmingham-Hoover-Talladega, AL",St. Clair County,Alabama,01,115,Outlying,,
+"Birmingham-Hoover, AL",13820,,142,Metropolitan Statistical Area,,"Birmingham-Hoover-Talladega, AL",Shelby County,Alabama,01,117,Central,,
+"Bismarck, ND",13900,,,Metropolitan Statistical Area,,,Burleigh County,North Dakota,38,015,Central,,
+"Bismarck, ND",13900,,,Metropolitan Statistical Area,,,Morton County,North Dakota,38,059,Central,,
+"Bismarck, ND",13900,,,Metropolitan Statistical Area,,,Oliver County,North Dakota,38,065,Outlying,,
+"Blackfoot, ID",13940,,292,Micropolitan Statistical Area,,"Idaho Falls-Rexburg-Blackfoot, ID",Bingham County,Idaho,16,011,Central,,
+"Blacksburg-Christiansburg, VA",13980,,,Metropolitan Statistical Area,,,Giles County,Virginia,51,071,Outlying,,
+"Blacksburg-Christiansburg, VA",13980,,,Metropolitan Statistical Area,,,Montgomery County,Virginia,51,121,Central,,
+"Blacksburg-Christiansburg, VA",13980,,,Metropolitan Statistical Area,,,Pulaski County,Virginia,51,155,Outlying,,
+"Blacksburg-Christiansburg, VA",13980,,,Metropolitan Statistical Area,,,Radford city,Virginia,51,750,Central,,
+"Bloomington, IL",14010,,145,Metropolitan Statistical Area,,"Bloomington-Pontiac, IL",McLean County,Illinois,17,113,Central,,
+"Bloomington, IN",14020,,144,Metropolitan Statistical Area,,"Bloomington-Bedford, IN",Monroe County,Indiana,18,105,Central,,
+"Bloomington, IN",14020,,144,Metropolitan Statistical Area,,"Bloomington-Bedford, IN",Owen County,Indiana,18,119,Outlying,,
+"Bloomsburg-Berwick, PA",14100,,146,Metropolitan Statistical Area,,"Bloomsburg-Berwick-Sunbury, PA",Columbia County,Pennsylvania,42,037,Central,,
+"Bloomsburg-Berwick, PA",14100,,146,Metropolitan Statistical Area,,"Bloomsburg-Berwick-Sunbury, PA",Montour County,Pennsylvania,42,093,Central,,
+"Bluefield, WV-VA",14140,,,Micropolitan Statistical Area,,,Bland County,Virginia,51,021,Outlying,,
+"Bluefield, WV-VA",14140,,,Micropolitan Statistical Area,,,Tazewell County,Virginia,51,185,Central,,
+"Bluefield, WV-VA",14140,,,Micropolitan Statistical Area,,,Mercer County,West Virginia,54,055,Central,,
+"Blytheville, AR",14180,,,Micropolitan Statistical Area,,,Mississippi County,Arkansas,05,093,Central,,
+"Bogalusa, LA",14220,,406,Micropolitan Statistical Area,,"New Orleans-Metairie-Hammond, LA-MS",Washington Parish,Louisiana,22,117,Central,,
+"Boise City, ID",14260,,147,Metropolitan Statistical Area,,"Boise City-Mountain Home-Ontario, ID-OR",Ada County,Idaho,16,001,Central,,
+"Boise City, ID",14260,,147,Metropolitan Statistical Area,,"Boise City-Mountain Home-Ontario, ID-OR",Boise County,Idaho,16,015,Outlying,,
+"Boise City, ID",14260,,147,Metropolitan Statistical Area,,"Boise City-Mountain Home-Ontario, ID-OR",Canyon County,Idaho,16,027,Outlying,,
+"Boise City, ID",14260,,147,Metropolitan Statistical Area,,"Boise City-Mountain Home-Ontario, ID-OR",Gem County,Idaho,16,045,Outlying,,
+"Boise City, ID",14260,,147,Metropolitan Statistical Area,,"Boise City-Mountain Home-Ontario, ID-OR",Owyhee County,Idaho,16,073,Outlying,,
+"Bonham, TX",14300,,206,Micropolitan Statistical Area,,"Dallas-Fort Worth, TX-OK",Fannin County,Texas,48,147,Central,,
+"Boone, NC",14380,,,Micropolitan Statistical Area,,,Watauga County,North Carolina,37,189,Central,,
+"Borger, TX",14420,,108,Micropolitan Statistical Area,,"Amarillo-Pampa-Borger, TX",Hutchinson County,Texas,48,233,Central,,
+"Boston-Cambridge-Newton, MA-NH",14460,14454,148,Metropolitan Statistical Area,"Boston, MA","Boston-Worcester-Providence, MA-RI-NH-CT",Norfolk County,Massachusetts,25,021,Central,,
+"Boston-Cambridge-Newton, MA-NH",14460,14454,148,Metropolitan Statistical Area,"Boston, MA","Boston-Worcester-Providence, MA-RI-NH-CT",Plymouth County,Massachusetts,25,023,Central,,
+"Boston-Cambridge-Newton, MA-NH",14460,14454,148,Metropolitan Statistical Area,"Boston, MA","Boston-Worcester-Providence, MA-RI-NH-CT",Suffolk County,Massachusetts,25,025,Central,,
+"Boston-Cambridge-Newton, MA-NH",14460,15764,148,Metropolitan Statistical Area,"Cambridge-Newton-Framingham, MA","Boston-Worcester-Providence, MA-RI-NH-CT",Essex County,Massachusetts,25,009,Central,,
+"Boston-Cambridge-Newton, MA-NH",14460,15764,148,Metropolitan Statistical Area,"Cambridge-Newton-Framingham, MA","Boston-Worcester-Providence, MA-RI-NH-CT",Middlesex County,Massachusetts,25,017,Central,,
+"Boston-Cambridge-Newton, MA-NH",14460,40484,148,Metropolitan Statistical Area,"Rockingham County-Strafford County, NH","Boston-Worcester-Providence, MA-RI-NH-CT",Rockingham County,New Hampshire,33,015,Central,,
+"Boston-Cambridge-Newton, MA-NH",14460,40484,148,Metropolitan Statistical Area,"Rockingham County-Strafford County, NH","Boston-Worcester-Providence, MA-RI-NH-CT",Strafford County,New Hampshire,33,017,Outlying,,
+"Boulder, CO",14500,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Boulder County,Colorado,08,013,Central,,
+"Bowling Green, KY",14540,,150,Metropolitan Statistical Area,,"Bowling Green-Glasgow, KY",Allen County,Kentucky,21,003,Outlying,,
+"Bowling Green, KY",14540,,150,Metropolitan Statistical Area,,"Bowling Green-Glasgow, KY",Butler County,Kentucky,21,031,Outlying,,
+"Bowling Green, KY",14540,,150,Metropolitan Statistical Area,,"Bowling Green-Glasgow, KY",Edmonson County,Kentucky,21,061,Outlying,,
+"Bowling Green, KY",14540,,150,Metropolitan Statistical Area,,"Bowling Green-Glasgow, KY",Warren County,Kentucky,21,227,Central,,
+"Bozeman, MT",14580,,,Micropolitan Statistical Area,,,Gallatin County,Montana,30,031,Central,,
+"Bradford, PA",14620,,,Micropolitan Statistical Area,,,McKean County,Pennsylvania,42,083,Central,,
+"Brainerd, MN",14660,,,Micropolitan Statistical Area,,,Cass County,Minnesota,27,021,Outlying,,
+"Brainerd, MN",14660,,,Micropolitan Statistical Area,,,Crow Wing County,Minnesota,27,035,Central,,
+"Branson, MO",14700,,,Micropolitan Statistical Area,,,Taney County,Missouri,29,213,Central,,
+"Breckenridge, CO",14720,,,Micropolitan Statistical Area,,,Summit County,Colorado,08,117,Central,,
+"Bremerton-Silverdale-Port Orchard, WA",14740,,500,Metropolitan Statistical Area,,"Seattle-Tacoma, WA",Kitsap County,Washington,53,035,Central,,
+"Brenham, TX",14780,,288,Micropolitan Statistical Area,,"Houston-The Woodlands, TX",Washington County,Texas,48,477,Central,,
+"Brevard, NC",14820,,120,Micropolitan Statistical Area,,"Asheville-Marion-Brevard, NC",Transylvania County,North Carolina,37,175,Central,,
+"Bridgeport-Stamford-Norwalk, CT",14860,,408,Metropolitan Statistical Area,,"New York-Newark, NY-NJ-CT-PA",Fairfield County,Connecticut,09,001,Central,,
+"Brookhaven, MS",15020,,298,Micropolitan Statistical Area,,"Jackson-Vicksburg-Brookhaven, MS",Lincoln County,Mississippi,28,085,Central,,
+"Brookings, OR",15060,,,Micropolitan Statistical Area,,,Curry County,Oregon,41,015,Central,,
+"Brookings, SD",15100,,,Micropolitan Statistical Area,,,Brookings County,South Dakota,46,011,Central,,
+"Brownsville, TN",15140,,297,Micropolitan Statistical Area,,"Jackson-Brownsville, TN",Haywood County,Tennessee,47,075,Central,,
+"Brownsville-Harlingen, TX",15180,,154,Metropolitan Statistical Area,,"Brownsville-Harlingen-Raymondville, TX",Cameron County,Texas,48,061,Central,,
+"Brownwood, TX",15220,,,Micropolitan Statistical Area,,,Brown County,Texas,48,049,Central,,
+"Brunswick, GA",15260,,,Metropolitan Statistical Area,,,Brantley County,Georgia,13,025,Outlying,,
+"Brunswick, GA",15260,,,Metropolitan Statistical Area,,,Glynn County,Georgia,13,127,Central,,
+"Brunswick, GA",15260,,,Metropolitan Statistical Area,,,McIntosh County,Georgia,13,191,Outlying,,
+"Bucyrus-Galion, OH",15340,,360,Micropolitan Statistical Area,,"Mansfield-Ashland-Bucyrus, OH",Crawford County,Ohio,39,033,Central,,
+"Buffalo-Cheektowaga, NY",15380,,160,Metropolitan Statistical Area,,"Buffalo-Cheektowaga-Olean, NY",Erie County,New York,36,029,Central,,
+"Buffalo-Cheektowaga, NY",15380,,160,Metropolitan Statistical Area,,"Buffalo-Cheektowaga-Olean, NY",Niagara County,New York,36,063,Central,,
+"Burley, ID",15420,,,Micropolitan Statistical Area,,,Cassia County,Idaho,16,031,Central,,
+"Burley, ID",15420,,,Micropolitan Statistical Area,,,Minidoka County,Idaho,16,067,Outlying,,
+"Burlington, IA-IL",15460,,161,Micropolitan Statistical Area,,"Burlington-Fort Madison-Keokuk, IA-IL-MO",Henderson County,Illinois,17,071,Outlying,,
+"Burlington, IA-IL",15460,,161,Micropolitan Statistical Area,,"Burlington-Fort Madison-Keokuk, IA-IL-MO",Des Moines County,Iowa,19,057,Central,,
+"Burlington, NC",15500,,268,Metropolitan Statistical Area,,"Greensboro--Winston-Salem--High Point, NC",Alamance County,North Carolina,37,001,Central,,
+"Burlington-South Burlington, VT",15540,,162,Metropolitan Statistical Area,,"Burlington-South Burlington-Barre, VT",Chittenden County,Vermont,50,007,Central,,
+"Burlington-South Burlington, VT",15540,,162,Metropolitan Statistical Area,,"Burlington-South Burlington-Barre, VT",Franklin County,Vermont,50,011,Outlying,,
+"Burlington-South Burlington, VT",15540,,162,Metropolitan Statistical Area,,"Burlington-South Burlington-Barre, VT",Grand Isle County,Vermont,50,013,Outlying,,
+"Butte-Silver Bow, MT",15580,,,Micropolitan Statistical Area,,,Silver Bow County,Montana,30,093,Central,,
+"Cadillac, MI",15620,,,Micropolitan Statistical Area,,,Missaukee County,Michigan,26,113,Outlying,,
+"Cadillac, MI",15620,,,Micropolitan Statistical Area,,,Wexford County,Michigan,26,165,Central,,
+"Calhoun, GA",15660,,174,Micropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Gordon County,Georgia,13,129,Central,,
+"California-Lexington Park, MD",15680,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",St. Mary's County,Maryland,24,037,Central,,
+"Cambridge, MD",15700,,480,Micropolitan Statistical Area,,"Salisbury-Cambridge, MD-DE",Dorchester County,Maryland,24,019,Central,,
+"Cambridge, OH",15740,,198,Micropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Guernsey County,Ohio,39,059,Central,,
+"Camden, AR",15780,,,Micropolitan Statistical Area,,,Calhoun County,Arkansas,05,013,Outlying,,
+"Camden, AR",15780,,,Micropolitan Statistical Area,,,Ouachita County,Arkansas,05,103,Central,,
+"Campbellsville, KY",15820,,,Micropolitan Statistical Area,,,Green County,Kentucky,21,087,Outlying,,
+"Campbellsville, KY",15820,,,Micropolitan Statistical Area,,,Taylor County,Kentucky,21,217,Central,,
+"Ca�on City, CO",15860,,444,Micropolitan Statistical Area,,"Pueblo-Ca�on City, CO",Fremont County,Colorado,08,043,Central,,
+"Canton-Massillon, OH",15940,,184,Metropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Carroll County,Ohio,39,019,Outlying,,
+"Canton-Massillon, OH",15940,,184,Metropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Stark County,Ohio,39,151,Central,,
+"Cape Coral-Fort Myers, FL",15980,,163,Metropolitan Statistical Area,,"Cape Coral-Fort Myers-Naples, FL",Lee County,Florida,12,071,Central,,
+"Cape Girardeau, MO-IL",16020,,164,Metropolitan Statistical Area,,"Cape Girardeau-Sikeston, MO-IL",Alexander County,Illinois,17,003,Outlying,,
+"Cape Girardeau, MO-IL",16020,,164,Metropolitan Statistical Area,,"Cape Girardeau-Sikeston, MO-IL",Bollinger County,Missouri,29,017,Outlying,,
+"Cape Girardeau, MO-IL",16020,,164,Metropolitan Statistical Area,,"Cape Girardeau-Sikeston, MO-IL",Cape Girardeau County,Missouri,29,031,Central,,
+"Carbondale-Marion, IL",16060,,,Metropolitan Statistical Area,,,Jackson County,Illinois,17,077,Central,,
+"Carbondale-Marion, IL",16060,,,Metropolitan Statistical Area,,,Johnson County,Illinois,17,087,Outlying,,
+"Carbondale-Marion, IL",16060,,,Metropolitan Statistical Area,,,Williamson County,Illinois,17,199,Central,,
+"Carlsbad-Artesia, NM",16100,,,Micropolitan Statistical Area,,,Eddy County,New Mexico,35,015,Central,,
+"Carroll, IA",16140,,,Micropolitan Statistical Area,,,Carroll County,Iowa,19,027,Central,,
+"Carson City, NV",16180,,456,Metropolitan Statistical Area,,"Reno-Carson City-Fernley, NV",Carson City,Nevada,32,510,Central,,
+"Casper, WY",16220,,,Metropolitan Statistical Area,,,Natrona County,Wyoming,56,025,Central,,
+"Cedar City, UT",16260,,,Micropolitan Statistical Area,,,Iron County,Utah,49,021,Central,,
+"Cedar Rapids, IA",16300,,168,Metropolitan Statistical Area,,"Cedar Rapids-Iowa City, IA",Benton County,Iowa,19,011,Outlying,,
+"Cedar Rapids, IA",16300,,168,Metropolitan Statistical Area,,"Cedar Rapids-Iowa City, IA",Jones County,Iowa,19,105,Outlying,,
+"Cedar Rapids, IA",16300,,168,Metropolitan Statistical Area,,"Cedar Rapids-Iowa City, IA",Linn County,Iowa,19,113,Central,,
+"Cedartown, GA",16340,,122,Micropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Polk County,Georgia,13,233,Central,,
+"Celina, OH",16380,,338,Micropolitan Statistical Area,,"Lima-Van Wert-Celina, OH",Mercer County,Ohio,39,107,Central,,
+"Central City, KY",16420,,,Micropolitan Statistical Area,,,Muhlenberg County,Kentucky,21,177,Central,,
+"Centralia, IL",16460,,476,Micropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Marion County,Illinois,17,121,Central,,
+"Centralia, WA",16500,,500,Micropolitan Statistical Area,,"Seattle-Tacoma, WA",Lewis County,Washington,53,041,Central,,
+"Chambersburg-Waynesboro, PA",16540,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Franklin County,Pennsylvania,42,055,Central,,
+"Champaign-Urbana, IL",16580,,,Metropolitan Statistical Area,,,Champaign County,Illinois,17,019,Central,,
+"Champaign-Urbana, IL",16580,,,Metropolitan Statistical Area,,,Piatt County,Illinois,17,147,Outlying,,
+"Charleston, WV",16620,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Boone County,West Virginia,54,005,Outlying,,
+"Charleston, WV",16620,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Clay County,West Virginia,54,015,Outlying,,
+"Charleston, WV",16620,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Jackson County,West Virginia,54,035,Outlying,,
+"Charleston, WV",16620,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Kanawha County,West Virginia,54,039,Central,,
+"Charleston, WV",16620,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Lincoln County,West Virginia,54,043,Outlying,,
+"Charleston-Mattoon, IL",16660,,,Micropolitan Statistical Area,,,Coles County,Illinois,17,029,Central,,
+"Charleston-Mattoon, IL",16660,,,Micropolitan Statistical Area,,,Cumberland County,Illinois,17,035,Outlying,,
+"Charleston-North Charleston, SC",16700,,,Metropolitan Statistical Area,,,Berkeley County,South Carolina,45,015,Central,,
+"Charleston-North Charleston, SC",16700,,,Metropolitan Statistical Area,,,Charleston County,South Carolina,45,019,Central,,
+"Charleston-North Charleston, SC",16700,,,Metropolitan Statistical Area,,,Dorchester County,South Carolina,45,035,Central,,
+"Charlotte-Concord-Gastonia, NC-SC",16740,,172,Metropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Anson County,North Carolina,37,007,Outlying,,
+"Charlotte-Concord-Gastonia, NC-SC",16740,,172,Metropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Cabarrus County,North Carolina,37,025,Outlying,,
+"Charlotte-Concord-Gastonia, NC-SC",16740,,172,Metropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Gaston County,North Carolina,37,071,Outlying,,
+"Charlotte-Concord-Gastonia, NC-SC",16740,,172,Metropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Iredell County,North Carolina,37,097,Central,,
+"Charlotte-Concord-Gastonia, NC-SC",16740,,172,Metropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Lincoln County,North Carolina,37,109,Outlying,,
+"Charlotte-Concord-Gastonia, NC-SC",16740,,172,Metropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Mecklenburg County,North Carolina,37,119,Central,,
+"Charlotte-Concord-Gastonia, NC-SC",16740,,172,Metropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Rowan County,North Carolina,37,159,Outlying,,
+"Charlotte-Concord-Gastonia, NC-SC",16740,,172,Metropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Union County,North Carolina,37,179,Central,,
+"Charlotte-Concord-Gastonia, NC-SC",16740,,172,Metropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Chester County,South Carolina,45,023,Outlying,,
+"Charlotte-Concord-Gastonia, NC-SC",16740,,172,Metropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Lancaster County,South Carolina,45,057,Outlying,,
+"Charlotte-Concord-Gastonia, NC-SC",16740,,172,Metropolitan Statistical Area,,"Charlotte-Concord, NC-SC",York County,South Carolina,45,091,Outlying,,
+"Charlottesville, VA",16820,,,Metropolitan Statistical Area,,,Albemarle County,Virginia,51,003,Central,,
+"Charlottesville, VA",16820,,,Metropolitan Statistical Area,,,Fluvanna County,Virginia,51,065,Outlying,,
+"Charlottesville, VA",16820,,,Metropolitan Statistical Area,,,Greene County,Virginia,51,079,Outlying,,
+"Charlottesville, VA",16820,,,Metropolitan Statistical Area,,,Nelson County,Virginia,51,125,Outlying,,
+"Charlottesville, VA",16820,,,Metropolitan Statistical Area,,,Charlottesville city,Virginia,51,540,Central,,
+"Chattanooga, TN-GA",16860,,174,Metropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Catoosa County,Georgia,13,047,Central,,
+"Chattanooga, TN-GA",16860,,174,Metropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Dade County,Georgia,13,083,Outlying,,
+"Chattanooga, TN-GA",16860,,174,Metropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Walker County,Georgia,13,295,Central,,
+"Chattanooga, TN-GA",16860,,174,Metropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Hamilton County,Tennessee,47,065,Central,,
+"Chattanooga, TN-GA",16860,,174,Metropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Marion County,Tennessee,47,115,Outlying,,
+"Chattanooga, TN-GA",16860,,174,Metropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Sequatchie County,Tennessee,47,153,Outlying,,
+"Cheyenne, WY",16940,,,Metropolitan Statistical Area,,,Laramie County,Wyoming,56,021,Central,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,16984,176,Metropolitan Statistical Area,"Chicago-Naperville-Evanston, IL","Chicago-Naperville, IL-IN-WI",Cook County,Illinois,17,031,Central,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,16984,176,Metropolitan Statistical Area,"Chicago-Naperville-Evanston, IL","Chicago-Naperville, IL-IN-WI",DuPage County,Illinois,17,043,Central,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,16984,176,Metropolitan Statistical Area,"Chicago-Naperville-Evanston, IL","Chicago-Naperville, IL-IN-WI",Grundy County,Illinois,17,063,Outlying,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,16984,176,Metropolitan Statistical Area,"Chicago-Naperville-Evanston, IL","Chicago-Naperville, IL-IN-WI",McHenry County,Illinois,17,111,Central,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,16984,176,Metropolitan Statistical Area,"Chicago-Naperville-Evanston, IL","Chicago-Naperville, IL-IN-WI",Will County,Illinois,17,197,Central,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,20994,176,Metropolitan Statistical Area,"Elgin, IL","Chicago-Naperville, IL-IN-WI",DeKalb County,Illinois,17,037,Outlying,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,20994,176,Metropolitan Statistical Area,"Elgin, IL","Chicago-Naperville, IL-IN-WI",Kane County,Illinois,17,089,Central,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,20994,176,Metropolitan Statistical Area,"Elgin, IL","Chicago-Naperville, IL-IN-WI",Kendall County,Illinois,17,093,Central,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,23844,176,Metropolitan Statistical Area,"Gary, IN","Chicago-Naperville, IL-IN-WI",Jasper County,Indiana,18,073,Outlying,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,23844,176,Metropolitan Statistical Area,"Gary, IN","Chicago-Naperville, IL-IN-WI",Lake County,Indiana,18,089,Central,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,23844,176,Metropolitan Statistical Area,"Gary, IN","Chicago-Naperville, IL-IN-WI",Newton County,Indiana,18,111,Outlying,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,23844,176,Metropolitan Statistical Area,"Gary, IN","Chicago-Naperville, IL-IN-WI",Porter County,Indiana,18,127,Central,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,29404,176,Metropolitan Statistical Area,"Lake County-Kenosha County, IL-WI","Chicago-Naperville, IL-IN-WI",Lake County,Illinois,17,097,Central,,
+"Chicago-Naperville-Elgin, IL-IN-WI",16980,29404,176,Metropolitan Statistical Area,"Lake County-Kenosha County, IL-WI","Chicago-Naperville, IL-IN-WI",Kenosha County,Wisconsin,55,059,Outlying,,
+"Chico, CA",17020,,,Metropolitan Statistical Area,,,Butte County,California,06,007,Central,,
+"Chillicothe, OH",17060,,198,Micropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Ross County,Ohio,39,141,Central,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Dearborn County,Indiana,18,029,Outlying,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Franklin County,Indiana,18,047,Outlying,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Ohio County,Indiana,18,115,Outlying,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Union County,Indiana,18,161,Outlying,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Boone County,Kentucky,21,015,Central,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Bracken County,Kentucky,21,023,Outlying,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Campbell County,Kentucky,21,037,Central,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Gallatin County,Kentucky,21,077,Outlying,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Grant County,Kentucky,21,081,Outlying,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Kenton County,Kentucky,21,117,Central,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Pendleton County,Kentucky,21,191,Outlying,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Brown County,Ohio,39,015,Outlying,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Butler County,Ohio,39,017,Central,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Clermont County,Ohio,39,025,Central,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Hamilton County,Ohio,39,061,Central,,
+"Cincinnati, OH-KY-IN",17140,,178,Metropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Warren County,Ohio,39,165,Central,,
+"Clarksburg, WV",17220,,,Micropolitan Statistical Area,,,Doddridge County,West Virginia,54,017,Outlying,,
+"Clarksburg, WV",17220,,,Micropolitan Statistical Area,,,Harrison County,West Virginia,54,033,Central,,
+"Clarksburg, WV",17220,,,Micropolitan Statistical Area,,,Taylor County,West Virginia,54,091,Outlying,,
+"Clarksdale, MS",17260,,,Micropolitan Statistical Area,,,Coahoma County,Mississippi,28,027,Central,,
+"Clarksville, TN-KY",17300,,,Metropolitan Statistical Area,,,Christian County,Kentucky,21,047,Outlying,,
+"Clarksville, TN-KY",17300,,,Metropolitan Statistical Area,,,Trigg County,Kentucky,21,221,Outlying,,
+"Clarksville, TN-KY",17300,,,Metropolitan Statistical Area,,,Montgomery County,Tennessee,47,125,Central,,
+"Clarksville, TN-KY",17300,,,Metropolitan Statistical Area,,,Stewart County,Tennessee,47,161,Outlying,,
+"Clearlake, CA",17340,,,Micropolitan Statistical Area,,,Lake County,California,06,033,Central,,
+"Cleveland, MS",17380,,185,Micropolitan Statistical Area,,"Cleveland-Indianola, MS",Bolivar County,Mississippi,28,011,Central,,
+"Cleveland, TN",17420,,174,Metropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Bradley County,Tennessee,47,011,Central,,
+"Cleveland, TN",17420,,174,Metropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Polk County,Tennessee,47,139,Outlying,,
+"Cleveland-Elyria, OH",17460,,184,Metropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Cuyahoga County,Ohio,39,035,Central,,
+"Cleveland-Elyria, OH",17460,,184,Metropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Geauga County,Ohio,39,055,Central,,
+"Cleveland-Elyria, OH",17460,,184,Metropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Lake County,Ohio,39,085,Central,,
+"Cleveland-Elyria, OH",17460,,184,Metropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Lorain County,Ohio,39,093,Outlying,,
+"Cleveland-Elyria, OH",17460,,184,Metropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Medina County,Ohio,39,103,Central,,
+"Clewiston, FL",17500,,163,Micropolitan Statistical Area,,"Cape Coral-Fort Myers-Naples, FL",Hendry County,Florida,12,051,Central,,
+"Clinton, IA",17540,,209,Micropolitan Statistical Area,,"Davenport-Moline, IA-IL",Clinton County,Iowa,19,045,Central,,
+"Clovis, NM",17580,,188,Micropolitan Statistical Area,,"Clovis-Portales, NM",Curry County,New Mexico,35,009,Central,,
+"Coamo, PR",17620,,434,Micropolitan Statistical Area,,"Ponce-Yauco-Coamo, PR",Coamo Municipio,Puerto Rico,72,043,Central,,
+"Coco, PR",17640,,490,Micropolitan Statistical Area,,"San Juan-Bayam�n, PR",Salinas Municipio,Puerto Rico,72,123,Central,,
+"Coeur d'Alene, ID",17660,,518,Metropolitan Statistical Area,,"Spokane-Spokane Valley-Coeur d'Alene, WA-ID",Kootenai County,Idaho,16,055,Central,,
+"Coffeyville, KS",17700,,,Micropolitan Statistical Area,,,Montgomery County,Kansas,20,125,Central,,
+"Coldwater, MI",17740,,310,Micropolitan Statistical Area,,"Kalamazoo-Battle Creek-Portage, MI",Branch County,Michigan,26,023,Central,,
+"College Station-Bryan, TX",17780,,,Metropolitan Statistical Area,,,Brazos County,Texas,48,041,Central,,
+"College Station-Bryan, TX",17780,,,Metropolitan Statistical Area,,,Burleson County,Texas,48,051,Outlying,,
+"College Station-Bryan, TX",17780,,,Metropolitan Statistical Area,,,Robertson County,Texas,48,395,Outlying,,
+"Colorado Springs, CO",17820,,,Metropolitan Statistical Area,,,El Paso County,Colorado,08,041,Central,,
+"Colorado Springs, CO",17820,,,Metropolitan Statistical Area,,,Teller County,Colorado,08,119,Outlying,,
+"Columbia, MO",17860,,190,Metropolitan Statistical Area,,"Columbia-Moberly-Mexico, MO",Boone County,Missouri,29,019,Central,,
+"Columbia, MO",17860,,190,Metropolitan Statistical Area,,"Columbia-Moberly-Mexico, MO",Cooper County,Missouri,29,053,Outlying,,
+"Columbia, MO",17860,,190,Metropolitan Statistical Area,,"Columbia-Moberly-Mexico, MO",Howard County,Missouri,29,089,Outlying,,
+"Columbia, SC",17900,,192,Metropolitan Statistical Area,,"Columbia-Orangeburg-Newberry, SC",Calhoun County,South Carolina,45,017,Outlying,,
+"Columbia, SC",17900,,192,Metropolitan Statistical Area,,"Columbia-Orangeburg-Newberry, SC",Fairfield County,South Carolina,45,039,Outlying,,
+"Columbia, SC",17900,,192,Metropolitan Statistical Area,,"Columbia-Orangeburg-Newberry, SC",Kershaw County,South Carolina,45,055,Outlying,,
+"Columbia, SC",17900,,192,Metropolitan Statistical Area,,"Columbia-Orangeburg-Newberry, SC",Lexington County,South Carolina,45,063,Central,,
+"Columbia, SC",17900,,192,Metropolitan Statistical Area,,"Columbia-Orangeburg-Newberry, SC",Richland County,South Carolina,45,079,Central,,
+"Columbia, SC",17900,,192,Metropolitan Statistical Area,,"Columbia-Orangeburg-Newberry, SC",Saluda County,South Carolina,45,081,Outlying,,
+"Columbus, GA-AL",17980,,194,Metropolitan Statistical Area,,"Columbus-Auburn-Opelika, GA-AL",Russell County,Alabama,01,113,Central,,
+"Columbus, GA-AL",17980,,194,Metropolitan Statistical Area,,"Columbus-Auburn-Opelika, GA-AL",Chattahoochee County,Georgia,13,053,Central,,
+"Columbus, GA-AL",17980,,194,Metropolitan Statistical Area,,"Columbus-Auburn-Opelika, GA-AL",Harris County,Georgia,13,145,Outlying,,
+"Columbus, GA-AL",17980,,194,Metropolitan Statistical Area,,"Columbus-Auburn-Opelika, GA-AL",Marion County,Georgia,13,197,Outlying,,
+"Columbus, GA-AL",17980,,194,Metropolitan Statistical Area,,"Columbus-Auburn-Opelika, GA-AL",Muscogee County,Georgia,13,215,Central,,
+"Columbus, GA-AL",17980,,194,Metropolitan Statistical Area,,"Columbus-Auburn-Opelika, GA-AL",Stewart County,Georgia,13,259,Outlying,,
+"Columbus, GA-AL",17980,,194,Metropolitan Statistical Area,,"Columbus-Auburn-Opelika, GA-AL",Talbot County,Georgia,13,263,Outlying,,
+"Columbus, IN",18020,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Bartholomew County,Indiana,18,005,Central,,
+"Columbus, MS",18060,,200,Micropolitan Statistical Area,,"Columbus-West Point, MS",Lowndes County,Mississippi,28,087,Central,,
+"Columbus, NE",18100,,,Micropolitan Statistical Area,,,Platte County,Nebraska,31,141,Central,,
+"Columbus, OH",18140,,198,Metropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Delaware County,Ohio,39,041,Central,,
+"Columbus, OH",18140,,198,Metropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Fairfield County,Ohio,39,045,Central,,
+"Columbus, OH",18140,,198,Metropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Franklin County,Ohio,39,049,Central,,
+"Columbus, OH",18140,,198,Metropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Hocking County,Ohio,39,073,Outlying,,
+"Columbus, OH",18140,,198,Metropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Licking County,Ohio,39,089,Outlying,,
+"Columbus, OH",18140,,198,Metropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Madison County,Ohio,39,097,Outlying,,
+"Columbus, OH",18140,,198,Metropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Morrow County,Ohio,39,117,Outlying,,
+"Columbus, OH",18140,,198,Metropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Perry County,Ohio,39,127,Outlying,,
+"Columbus, OH",18140,,198,Metropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Pickaway County,Ohio,39,129,Outlying,,
+"Columbus, OH",18140,,198,Metropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Union County,Ohio,39,159,Outlying,,
+"Concord, NH",18180,,148,Micropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Merrimack County,New Hampshire,33,013,Central,,
+"Connersville, IN",18220,,458,Micropolitan Statistical Area,,"Richmond-Connersville, IN",Fayette County,Indiana,18,041,Central,,
+"Cookeville, TN",18260,,,Micropolitan Statistical Area,,,Jackson County,Tennessee,47,087,Outlying,,
+"Cookeville, TN",18260,,,Micropolitan Statistical Area,,,Overton County,Tennessee,47,133,Outlying,,
+"Cookeville, TN",18260,,,Micropolitan Statistical Area,,,Putnam County,Tennessee,47,141,Central,,
+"Coos Bay, OR",18300,,,Micropolitan Statistical Area,,,Coos County,Oregon,41,011,Central,,
+"Cordele, GA",18380,,,Micropolitan Statistical Area,,,Crisp County,Georgia,13,081,Central,,
+"Corinth, MS",18420,,539,Micropolitan Statistical Area,,"Tupelo-Corinth, MS",Alcorn County,Mississippi,28,003,Central,,
+"Cornelia, GA",18460,,122,Micropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Habersham County,Georgia,13,137,Central,,
+"Corning, NY",18500,,236,Micropolitan Statistical Area,,"Elmira-Corning, NY",Steuben County,New York,36,101,Central,,
+"Corpus Christi, TX",18580,,204,Metropolitan Statistical Area,,"Corpus Christi-Kingsville-Alice, TX",Nueces County,Texas,48,355,Central,,
+"Corpus Christi, TX",18580,,204,Metropolitan Statistical Area,,"Corpus Christi-Kingsville-Alice, TX",San Patricio County,Texas,48,409,Central,,
+"Corsicana, TX",18620,,206,Micropolitan Statistical Area,,"Dallas-Fort Worth, TX-OK",Navarro County,Texas,48,349,Central,,
+"Cortland, NY",18660,,296,Micropolitan Statistical Area,,"Ithaca-Cortland, NY",Cortland County,New York,36,023,Central,,
+"Corvallis, OR",18700,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Benton County,Oregon,41,003,Central,,
+"Coshocton, OH",18740,,,Micropolitan Statistical Area,,,Coshocton County,Ohio,39,031,Central,,
+"Craig, CO",18780,,525,Micropolitan Statistical Area,,"Steamboat Springs-Craig, CO",Moffat County,Colorado,08,081,Central,,
+"Crawfordsville, IN",18820,,294,Micropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Montgomery County,Indiana,18,107,Central,,
+"Crescent City, CA",18860,,,Micropolitan Statistical Area,,,Del Norte County,California,06,015,Central,,
+"Crestview-Fort Walton Beach-Destin, FL",18880,,,Metropolitan Statistical Area,,,Okaloosa County,Florida,12,091,Central,,
+"Crestview-Fort Walton Beach-Destin, FL",18880,,,Metropolitan Statistical Area,,,Walton County,Florida,12,131,Central,,
+"Crossville, TN",18900,,,Micropolitan Statistical Area,,,Cumberland County,Tennessee,47,035,Central,,
+"Cullman, AL",18980,,142,Micropolitan Statistical Area,,"Birmingham-Hoover-Talladega, AL",Cullman County,Alabama,01,043,Central,,
+"Cullowhee, NC",19000,,,Micropolitan Statistical Area,,,Jackson County,North Carolina,37,099,Central,,
+"Cullowhee, NC",19000,,,Micropolitan Statistical Area,,,Swain County,North Carolina,37,173,Outlying,,
+"Cumberland, MD-WV",19060,,,Metropolitan Statistical Area,,,Allegany County,Maryland,24,001,Central,,
+"Cumberland, MD-WV",19060,,,Metropolitan Statistical Area,,,Mineral County,West Virginia,54,057,Outlying,,
+"Dallas-Fort Worth-Arlington, TX",19100,19124,206,Metropolitan Statistical Area,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Collin County,Texas,48,085,Central,,
+"Dallas-Fort Worth-Arlington, TX",19100,19124,206,Metropolitan Statistical Area,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Dallas County,Texas,48,113,Central,,
+"Dallas-Fort Worth-Arlington, TX",19100,19124,206,Metropolitan Statistical Area,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Denton County,Texas,48,121,Outlying,,
+"Dallas-Fort Worth-Arlington, TX",19100,19124,206,Metropolitan Statistical Area,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Ellis County,Texas,48,139,Central,,
+"Dallas-Fort Worth-Arlington, TX",19100,19124,206,Metropolitan Statistical Area,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Hunt County,Texas,48,231,Outlying,,
+"Dallas-Fort Worth-Arlington, TX",19100,19124,206,Metropolitan Statistical Area,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Kaufman County,Texas,48,257,Outlying,,
+"Dallas-Fort Worth-Arlington, TX",19100,19124,206,Metropolitan Statistical Area,"Dallas-Plano-Irving, TX","Dallas-Fort Worth, TX-OK",Rockwall County,Texas,48,397,Central,,
+"Dallas-Fort Worth-Arlington, TX",19100,23104,206,Metropolitan Statistical Area,"Fort Worth-Arlington-Grapevine, TX","Dallas-Fort Worth, TX-OK",Johnson County,Texas,48,251,Central,,
+"Dallas-Fort Worth-Arlington, TX",19100,23104,206,Metropolitan Statistical Area,"Fort Worth-Arlington-Grapevine, TX","Dallas-Fort Worth, TX-OK",Parker County,Texas,48,367,Outlying,,
+"Dallas-Fort Worth-Arlington, TX",19100,23104,206,Metropolitan Statistical Area,"Fort Worth-Arlington-Grapevine, TX","Dallas-Fort Worth, TX-OK",Tarrant County,Texas,48,439,Central,,
+"Dallas-Fort Worth-Arlington, TX",19100,23104,206,Metropolitan Statistical Area,"Fort Worth-Arlington-Grapevine, TX","Dallas-Fort Worth, TX-OK",Wise County,Texas,48,497,Outlying,,
+"Dalton, GA",19140,,174,Metropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Murray County,Georgia,13,213,Central,,
+"Dalton, GA",19140,,174,Metropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Whitfield County,Georgia,13,313,Central,,
+"Danville, IL",19180,,,Metropolitan Statistical Area,,,Vermilion County,Illinois,17,183,Central,,
+"Danville, KY",19220,,,Micropolitan Statistical Area,,,Boyle County,Kentucky,21,021,Central,,
+"Danville, KY",19220,,,Micropolitan Statistical Area,,,Lincoln County,Kentucky,21,137,Outlying,,
+"Danville, VA",19260,,,Micropolitan Statistical Area,,,Pittsylvania County,Virginia,51,143,Central,,
+"Danville, VA",19260,,,Micropolitan Statistical Area,,,Danville city,Virginia,51,590,Central,,
+"Daphne-Fairhope-Foley, AL",19300,,380,Metropolitan Statistical Area,,"Mobile-Daphne-Fairhope, AL",Baldwin County,Alabama,01,003,Central,,
+"Davenport-Moline-Rock Island, IA-IL",19340,,209,Metropolitan Statistical Area,,"Davenport-Moline, IA-IL",Henry County,Illinois,17,073,Outlying,,
+"Davenport-Moline-Rock Island, IA-IL",19340,,209,Metropolitan Statistical Area,,"Davenport-Moline, IA-IL",Mercer County,Illinois,17,131,Outlying,,
+"Davenport-Moline-Rock Island, IA-IL",19340,,209,Metropolitan Statistical Area,,"Davenport-Moline, IA-IL",Rock Island County,Illinois,17,161,Central,,
+"Davenport-Moline-Rock Island, IA-IL",19340,,209,Metropolitan Statistical Area,,"Davenport-Moline, IA-IL",Scott County,Iowa,19,163,Central,,
+"Dayton, TN",19420,,174,Micropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Rhea County,Tennessee,47,143,Central,,
+"Dayton-Kettering, OH",19430,,212,Metropolitan Statistical Area,,"Dayton-Springfield-Kettering, OH",Greene County,Ohio,39,057,Central,,
+"Dayton-Kettering, OH",19430,,212,Metropolitan Statistical Area,,"Dayton-Springfield-Kettering, OH",Miami County,Ohio,39,109,Central,,
+"Dayton-Kettering, OH",19430,,212,Metropolitan Statistical Area,,"Dayton-Springfield-Kettering, OH",Montgomery County,Ohio,39,113,Central,,
+"Decatur, AL",19460,,290,Metropolitan Statistical Area,,"Huntsville-Decatur, AL",Lawrence County,Alabama,01,079,Outlying,,
+"Decatur, AL",19460,,290,Metropolitan Statistical Area,,"Huntsville-Decatur, AL",Morgan County,Alabama,01,103,Central,,
+"Decatur, IL",19500,,,Metropolitan Statistical Area,,,Macon County,Illinois,17,115,Central,,
+"Decatur, IN",19540,,258,Micropolitan Statistical Area,,"Fort Wayne-Huntington-Auburn, IN",Adams County,Indiana,18,001,Central,,
+"Defiance, OH",19580,,,Micropolitan Statistical Area,,,Defiance County,Ohio,39,039,Central,,
+"Del Rio, TX",19620,,,Micropolitan Statistical Area,,,Val Verde County,Texas,48,465,Central,,
+"Deltona-Daytona Beach-Ormond Beach, FL",19660,,422,Metropolitan Statistical Area,,"Orlando-Lakeland-Deltona, FL",Flagler County,Florida,12,035,Central,,
+"Deltona-Daytona Beach-Ormond Beach, FL",19660,,422,Metropolitan Statistical Area,,"Orlando-Lakeland-Deltona, FL",Volusia County,Florida,12,127,Central,,
+"Deming, NM",19700,,,Micropolitan Statistical Area,,,Luna County,New Mexico,35,029,Central,,
+"Denver-Aurora-Lakewood, CO",19740,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Adams County,Colorado,08,001,Central,,
+"Denver-Aurora-Lakewood, CO",19740,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Arapahoe County,Colorado,08,005,Central,,
+"Denver-Aurora-Lakewood, CO",19740,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Broomfield County,Colorado,08,014,Central,,
+"Denver-Aurora-Lakewood, CO",19740,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Clear Creek County,Colorado,08,019,Outlying,,
+"Denver-Aurora-Lakewood, CO",19740,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Denver County,Colorado,08,031,Central,,
+"Denver-Aurora-Lakewood, CO",19740,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Douglas County,Colorado,08,035,Central,,
+"Denver-Aurora-Lakewood, CO",19740,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Elbert County,Colorado,08,039,Outlying,,
+"Denver-Aurora-Lakewood, CO",19740,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Gilpin County,Colorado,08,047,Outlying,,
+"Denver-Aurora-Lakewood, CO",19740,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Jefferson County,Colorado,08,059,Central,,
+"Denver-Aurora-Lakewood, CO",19740,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Park County,Colorado,08,093,Outlying,,
+"DeRidder, LA",19760,,217,Micropolitan Statistical Area,,"DeRidder-Fort Polk South, LA",Beauregard Parish,Louisiana,22,011,Central,,
+"Des Moines-West Des Moines, IA",19780,,218,Metropolitan Statistical Area,,"Des Moines-Ames-West Des Moines, IA",Dallas County,Iowa,19,049,Central,,
+"Des Moines-West Des Moines, IA",19780,,218,Metropolitan Statistical Area,,"Des Moines-Ames-West Des Moines, IA",Guthrie County,Iowa,19,077,Outlying,,
+"Des Moines-West Des Moines, IA",19780,,218,Metropolitan Statistical Area,,"Des Moines-Ames-West Des Moines, IA",Jasper County,Iowa,19,099,Outlying,,
+"Des Moines-West Des Moines, IA",19780,,218,Metropolitan Statistical Area,,"Des Moines-Ames-West Des Moines, IA",Madison County,Iowa,19,121,Outlying,,
+"Des Moines-West Des Moines, IA",19780,,218,Metropolitan Statistical Area,,"Des Moines-Ames-West Des Moines, IA",Polk County,Iowa,19,153,Central,,
+"Des Moines-West Des Moines, IA",19780,,218,Metropolitan Statistical Area,,"Des Moines-Ames-West Des Moines, IA",Warren County,Iowa,19,181,Outlying,,
+"Detroit-Warren-Dearborn, MI",19820,19804,220,Metropolitan Statistical Area,"Detroit-Dearborn-Livonia, MI","Detroit-Warren-Ann Arbor, MI",Wayne County,Michigan,26,163,Central,,
+"Detroit-Warren-Dearborn, MI",19820,47664,220,Metropolitan Statistical Area,"Warren-Troy-Farmington Hills, MI","Detroit-Warren-Ann Arbor, MI",Lapeer County,Michigan,26,087,Outlying,,
+"Detroit-Warren-Dearborn, MI",19820,47664,220,Metropolitan Statistical Area,"Warren-Troy-Farmington Hills, MI","Detroit-Warren-Ann Arbor, MI",Livingston County,Michigan,26,093,Outlying,,
+"Detroit-Warren-Dearborn, MI",19820,47664,220,Metropolitan Statistical Area,"Warren-Troy-Farmington Hills, MI","Detroit-Warren-Ann Arbor, MI",Macomb County,Michigan,26,099,Central,,
+"Detroit-Warren-Dearborn, MI",19820,47664,220,Metropolitan Statistical Area,"Warren-Troy-Farmington Hills, MI","Detroit-Warren-Ann Arbor, MI",Oakland County,Michigan,26,125,Central,,
+"Detroit-Warren-Dearborn, MI",19820,47664,220,Metropolitan Statistical Area,"Warren-Troy-Farmington Hills, MI","Detroit-Warren-Ann Arbor, MI",St. Clair County,Michigan,26,147,Outlying,,
+"Dickinson, ND",19860,,,Micropolitan Statistical Area,,,Billings County,North Dakota,38,007,Outlying,,
+"Dickinson, ND",19860,,,Micropolitan Statistical Area,,,Stark County,North Dakota,38,089,Central,,
+"Dixon, IL",19940,,221,Micropolitan Statistical Area,,"Dixon-Sterling, IL",Lee County,Illinois,17,103,Central,,
+"Dodge City, KS",19980,,,Micropolitan Statistical Area,,,Ford County,Kansas,20,057,Central,,
+"Dothan, AL",20020,,222,Metropolitan Statistical Area,,"Dothan-Ozark, AL",Geneva County,Alabama,01,061,Outlying,,
+"Dothan, AL",20020,,222,Metropolitan Statistical Area,,"Dothan-Ozark, AL",Henry County,Alabama,01,067,Outlying,,
+"Dothan, AL",20020,,222,Metropolitan Statistical Area,,"Dothan-Ozark, AL",Houston County,Alabama,01,069,Central,,
+"Douglas, GA",20060,,,Micropolitan Statistical Area,,,Atkinson County,Georgia,13,003,Outlying,,
+"Douglas, GA",20060,,,Micropolitan Statistical Area,,,Coffee County,Georgia,13,069,Central,,
+"Dover, DE",20100,,428,Metropolitan Statistical Area,,"Philadelphia-Reading-Camden, PA-NJ-DE-MD",Kent County,Delaware,10,001,Central,,
+"Dublin, GA",20140,,,Micropolitan Statistical Area,,,Johnson County,Georgia,13,167,Outlying,,
+"Dublin, GA",20140,,,Micropolitan Statistical Area,,,Laurens County,Georgia,13,175,Central,,
+"Dublin, GA",20140,,,Micropolitan Statistical Area,,,Treutlen County,Georgia,13,283,Outlying,,
+"DuBois, PA",20180,,524,Micropolitan Statistical Area,,"State College-DuBois, PA",Clearfield County,Pennsylvania,42,033,Central,,
+"Dubuque, IA",20220,,,Metropolitan Statistical Area,,,Dubuque County,Iowa,19,061,Central,,
+"Duluth, MN-WI",20260,,,Metropolitan Statistical Area,,,Carlton County,Minnesota,27,017,Outlying,,
+"Duluth, MN-WI",20260,,,Metropolitan Statistical Area,,,Lake County,Minnesota,27,075,Outlying,,
+"Duluth, MN-WI",20260,,,Metropolitan Statistical Area,,,St. Louis County,Minnesota,27,137,Central,,
+"Duluth, MN-WI",20260,,,Metropolitan Statistical Area,,,Douglas County,Wisconsin,55,031,Central,,
+"Dumas, TX",20300,,,Micropolitan Statistical Area,,,Moore County,Texas,48,341,Central,,
+"Duncan, OK",20340,,,Micropolitan Statistical Area,,,Stephens County,Oklahoma,40,137,Central,,
+"Durango, CO",20420,,,Micropolitan Statistical Area,,,La Plata County,Colorado,08,067,Central,,
+"Durant, OK",20460,,206,Micropolitan Statistical Area,,"Dallas-Fort Worth, TX-OK",Bryan County,Oklahoma,40,013,Central,,
+"Durham-Chapel Hill, NC",20500,,450,Metropolitan Statistical Area,,"Raleigh-Durham-Cary, NC",Chatham County,North Carolina,37,037,Central,,
+"Durham-Chapel Hill, NC",20500,,450,Metropolitan Statistical Area,,"Raleigh-Durham-Cary, NC",Durham County,North Carolina,37,063,Central,,
+"Durham-Chapel Hill, NC",20500,,450,Metropolitan Statistical Area,,"Raleigh-Durham-Cary, NC",Granville County,North Carolina,37,077,Outlying,,
+"Durham-Chapel Hill, NC",20500,,450,Metropolitan Statistical Area,,"Raleigh-Durham-Cary, NC",Orange County,North Carolina,37,135,Central,,
+"Durham-Chapel Hill, NC",20500,,450,Metropolitan Statistical Area,,"Raleigh-Durham-Cary, NC",Person County,North Carolina,37,145,Outlying,,
+"Dyersburg, TN",20540,,,Micropolitan Statistical Area,,,Dyer County,Tennessee,47,045,Central,,
+"Eagle Pass, TX",20580,,,Micropolitan Statistical Area,,,Maverick County,Texas,48,323,Central,,
+"Easton, MD",20660,,548,Micropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Talbot County,Maryland,24,041,Central,,
+"East Stroudsburg, PA",20700,,408,Metropolitan Statistical Area,,"New York-Newark, NY-NJ-CT-PA",Monroe County,Pennsylvania,42,089,Central,,
+"Eau Claire, WI",20740,,232,Metropolitan Statistical Area,,"Eau Claire-Menomonie, WI",Chippewa County,Wisconsin,55,017,Central,,
+"Eau Claire, WI",20740,,232,Metropolitan Statistical Area,,"Eau Claire-Menomonie, WI",Eau Claire County,Wisconsin,55,035,Central,,
+"Edwards, CO",20780,,233,Micropolitan Statistical Area,,"Edwards-Glenwood Springs, CO",Eagle County,Colorado,08,037,Central,,
+"Effingham, IL",20820,,,Micropolitan Statistical Area,,,Effingham County,Illinois,17,049,Central,,
+"El Campo, TX",20900,,288,Micropolitan Statistical Area,,"Houston-The Woodlands, TX",Wharton County,Texas,48,481,Central,,
+"El Centro, CA",20940,,,Metropolitan Statistical Area,,,Imperial County,California,06,025,Central,,
+"El Dorado, AR",20980,,,Micropolitan Statistical Area,,,Union County,Arkansas,05,139,Central,,
+"Elizabeth City, NC",21020,,545,Micropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Pasquotank County,North Carolina,37,139,Central,,
+"Elizabeth City, NC",21020,,545,Micropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Perquimans County,North Carolina,37,143,Outlying,,
+"Elizabethtown-Fort Knox, KY",21060,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Hardin County,Kentucky,21,093,Central,,
+"Elizabethtown-Fort Knox, KY",21060,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Larue County,Kentucky,21,123,Outlying,,
+"Elizabethtown-Fort Knox, KY",21060,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Meade County,Kentucky,21,163,Outlying,,
+"Elk City, OK",21120,,,Micropolitan Statistical Area,,,Beckham County,Oklahoma,40,009,Central,,
+"Elkhart-Goshen, IN",21140,,515,Metropolitan Statistical Area,,"South Bend-Elkhart-Mishawaka, IN-MI",Elkhart County,Indiana,18,039,Central,,
+"Elkins, WV",21180,,,Micropolitan Statistical Area,,,Randolph County,West Virginia,54,083,Central,,
+"Elko, NV",21220,,,Micropolitan Statistical Area,,,Elko County,Nevada,32,007,Central,,
+"Elko, NV",21220,,,Micropolitan Statistical Area,,,Eureka County,Nevada,32,011,Outlying,,
+"Ellensburg, WA",21260,,,Micropolitan Statistical Area,,,Kittitas County,Washington,53,037,Central,,
+"Elmira, NY",21300,,236,Metropolitan Statistical Area,,"Elmira-Corning, NY",Chemung County,New York,36,015,Central,,
+"El Paso, TX",21340,,238,Metropolitan Statistical Area,,"El Paso-Las Cruces, TX-NM",El Paso County,Texas,48,141,Central,,
+"El Paso, TX",21340,,238,Metropolitan Statistical Area,,"El Paso-Las Cruces, TX-NM",Hudspeth County,Texas,48,229,Outlying,,
+"Emporia, KS",21380,,,Micropolitan Statistical Area,,,Chase County,Kansas,20,017,Outlying,,
+"Emporia, KS",21380,,,Micropolitan Statistical Area,,,Lyon County,Kansas,20,111,Central,,
+"Enid, OK",21420,,,Metropolitan Statistical Area,,,Garfield County,Oklahoma,40,047,Central,,
+"Enterprise, AL",21460,,,Micropolitan Statistical Area,,,Coffee County,Alabama,01,031,Central,,
+"Erie, PA",21500,,240,Metropolitan Statistical Area,,"Erie-Meadville, PA",Erie County,Pennsylvania,42,049,Central,,
+"Escanaba, MI",21540,,,Micropolitan Statistical Area,,,Delta County,Michigan,26,041,Central,,
+"Espa�ola, NM",21580,,106,Micropolitan Statistical Area,,"Albuquerque-Santa Fe-Las Vegas, NM",Rio Arriba County,New Mexico,35,039,Central,,
+"Eufaula, AL-GA",21640,,,Micropolitan Statistical Area,,,Barbour County,Alabama,01,005,Central,,
+"Eufaula, AL-GA",21640,,,Micropolitan Statistical Area,,,Quitman County,Georgia,13,239,Outlying,,
+"Eugene-Springfield, OR",21660,,,Metropolitan Statistical Area,,,Lane County,Oregon,41,039,Central,,
+"Eureka-Arcata, CA",21700,,,Micropolitan Statistical Area,,,Humboldt County,California,06,023,Central,,
+"Evanston, WY",21740,,,Micropolitan Statistical Area,,,Uinta County,Wyoming,56,041,Central,,
+"Evansville, IN-KY",21780,,,Metropolitan Statistical Area,,,Posey County,Indiana,18,129,Outlying,,
+"Evansville, IN-KY",21780,,,Metropolitan Statistical Area,,,Vanderburgh County,Indiana,18,163,Central,,
+"Evansville, IN-KY",21780,,,Metropolitan Statistical Area,,,Warrick County,Indiana,18,173,Central,,
+"Evansville, IN-KY",21780,,,Metropolitan Statistical Area,,,Henderson County,Kentucky,21,101,Central,,
+"Fairbanks, AK",21820,,,Metropolitan Statistical Area,,,Fairbanks North Star Borough,Alaska,02,090,Central,,
+"Fairfield, IA",21840,,,Micropolitan Statistical Area,,,Jefferson County,Iowa,19,101,Central,,
+"Fairmont, MN",21860,,,Micropolitan Statistical Area,,,Martin County,Minnesota,27,091,Central,,
+"Fairmont, WV",21900,,390,Micropolitan Statistical Area,,"Morgantown-Fairmont, WV",Marion County,West Virginia,54,049,Central,,
+"Fallon, NV",21980,,,Micropolitan Statistical Area,,,Churchill County,Nevada,32,001,Central,,
+"Fargo, ND-MN",22020,,244,Metropolitan Statistical Area,,"Fargo-Wahpeton, ND-MN",Clay County,Minnesota,27,027,Central,,
+"Fargo, ND-MN",22020,,244,Metropolitan Statistical Area,,"Fargo-Wahpeton, ND-MN",Cass County,North Dakota,38,017,Central,,
+"Faribault-Northfield, MN",22060,,378,Micropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Rice County,Minnesota,27,131,Central,,
+"Farmington, MO",22100,,476,Micropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",St. Francois County,Missouri,29,187,Central,,
+"Farmington, NM",22140,,,Metropolitan Statistical Area,,,San Juan County,New Mexico,35,045,Central,,
+"Fayetteville, NC",22180,,246,Metropolitan Statistical Area,,"Fayetteville-Sanford-Lumberton, NC",Cumberland County,North Carolina,37,051,Central,,
+"Fayetteville, NC",22180,,246,Metropolitan Statistical Area,,"Fayetteville-Sanford-Lumberton, NC",Harnett County,North Carolina,37,085,Outlying,,
+"Fayetteville, NC",22180,,246,Metropolitan Statistical Area,,"Fayetteville-Sanford-Lumberton, NC",Hoke County,North Carolina,37,093,Central,,
+"Fayetteville-Springdale-Rogers, AR",22220,,,Metropolitan Statistical Area,,,Benton County,Arkansas,05,007,Central,,
+"Fayetteville-Springdale-Rogers, AR",22220,,,Metropolitan Statistical Area,,,Madison County,Arkansas,05,087,Outlying,,
+"Fayetteville-Springdale-Rogers, AR",22220,,,Metropolitan Statistical Area,,,Washington County,Arkansas,05,143,Central,,
+"Fergus Falls, MN",22260,,,Micropolitan Statistical Area,,,Otter Tail County,Minnesota,27,111,Central,,
+"Fernley, NV",22280,,456,Micropolitan Statistical Area,,"Reno-Carson City-Fernley, NV",Lyon County,Nevada,32,019,Central,,
+"Findlay, OH",22300,,534,Micropolitan Statistical Area,,"Toledo-Findlay-Tiffin, OH",Hancock County,Ohio,39,063,Central,,
+"Fitzgerald, GA",22340,,,Micropolitan Statistical Area,,,Ben Hill County,Georgia,13,017,Central,,
+"Flagstaff, AZ",22380,,,Metropolitan Statistical Area,,,Coconino County,Arizona,04,005,Central,,
+"Flint, MI",22420,,220,Metropolitan Statistical Area,,"Detroit-Warren-Ann Arbor, MI",Genesee County,Michigan,26,049,Central,,
+"Florence, SC",22500,,,Metropolitan Statistical Area,,,Darlington County,South Carolina,45,031,Outlying,,
+"Florence, SC",22500,,,Metropolitan Statistical Area,,,Florence County,South Carolina,45,041,Central,,
+"Florence-Muscle Shoals, AL",22520,,,Metropolitan Statistical Area,,,Colbert County,Alabama,01,033,Central,,
+"Florence-Muscle Shoals, AL",22520,,,Metropolitan Statistical Area,,,Lauderdale County,Alabama,01,077,Central,,
+"Fond du Lac, WI",22540,,,Metropolitan Statistical Area,,,Fond du Lac County,Wisconsin,55,039,Central,,
+"Forest City, NC",22580,,,Micropolitan Statistical Area,,,Rutherford County,North Carolina,37,161,Central,,
+"Forrest City, AR",22620,,368,Micropolitan Statistical Area,,"Memphis-Forrest City, TN-MS-AR",St. Francis County,Arkansas,05,123,Central,,
+"Fort Collins, CO",22660,,,Metropolitan Statistical Area,,,Larimer County,Colorado,08,069,Central,,
+"Fort Dodge, IA",22700,,,Micropolitan Statistical Area,,,Webster County,Iowa,19,187,Central,,
+"Fort Leonard Wood, MO",22780,,,Micropolitan Statistical Area,,,Pulaski County,Missouri,29,169,Central,,
+"Fort Madison-Keokuk, IA-IL-MO",22800,,161,Micropolitan Statistical Area,,"Burlington-Fort Madison-Keokuk, IA-IL-MO",Hancock County,Illinois,17,067,Outlying,,
+"Fort Madison-Keokuk, IA-IL-MO",22800,,161,Micropolitan Statistical Area,,"Burlington-Fort Madison-Keokuk, IA-IL-MO",Lee County,Iowa,19,111,Central,,
+"Fort Madison-Keokuk, IA-IL-MO",22800,,161,Micropolitan Statistical Area,,"Burlington-Fort Madison-Keokuk, IA-IL-MO",Clark County,Missouri,29,045,Outlying,,
+"Fort Morgan, CO",22820,,,Micropolitan Statistical Area,,,Morgan County,Colorado,08,087,Central,,
+"Fort Payne, AL",22840,,497,Micropolitan Statistical Area,,"Scottsboro-Fort Payne, AL",DeKalb County,Alabama,01,049,Central,,
+"Fort Polk South, LA",22860,,217,Micropolitan Statistical Area,,"DeRidder-Fort Polk South, LA",Vernon Parish,Louisiana,22,115,Central,,
+"Fort Smith, AR-OK",22900,,,Metropolitan Statistical Area,,,Crawford County,Arkansas,05,033,Central,,
+"Fort Smith, AR-OK",22900,,,Metropolitan Statistical Area,,,Franklin County,Arkansas,05,047,Outlying,,
+"Fort Smith, AR-OK",22900,,,Metropolitan Statistical Area,,,Sebastian County,Arkansas,05,131,Central,,
+"Fort Smith, AR-OK",22900,,,Metropolitan Statistical Area,,,Sequoyah County,Oklahoma,40,135,Outlying,,
+"Fort Wayne, IN",23060,,258,Metropolitan Statistical Area,,"Fort Wayne-Huntington-Auburn, IN",Allen County,Indiana,18,003,Central,,
+"Fort Wayne, IN",23060,,258,Metropolitan Statistical Area,,"Fort Wayne-Huntington-Auburn, IN",Whitley County,Indiana,18,183,Outlying,,
+"Frankfort, IN",23140,,320,Micropolitan Statistical Area,,"Lafayette-West Lafayette-Frankfort, IN",Clinton County,Indiana,18,023,Central,,
+"Frankfort, KY",23180,,336,Micropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Anderson County,Kentucky,21,005,Outlying,,
+"Frankfort, KY",23180,,336,Micropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Franklin County,Kentucky,21,073,Central,,
+"Fredericksburg, TX",23240,,314,Micropolitan Statistical Area,,"Kerrville-Fredericksburg, TX",Gillespie County,Texas,48,171,Central,,
+"Freeport, IL",23300,,466,Micropolitan Statistical Area,,"Rockford-Freeport-Rochelle, IL",Stephenson County,Illinois,17,177,Central,,
+"Fremont, NE",23340,,420,Micropolitan Statistical Area,,"Omaha-Council Bluffs-Fremont, NE-IA",Dodge County,Nebraska,31,053,Central,,
+"Fremont, OH",23380,,534,Micropolitan Statistical Area,,"Toledo-Findlay-Tiffin, OH",Sandusky County,Ohio,39,143,Central,,
+"Fresno, CA",23420,,260,Metropolitan Statistical Area,,"Fresno-Madera-Hanford, CA",Fresno County,California,06,019,Central,,
+"Gadsden, AL",23460,,,Metropolitan Statistical Area,,,Etowah County,Alabama,01,055,Central,,
+"Gaffney, SC",23500,,273,Micropolitan Statistical Area,,"Greenville-Spartanburg-Anderson, SC",Cherokee County,South Carolina,45,021,Central,,
+"Gainesville, FL",23540,,264,Metropolitan Statistical Area,,"Gainesville-Lake City, FL",Alachua County,Florida,12,001,Central,,
+"Gainesville, FL",23540,,264,Metropolitan Statistical Area,,"Gainesville-Lake City, FL",Gilchrist County,Florida,12,041,Outlying,,
+"Gainesville, FL",23540,,264,Metropolitan Statistical Area,,"Gainesville-Lake City, FL",Levy County,Florida,12,075,Outlying,,
+"Gainesville, GA",23580,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Hall County,Georgia,13,139,Central,,
+"Gainesville, TX",23620,,206,Micropolitan Statistical Area,,"Dallas-Fort Worth, TX-OK",Cooke County,Texas,48,097,Central,,
+"Galesburg, IL",23660,,,Micropolitan Statistical Area,,,Knox County,Illinois,17,095,Central,,
+"Gallup, NM",23700,,,Micropolitan Statistical Area,,,McKinley County,New Mexico,35,031,Central,,
+"Garden City, KS",23780,,,Micropolitan Statistical Area,,,Finney County,Kansas,20,055,Central,,
+"Garden City, KS",23780,,,Micropolitan Statistical Area,,,Kearny County,Kansas,20,093,Outlying,,
+"Gardnerville Ranchos, NV",23820,,456,Micropolitan Statistical Area,,"Reno-Carson City-Fernley, NV",Douglas County,Nevada,32,005,Central,,
+"Georgetown, SC",23860,,396,Micropolitan Statistical Area,,"Myrtle Beach-Conway, SC-NC",Georgetown County,South Carolina,45,043,Central,,
+"Gettysburg, PA",23900,,276,Metropolitan Statistical Area,,"Harrisburg-York-Lebanon, PA",Adams County,Pennsylvania,42,001,Central,,
+"Gillette, WY",23940,,,Micropolitan Statistical Area,,,Campbell County,Wyoming,56,005,Central,,
+"Gillette, WY",23940,,,Micropolitan Statistical Area,,,Crook County,Wyoming,56,011,Outlying,,
+"Gillette, WY",23940,,,Micropolitan Statistical Area,,,Weston County,Wyoming,56,045,Outlying,,
+"Glasgow, KY",23980,,150,Micropolitan Statistical Area,,"Bowling Green-Glasgow, KY",Barren County,Kentucky,21,009,Central,,
+"Glasgow, KY",23980,,150,Micropolitan Statistical Area,,"Bowling Green-Glasgow, KY",Metcalfe County,Kentucky,21,169,Outlying,,
+"Glens Falls, NY",24020,,104,Metropolitan Statistical Area,,"Albany-Schenectady, NY",Warren County,New York,36,113,Central,,
+"Glens Falls, NY",24020,,104,Metropolitan Statistical Area,,"Albany-Schenectady, NY",Washington County,New York,36,115,Central,,
+"Glenwood Springs, CO",24060,,233,Micropolitan Statistical Area,,"Edwards-Glenwood Springs, CO",Garfield County,Colorado,08,045,Central,,
+"Glenwood Springs, CO",24060,,233,Micropolitan Statistical Area,,"Edwards-Glenwood Springs, CO",Pitkin County,Colorado,08,097,Outlying,,
+"Gloversville, NY",24100,,104,Micropolitan Statistical Area,,"Albany-Schenectady, NY",Fulton County,New York,36,035,Central,,
+"Goldsboro, NC",24140,,,Metropolitan Statistical Area,,,Wayne County,North Carolina,37,191,Central,,
+"Granbury, TX",24180,,206,Micropolitan Statistical Area,,"Dallas-Fort Worth, TX-OK",Hood County,Texas,48,221,Central,,
+"Grand Forks, ND-MN",24220,,,Metropolitan Statistical Area,,,Polk County,Minnesota,27,119,Central,,
+"Grand Forks, ND-MN",24220,,,Metropolitan Statistical Area,,,Grand Forks County,North Dakota,38,035,Central,,
+"Grand Island, NE",24260,,,Metropolitan Statistical Area,,,Hall County,Nebraska,31,079,Central,,
+"Grand Island, NE",24260,,,Metropolitan Statistical Area,,,Howard County,Nebraska,31,093,Outlying,,
+"Grand Island, NE",24260,,,Metropolitan Statistical Area,,,Merrick County,Nebraska,31,121,Outlying,,
+"Grand Junction, CO",24300,,,Metropolitan Statistical Area,,,Mesa County,Colorado,08,077,Central,,
+"Grand Rapids, MN",24330,,,Micropolitan Statistical Area,,,Itasca County,Minnesota,27,061,Central,,
+"Grand Rapids-Kentwood, MI",24340,,266,Metropolitan Statistical Area,,"Grand Rapids-Kentwood-Muskegon, MI",Ionia County,Michigan,26,067,Outlying,,
+"Grand Rapids-Kentwood, MI",24340,,266,Metropolitan Statistical Area,,"Grand Rapids-Kentwood-Muskegon, MI",Kent County,Michigan,26,081,Central,,
+"Grand Rapids-Kentwood, MI",24340,,266,Metropolitan Statistical Area,,"Grand Rapids-Kentwood-Muskegon, MI",Montcalm County,Michigan,26,117,Outlying,,
+"Grand Rapids-Kentwood, MI",24340,,266,Metropolitan Statistical Area,,"Grand Rapids-Kentwood-Muskegon, MI",Ottawa County,Michigan,26,139,Outlying,,
+"Grants, NM",24380,,,Micropolitan Statistical Area,,,Cibola County,New Mexico,35,006,Central,,
+"Grants Pass, OR",24420,,366,Metropolitan Statistical Area,,"Medford-Grants Pass, OR",Josephine County,Oregon,41,033,Central,,
+"Great Bend, KS",24460,,,Micropolitan Statistical Area,,,Barton County,Kansas,20,009,Central,,
+"Great Falls, MT",24500,,,Metropolitan Statistical Area,,,Cascade County,Montana,30,013,Central,,
+"Greeley, CO",24540,,216,Metropolitan Statistical Area,,"Denver-Aurora, CO",Weld County,Colorado,08,123,Central,,
+"Green Bay, WI",24580,,267,Metropolitan Statistical Area,,"Green Bay-Shawano, WI",Brown County,Wisconsin,55,009,Central,,
+"Green Bay, WI",24580,,267,Metropolitan Statistical Area,,"Green Bay-Shawano, WI",Kewaunee County,Wisconsin,55,061,Outlying,,
+"Green Bay, WI",24580,,267,Metropolitan Statistical Area,,"Green Bay-Shawano, WI",Oconto County,Wisconsin,55,083,Outlying,,
+"Greeneville, TN",24620,,,Micropolitan Statistical Area,,,Greene County,Tennessee,47,059,Central,,
+"Greensboro-High Point, NC",24660,,268,Metropolitan Statistical Area,,"Greensboro--Winston-Salem--High Point, NC",Guilford County,North Carolina,37,081,Central,,
+"Greensboro-High Point, NC",24660,,268,Metropolitan Statistical Area,,"Greensboro--Winston-Salem--High Point, NC",Randolph County,North Carolina,37,151,Outlying,,
+"Greensboro-High Point, NC",24660,,268,Metropolitan Statistical Area,,"Greensboro--Winston-Salem--High Point, NC",Rockingham County,North Carolina,37,157,Outlying,,
+"Greensburg, IN",24700,,294,Micropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Decatur County,Indiana,18,031,Central,,
+"Greenville, MS",24740,,,Micropolitan Statistical Area,,,Washington County,Mississippi,28,151,Central,,
+"Greenville, NC",24780,,272,Metropolitan Statistical Area,,"Greenville-Kinston-Washington, NC",Pitt County,North Carolina,37,147,Central,,
+"Greenville, OH",24820,,212,Micropolitan Statistical Area,,"Dayton-Springfield-Kettering, OH",Darke County,Ohio,39,037,Central,,
+"Greenville-Anderson, SC",24860,,273,Metropolitan Statistical Area,,"Greenville-Spartanburg-Anderson, SC",Anderson County,South Carolina,45,007,Outlying,,
+"Greenville-Anderson, SC",24860,,273,Metropolitan Statistical Area,,"Greenville-Spartanburg-Anderson, SC",Greenville County,South Carolina,45,045,Central,,
+"Greenville-Anderson, SC",24860,,273,Metropolitan Statistical Area,,"Greenville-Spartanburg-Anderson, SC",Laurens County,South Carolina,45,059,Outlying,,
+"Greenville-Anderson, SC",24860,,273,Metropolitan Statistical Area,,"Greenville-Spartanburg-Anderson, SC",Pickens County,South Carolina,45,077,Central,,
+"Greenwood, MS",24900,,,Micropolitan Statistical Area,,,Carroll County,Mississippi,28,015,Outlying,,
+"Greenwood, MS",24900,,,Micropolitan Statistical Area,,,Leflore County,Mississippi,28,083,Central,,
+"Greenwood, SC",24940,,273,Micropolitan Statistical Area,,"Greenville-Spartanburg-Anderson, SC",Greenwood County,South Carolina,45,047,Central,,
+"Grenada, MS",24980,,,Micropolitan Statistical Area,,,Grenada County,Mississippi,28,043,Central,,
+"Guayama, PR",25020,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Arroyo Municipio,Puerto Rico,72,015,Central,,
+"Guayama, PR",25020,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Guayama Municipio,Puerto Rico,72,057,Central,,
+"Guayama, PR",25020,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Patillas Municipio,Puerto Rico,72,109,Central,,
+"Gulfport-Biloxi, MS",25060,,,Metropolitan Statistical Area,,,Hancock County,Mississippi,28,045,Central,,
+"Gulfport-Biloxi, MS",25060,,,Metropolitan Statistical Area,,,Harrison County,Mississippi,28,047,Central,,
+"Gulfport-Biloxi, MS",25060,,,Metropolitan Statistical Area,,,Jackson County,Mississippi,28,059,Outlying,,
+"Gulfport-Biloxi, MS",25060,,,Metropolitan Statistical Area,,,Stone County,Mississippi,28,131,Outlying,,
+"Guymon, OK",25100,,,Micropolitan Statistical Area,,,Texas County,Oklahoma,40,139,Central,,
+"Hagerstown-Martinsburg, MD-WV",25180,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Washington County,Maryland,24,043,Central,,
+"Hagerstown-Martinsburg, MD-WV",25180,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Berkeley County,West Virginia,54,003,Central,,
+"Hagerstown-Martinsburg, MD-WV",25180,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Morgan County,West Virginia,54,065,Outlying,,
+"Hailey, ID",25200,,,Micropolitan Statistical Area,,,Blaine County,Idaho,16,013,Central,,
+"Hailey, ID",25200,,,Micropolitan Statistical Area,,,Camas County,Idaho,16,025,Outlying,,
+"Hammond, LA",25220,,406,Metropolitan Statistical Area,,"New Orleans-Metairie-Hammond, LA-MS",Tangipahoa Parish,Louisiana,22,105,Central,,
+"Hanford-Corcoran, CA",25260,,260,Metropolitan Statistical Area,,"Fresno-Madera-Hanford, CA",Kings County,California,06,031,Central,,
+"Hannibal, MO",25300,,448,Micropolitan Statistical Area,,"Quincy-Hannibal, IL-MO",Marion County,Missouri,29,127,Central,,
+"Hannibal, MO",25300,,448,Micropolitan Statistical Area,,"Quincy-Hannibal, IL-MO",Ralls County,Missouri,29,173,Outlying,,
+"Harrisburg-Carlisle, PA",25420,,276,Metropolitan Statistical Area,,"Harrisburg-York-Lebanon, PA",Cumberland County,Pennsylvania,42,041,Central,,
+"Harrisburg-Carlisle, PA",25420,,276,Metropolitan Statistical Area,,"Harrisburg-York-Lebanon, PA",Dauphin County,Pennsylvania,42,043,Central,,
+"Harrisburg-Carlisle, PA",25420,,276,Metropolitan Statistical Area,,"Harrisburg-York-Lebanon, PA",Perry County,Pennsylvania,42,099,Outlying,,
+"Harrison, AR",25460,,,Micropolitan Statistical Area,,,Boone County,Arkansas,05,009,Central,,
+"Harrison, AR",25460,,,Micropolitan Statistical Area,,,Newton County,Arkansas,05,101,Outlying,,
+"Harrisonburg, VA",25500,,277,Metropolitan Statistical Area,,"Harrisonburg-Staunton, VA",Rockingham County,Virginia,51,165,Central,,
+"Harrisonburg, VA",25500,,277,Metropolitan Statistical Area,,"Harrisonburg-Staunton, VA",Harrisonburg city,Virginia,51,660,Central,,
+"Hartford-East Hartford-Middletown, CT",25540,,278,Metropolitan Statistical Area,,"Hartford-East Hartford, CT",Hartford County,Connecticut,09,003,Central,,
+"Hartford-East Hartford-Middletown, CT",25540,,278,Metropolitan Statistical Area,,"Hartford-East Hartford, CT",Middlesex County,Connecticut,09,007,Central,,
+"Hartford-East Hartford-Middletown, CT",25540,,278,Metropolitan Statistical Area,,"Hartford-East Hartford, CT",Tolland County,Connecticut,09,013,Central,,
+"Hastings, NE",25580,,,Micropolitan Statistical Area,,,Adams County,Nebraska,31,001,Central,,
+"Hattiesburg, MS",25620,,279,Metropolitan Statistical Area,,"Hattiesburg-Laurel, MS",Covington County,Mississippi,28,031,Outlying,,
+"Hattiesburg, MS",25620,,279,Metropolitan Statistical Area,,"Hattiesburg-Laurel, MS",Forrest County,Mississippi,28,035,Central,,
+"Hattiesburg, MS",25620,,279,Metropolitan Statistical Area,,"Hattiesburg-Laurel, MS",Lamar County,Mississippi,28,073,Central,,
+"Hattiesburg, MS",25620,,279,Metropolitan Statistical Area,,"Hattiesburg-Laurel, MS",Perry County,Mississippi,28,111,Outlying,,
+"Hays, KS",25700,,,Micropolitan Statistical Area,,,Ellis County,Kansas,20,051,Central,,
+"Heber, UT",25720,,482,Micropolitan Statistical Area,,"Salt Lake City-Provo-Orem, UT",Summit County,Utah,49,043,Central,,
+"Heber, UT",25720,,482,Micropolitan Statistical Area,,"Salt Lake City-Provo-Orem, UT",Wasatch County,Utah,49,051,Outlying,,
+"Helena, MT",25740,,,Micropolitan Statistical Area,,,Jefferson County,Montana,30,043,Outlying,,
+"Helena, MT",25740,,,Micropolitan Statistical Area,,,Lewis and Clark County,Montana,30,049,Central,,
+"Helena-West Helena, AR",25760,,,Micropolitan Statistical Area,,,Phillips County,Arkansas,05,107,Central,,
+"Henderson, NC",25780,,450,Micropolitan Statistical Area,,"Raleigh-Durham-Cary, NC",Vance County,North Carolina,37,181,Central,,
+"Hereford, TX",25820,,,Micropolitan Statistical Area,,,Deaf Smith County,Texas,48,117,Central,,
+"Hermiston-Pendleton, OR",25840,,,Micropolitan Statistical Area,,,Morrow County,Oregon,41,049,Outlying,,
+"Hermiston-Pendleton, OR",25840,,,Micropolitan Statistical Area,,,Umatilla County,Oregon,41,059,Central,,
+"Hickory-Lenoir-Morganton, NC",25860,,,Metropolitan Statistical Area,,,Alexander County,North Carolina,37,003,Outlying,,
+"Hickory-Lenoir-Morganton, NC",25860,,,Metropolitan Statistical Area,,,Burke County,North Carolina,37,023,Central,,
+"Hickory-Lenoir-Morganton, NC",25860,,,Metropolitan Statistical Area,,,Caldwell County,North Carolina,37,027,Central,,
+"Hickory-Lenoir-Morganton, NC",25860,,,Metropolitan Statistical Area,,,Catawba County,North Carolina,37,035,Central,,
+"Hillsdale, MI",25880,,,Micropolitan Statistical Area,,,Hillsdale County,Michigan,26,059,Central,,
+"Hilo, HI",25900,,,Micropolitan Statistical Area,,,Hawaii County,Hawaii,15,001,Central,,
+"Hilton Head Island-Bluffton, SC",25940,,,Metropolitan Statistical Area,,,Beaufort County,South Carolina,45,013,Central,,
+"Hilton Head Island-Bluffton, SC",25940,,,Metropolitan Statistical Area,,,Jasper County,South Carolina,45,053,Outlying,,
+"Hinesville, GA",25980,,496,Metropolitan Statistical Area,,"Savannah-Hinesville-Statesboro, GA",Liberty County,Georgia,13,179,Central,,
+"Hinesville, GA",25980,,496,Metropolitan Statistical Area,,"Savannah-Hinesville-Statesboro, GA",Long County,Georgia,13,183,Outlying,,
+"Hobbs, NM",26020,,,Micropolitan Statistical Area,,,Lea County,New Mexico,35,025,Central,,
+"Holland, MI",26090,,266,Micropolitan Statistical Area,,"Grand Rapids-Kentwood-Muskegon, MI",Allegan County,Michigan,26,005,Central,,
+"Homosassa Springs, FL",26140,,,Metropolitan Statistical Area,,,Citrus County,Florida,12,017,Central,,
+"Hood River, OR",26220,,,Micropolitan Statistical Area,,,Hood River County,Oregon,41,027,Central,,
+"Hope, AR",26260,,,Micropolitan Statistical Area,,,Hempstead County,Arkansas,05,057,Central,,
+"Hope, AR",26260,,,Micropolitan Statistical Area,,,Nevada County,Arkansas,05,099,Outlying,,
+"Hot Springs, AR",26300,,284,Metropolitan Statistical Area,,"Hot Springs-Malvern, AR",Garland County,Arkansas,05,051,Central,,
+"Houghton, MI",26340,,,Micropolitan Statistical Area,,,Houghton County,Michigan,26,061,Central,,
+"Houghton, MI",26340,,,Micropolitan Statistical Area,,,Keweenaw County,Michigan,26,083,Outlying,,
+"Houma-Thibodaux, LA",26380,,,Metropolitan Statistical Area,,,Lafourche Parish,Louisiana,22,057,Central,,
+"Houma-Thibodaux, LA",26380,,,Metropolitan Statistical Area,,,Terrebonne Parish,Louisiana,22,109,Central,,
+"Houston-The Woodlands-Sugar Land, TX",26420,,288,Metropolitan Statistical Area,,"Houston-The Woodlands, TX",Austin County,Texas,48,015,Outlying,,
+"Houston-The Woodlands-Sugar Land, TX",26420,,288,Metropolitan Statistical Area,,"Houston-The Woodlands, TX",Brazoria County,Texas,48,039,Central,,
+"Houston-The Woodlands-Sugar Land, TX",26420,,288,Metropolitan Statistical Area,,"Houston-The Woodlands, TX",Chambers County,Texas,48,071,Central,,
+"Houston-The Woodlands-Sugar Land, TX",26420,,288,Metropolitan Statistical Area,,"Houston-The Woodlands, TX",Fort Bend County,Texas,48,157,Central,,
+"Houston-The Woodlands-Sugar Land, TX",26420,,288,Metropolitan Statistical Area,,"Houston-The Woodlands, TX",Galveston County,Texas,48,167,Central,,
+"Houston-The Woodlands-Sugar Land, TX",26420,,288,Metropolitan Statistical Area,,"Houston-The Woodlands, TX",Harris County,Texas,48,201,Central,,
+"Houston-The Woodlands-Sugar Land, TX",26420,,288,Metropolitan Statistical Area,,"Houston-The Woodlands, TX",Liberty County,Texas,48,291,Outlying,,
+"Houston-The Woodlands-Sugar Land, TX",26420,,288,Metropolitan Statistical Area,,"Houston-The Woodlands, TX",Montgomery County,Texas,48,339,Outlying,,
+"Houston-The Woodlands-Sugar Land, TX",26420,,288,Metropolitan Statistical Area,,"Houston-The Woodlands, TX",Waller County,Texas,48,473,Outlying,,
+"Hudson, NY",26460,,104,Micropolitan Statistical Area,,"Albany-Schenectady, NY",Columbia County,New York,36,021,Central,,
+"Huntingdon, PA",26500,,107,Micropolitan Statistical Area,,"Altoona-Huntingdon, PA",Huntingdon County,Pennsylvania,42,061,Central,,
+"Huntington, IN",26540,,258,Micropolitan Statistical Area,,"Fort Wayne-Huntington-Auburn, IN",Huntington County,Indiana,18,069,Central,,
+"Huntington-Ashland, WV-KY-OH",26580,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Boyd County,Kentucky,21,019,Central,,
+"Huntington-Ashland, WV-KY-OH",26580,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Carter County,Kentucky,21,043,Outlying,,
+"Huntington-Ashland, WV-KY-OH",26580,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Greenup County,Kentucky,21,089,Central,,
+"Huntington-Ashland, WV-KY-OH",26580,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Lawrence County,Ohio,39,087,Central,,
+"Huntington-Ashland, WV-KY-OH",26580,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Cabell County,West Virginia,54,011,Central,,
+"Huntington-Ashland, WV-KY-OH",26580,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Putnam County,West Virginia,54,079,Central,,
+"Huntington-Ashland, WV-KY-OH",26580,,170,Metropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Wayne County,West Virginia,54,099,Central,,
+"Huntsville, AL",26620,,290,Metropolitan Statistical Area,,"Huntsville-Decatur, AL",Limestone County,Alabama,01,083,Outlying,,
+"Huntsville, AL",26620,,290,Metropolitan Statistical Area,,"Huntsville-Decatur, AL",Madison County,Alabama,01,089,Central,,
+"Huntsville, TX",26660,,288,Micropolitan Statistical Area,,"Houston-The Woodlands, TX",Walker County,Texas,48,471,Central,,
+"Huron, SD",26700,,,Micropolitan Statistical Area,,,Beadle County,South Dakota,46,005,Central,,
+"Huron, SD",26700,,,Micropolitan Statistical Area,,,Jerauld County,South Dakota,46,073,Outlying,,
+"Hutchinson, KS",26740,,,Micropolitan Statistical Area,,,Reno County,Kansas,20,155,Central,,
+"Hutchinson, MN",26780,,378,Micropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",McLeod County,Minnesota,27,085,Central,,
+"Idaho Falls, ID",26820,,292,Metropolitan Statistical Area,,"Idaho Falls-Rexburg-Blackfoot, ID",Bonneville County,Idaho,16,019,Central,,
+"Idaho Falls, ID",26820,,292,Metropolitan Statistical Area,,"Idaho Falls-Rexburg-Blackfoot, ID",Butte County,Idaho,16,023,Outlying,,
+"Idaho Falls, ID",26820,,292,Metropolitan Statistical Area,,"Idaho Falls-Rexburg-Blackfoot, ID",Jefferson County,Idaho,16,051,Outlying,,
+"Indiana, PA",26860,,430,Micropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Indiana County,Pennsylvania,42,063,Central,,
+"Indianapolis-Carmel-Anderson, IN",26900,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Boone County,Indiana,18,011,Central,,
+"Indianapolis-Carmel-Anderson, IN",26900,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Brown County,Indiana,18,013,Outlying,,
+"Indianapolis-Carmel-Anderson, IN",26900,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Hamilton County,Indiana,18,057,Central,,
+"Indianapolis-Carmel-Anderson, IN",26900,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Hancock County,Indiana,18,059,Central,,
+"Indianapolis-Carmel-Anderson, IN",26900,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Hendricks County,Indiana,18,063,Central,,
+"Indianapolis-Carmel-Anderson, IN",26900,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Johnson County,Indiana,18,081,Central,,
+"Indianapolis-Carmel-Anderson, IN",26900,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Madison County,Indiana,18,095,Outlying,,
+"Indianapolis-Carmel-Anderson, IN",26900,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Marion County,Indiana,18,097,Central,,
+"Indianapolis-Carmel-Anderson, IN",26900,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Morgan County,Indiana,18,109,Central,,
+"Indianapolis-Carmel-Anderson, IN",26900,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Putnam County,Indiana,18,133,Outlying,,
+"Indianapolis-Carmel-Anderson, IN",26900,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Shelby County,Indiana,18,145,Outlying,,
+"Indianola, MS",26940,,185,Micropolitan Statistical Area,,"Cleveland-Indianola, MS",Sunflower County,Mississippi,28,133,Central,,
+"Iowa City, IA",26980,,168,Metropolitan Statistical Area,,"Cedar Rapids-Iowa City, IA",Johnson County,Iowa,19,103,Central,,
+"Iowa City, IA",26980,,168,Metropolitan Statistical Area,,"Cedar Rapids-Iowa City, IA",Washington County,Iowa,19,183,Outlying,,
+"Iron Mountain, MI-WI",27020,,361,Micropolitan Statistical Area,,"Marinette-Iron Mountain, WI-MI",Dickinson County,Michigan,26,043,Central,,
+"Iron Mountain, MI-WI",27020,,361,Micropolitan Statistical Area,,"Marinette-Iron Mountain, WI-MI",Florence County,Wisconsin,55,037,Outlying,,
+"Ithaca, NY",27060,,296,Metropolitan Statistical Area,,"Ithaca-Cortland, NY",Tompkins County,New York,36,109,Central,,
+"Jackson, MI",27100,,,Metropolitan Statistical Area,,,Jackson County,Michigan,26,075,Central,,
+"Jackson, MS",27140,,298,Metropolitan Statistical Area,,"Jackson-Vicksburg-Brookhaven, MS",Copiah County,Mississippi,28,029,Outlying,,
+"Jackson, MS",27140,,298,Metropolitan Statistical Area,,"Jackson-Vicksburg-Brookhaven, MS",Hinds County,Mississippi,28,049,Central,,
+"Jackson, MS",27140,,298,Metropolitan Statistical Area,,"Jackson-Vicksburg-Brookhaven, MS",Holmes County,Mississippi,28,051,Outlying,,
+"Jackson, MS",27140,,298,Metropolitan Statistical Area,,"Jackson-Vicksburg-Brookhaven, MS",Madison County,Mississippi,28,089,Central,,
+"Jackson, MS",27140,,298,Metropolitan Statistical Area,,"Jackson-Vicksburg-Brookhaven, MS",Rankin County,Mississippi,28,121,Central,,
+"Jackson, MS",27140,,298,Metropolitan Statistical Area,,"Jackson-Vicksburg-Brookhaven, MS",Simpson County,Mississippi,28,127,Outlying,,
+"Jackson, MS",27140,,298,Metropolitan Statistical Area,,"Jackson-Vicksburg-Brookhaven, MS",Yazoo County,Mississippi,28,163,Outlying,,
+"Jackson, OH",27160,,,Micropolitan Statistical Area,,,Jackson County,Ohio,39,079,Central,,
+"Jackson, TN",27180,,297,Metropolitan Statistical Area,,"Jackson-Brownsville, TN",Chester County,Tennessee,47,023,Outlying,,
+"Jackson, TN",27180,,297,Metropolitan Statistical Area,,"Jackson-Brownsville, TN",Crockett County,Tennessee,47,033,Outlying,,
+"Jackson, TN",27180,,297,Metropolitan Statistical Area,,"Jackson-Brownsville, TN",Gibson County,Tennessee,47,053,Outlying,,
+"Jackson, TN",27180,,297,Metropolitan Statistical Area,,"Jackson-Brownsville, TN",Madison County,Tennessee,47,113,Central,,
+"Jackson, WY-ID",27220,,,Micropolitan Statistical Area,,,Teton County,Idaho,16,081,Outlying,,
+"Jackson, WY-ID",27220,,,Micropolitan Statistical Area,,,Teton County,Wyoming,56,039,Central,,
+"Jacksonville, FL",27260,,300,Metropolitan Statistical Area,,"Jacksonville-St. Marys-Palatka, FL-GA",Baker County,Florida,12,003,Outlying,,
+"Jacksonville, FL",27260,,300,Metropolitan Statistical Area,,"Jacksonville-St. Marys-Palatka, FL-GA",Clay County,Florida,12,019,Central,,
+"Jacksonville, FL",27260,,300,Metropolitan Statistical Area,,"Jacksonville-St. Marys-Palatka, FL-GA",Duval County,Florida,12,031,Central,,
+"Jacksonville, FL",27260,,300,Metropolitan Statistical Area,,"Jacksonville-St. Marys-Palatka, FL-GA",Nassau County,Florida,12,089,Outlying,,
+"Jacksonville, FL",27260,,300,Metropolitan Statistical Area,,"Jacksonville-St. Marys-Palatka, FL-GA",St. Johns County,Florida,12,109,Outlying,,
+"Jacksonville, IL",27300,,522,Micropolitan Statistical Area,,"Springfield-Jacksonville-Lincoln, IL",Morgan County,Illinois,17,137,Central,,
+"Jacksonville, IL",27300,,522,Micropolitan Statistical Area,,"Springfield-Jacksonville-Lincoln, IL",Scott County,Illinois,17,171,Outlying,,
+"Jacksonville, NC",27340,,,Metropolitan Statistical Area,,,Onslow County,North Carolina,37,133,Central,,
+"Jacksonville, TX",27380,,540,Micropolitan Statistical Area,,"Tyler-Jacksonville, TX",Cherokee County,Texas,48,073,Central,,
+"Jamestown, ND",27420,,,Micropolitan Statistical Area,,,Stutsman County,North Dakota,38,093,Central,,
+"Jamestown-Dunkirk-Fredonia, NY",27460,,,Micropolitan Statistical Area,,,Chautauqua County,New York,36,013,Central,,
+"Janesville-Beloit, WI",27500,,357,Metropolitan Statistical Area,,"Madison-Janesville-Beloit, WI",Rock County,Wisconsin,55,105,Central,,
+"Jasper, AL",27530,,142,Micropolitan Statistical Area,,"Birmingham-Hoover-Talladega, AL",Walker County,Alabama,01,127,Central,,
+"Jasper, IN",27540,,,Micropolitan Statistical Area,,,Dubois County,Indiana,18,037,Central,,
+"Jasper, IN",27540,,,Micropolitan Statistical Area,,,Pike County,Indiana,18,125,Outlying,,
+"Jayuya, PR",27580,,,Micropolitan Statistical Area,,,Jayuya Municipio,Puerto Rico,72,073,Central,,
+"Jefferson, GA",27600,,122,Micropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Jackson County,Georgia,13,157,Central,,
+"Jefferson City, MO",27620,,,Metropolitan Statistical Area,,,Callaway County,Missouri,29,027,Outlying,,
+"Jefferson City, MO",27620,,,Metropolitan Statistical Area,,,Cole County,Missouri,29,051,Central,,
+"Jefferson City, MO",27620,,,Metropolitan Statistical Area,,,Moniteau County,Missouri,29,135,Outlying,,
+"Jefferson City, MO",27620,,,Metropolitan Statistical Area,,,Osage County,Missouri,29,151,Outlying,,
+"Jennings, LA",27660,,324,Micropolitan Statistical Area,,"Lake Charles-Jennings, LA",Jefferson Davis Parish,Louisiana,22,053,Central,,
+"Jesup, GA",27700,,496,Micropolitan Statistical Area,,"Savannah-Hinesville-Statesboro, GA",Wayne County,Georgia,13,305,Central,,
+"Johnson City, TN",27740,,304,Metropolitan Statistical Area,,"Johnson City-Kingsport-Bristol, TN-VA",Carter County,Tennessee,47,019,Central,,
+"Johnson City, TN",27740,,304,Metropolitan Statistical Area,,"Johnson City-Kingsport-Bristol, TN-VA",Unicoi County,Tennessee,47,171,Outlying,,
+"Johnson City, TN",27740,,304,Metropolitan Statistical Area,,"Johnson City-Kingsport-Bristol, TN-VA",Washington County,Tennessee,47,179,Central,,
+"Johnstown, PA",27780,,306,Metropolitan Statistical Area,,"Johnstown-Somerset, PA",Cambria County,Pennsylvania,42,021,Central,,
+"Jonesboro, AR",27860,,308,Metropolitan Statistical Area,,"Jonesboro-Paragould, AR",Craighead County,Arkansas,05,031,Central,,
+"Jonesboro, AR",27860,,308,Metropolitan Statistical Area,,"Jonesboro-Paragould, AR",Poinsett County,Arkansas,05,111,Outlying,,
+"Joplin, MO",27900,,309,Metropolitan Statistical Area,,"Joplin-Miami, MO-OK",Jasper County,Missouri,29,097,Central,,
+"Joplin, MO",27900,,309,Metropolitan Statistical Area,,"Joplin-Miami, MO-OK",Newton County,Missouri,29,145,Outlying,,
+"Juneau, AK",27940,,,Micropolitan Statistical Area,,,Juneau City and Borough,Alaska,02,110,Central,,
+"Kahului-Wailuku-Lahaina, HI",27980,,,Metropolitan Statistical Area,,,Maui County,Hawaii,15,009,Central,,
+"Kalamazoo-Portage, MI",28020,,310,Metropolitan Statistical Area,,"Kalamazoo-Battle Creek-Portage, MI",Kalamazoo County,Michigan,26,077,Central,,
+"Kalispell, MT",28060,,,Micropolitan Statistical Area,,,Flathead County,Montana,30,029,Central,,
+"Kankakee, IL",28100,,176,Metropolitan Statistical Area,,"Chicago-Naperville, IL-IN-WI",Kankakee County,Illinois,17,091,Central,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Johnson County,Kansas,20,091,Central,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Leavenworth County,Kansas,20,103,Outlying,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Linn County,Kansas,20,107,Outlying,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Miami County,Kansas,20,121,Outlying,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Wyandotte County,Kansas,20,209,Central,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Bates County,Missouri,29,013,Outlying,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Caldwell County,Missouri,29,025,Outlying,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Cass County,Missouri,29,037,Central,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Clay County,Missouri,29,047,Central,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Clinton County,Missouri,29,049,Outlying,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Jackson County,Missouri,29,095,Central,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Lafayette County,Missouri,29,107,Outlying,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Platte County,Missouri,29,165,Central,,
+"Kansas City, MO-KS",28140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Ray County,Missouri,29,177,Outlying,,
+"Kapaa, HI",28180,,,Micropolitan Statistical Area,,,Kauai County,Hawaii,15,007,Central,,
+"Kearney, NE",28260,,,Micropolitan Statistical Area,,,Buffalo County,Nebraska,31,019,Central,,
+"Kearney, NE",28260,,,Micropolitan Statistical Area,,,Kearney County,Nebraska,31,099,Outlying,,
+"Keene, NH",28300,,,Micropolitan Statistical Area,,,Cheshire County,New Hampshire,33,005,Central,,
+"Kendallville, IN",28340,,258,Micropolitan Statistical Area,,"Fort Wayne-Huntington-Auburn, IN",Noble County,Indiana,18,113,Central,,
+"Kennett, MO",28380,,,Micropolitan Statistical Area,,,Dunklin County,Missouri,29,069,Central,,
+"Kennewick-Richland, WA",28420,,313,Metropolitan Statistical Area,,"Kennewick-Richland-Walla Walla, WA",Benton County,Washington,53,005,Central,,
+"Kennewick-Richland, WA",28420,,313,Metropolitan Statistical Area,,"Kennewick-Richland-Walla Walla, WA",Franklin County,Washington,53,021,Central,,
+"Kerrville, TX",28500,,314,Micropolitan Statistical Area,,"Kerrville-Fredericksburg, TX",Kerr County,Texas,48,265,Central,,
+"Ketchikan, AK",28540,,,Micropolitan Statistical Area,,,Ketchikan Gateway Borough,Alaska,02,130,Central,,
+"Key West, FL",28580,,370,Micropolitan Statistical Area,,"Miami-Port St. Lucie-Fort Lauderdale, FL",Monroe County,Florida,12,087,Central,,
+"Kill Devil Hills, NC",28620,,545,Micropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Dare County,North Carolina,37,055,Central,,
+"Killeen-Temple, TX",28660,,,Metropolitan Statistical Area,,,Bell County,Texas,48,027,Central,,
+"Killeen-Temple, TX",28660,,,Metropolitan Statistical Area,,,Coryell County,Texas,48,099,Central,,
+"Killeen-Temple, TX",28660,,,Metropolitan Statistical Area,,,Lampasas County,Texas,48,281,Outlying,,
+"Kingsport-Bristol, TN-VA",28700,,304,Metropolitan Statistical Area,,"Johnson City-Kingsport-Bristol, TN-VA",Hawkins County,Tennessee,47,073,Central,,
+"Kingsport-Bristol, TN-VA",28700,,304,Metropolitan Statistical Area,,"Johnson City-Kingsport-Bristol, TN-VA",Sullivan County,Tennessee,47,163,Central,,
+"Kingsport-Bristol, TN-VA",28700,,304,Metropolitan Statistical Area,,"Johnson City-Kingsport-Bristol, TN-VA",Scott County,Virginia,51,169,Outlying,,
+"Kingsport-Bristol, TN-VA",28700,,304,Metropolitan Statistical Area,,"Johnson City-Kingsport-Bristol, TN-VA",Washington County,Virginia,51,191,Outlying,,
+"Kingsport-Bristol, TN-VA",28700,,304,Metropolitan Statistical Area,,"Johnson City-Kingsport-Bristol, TN-VA",Bristol city,Virginia,51,520,Outlying,,
+"Kingston, NY",28740,,408,Metropolitan Statistical Area,,"New York-Newark, NY-NJ-CT-PA",Ulster County,New York,36,111,Central,,
+"Kingsville, TX",28780,,204,Micropolitan Statistical Area,,"Corpus Christi-Kingsville-Alice, TX",Kenedy County,Texas,48,261,Outlying,,
+"Kingsville, TX",28780,,204,Micropolitan Statistical Area,,"Corpus Christi-Kingsville-Alice, TX",Kleberg County,Texas,48,273,Central,,
+"Kinston, NC",28820,,272,Micropolitan Statistical Area,,"Greenville-Kinston-Washington, NC",Lenoir County,North Carolina,37,107,Central,,
+"Kirksville, MO",28860,,,Micropolitan Statistical Area,,,Adair County,Missouri,29,001,Central,,
+"Kirksville, MO",28860,,,Micropolitan Statistical Area,,,Schuyler County,Missouri,29,197,Outlying,,
+"Klamath Falls, OR",28900,,,Micropolitan Statistical Area,,,Klamath County,Oregon,41,035,Central,,
+"Knoxville, TN",28940,,315,Metropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Anderson County,Tennessee,47,001,Central,,
+"Knoxville, TN",28940,,315,Metropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Blount County,Tennessee,47,009,Central,,
+"Knoxville, TN",28940,,315,Metropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Campbell County,Tennessee,47,013,Outlying,,
+"Knoxville, TN",28940,,315,Metropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Knox County,Tennessee,47,093,Central,,
+"Knoxville, TN",28940,,315,Metropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Loudon County,Tennessee,47,105,Central,,
+"Knoxville, TN",28940,,315,Metropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Morgan County,Tennessee,47,129,Outlying,,
+"Knoxville, TN",28940,,315,Metropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Roane County,Tennessee,47,145,Outlying,,
+"Knoxville, TN",28940,,315,Metropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Union County,Tennessee,47,173,Outlying,,
+"Kokomo, IN",29020,,316,Metropolitan Statistical Area,,"Kokomo-Peru, IN",Howard County,Indiana,18,067,Central,,
+"Laconia, NH",29060,,148,Micropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Belknap County,New Hampshire,33,001,Central,,
+"La Crosse-Onalaska, WI-MN",29100,,,Metropolitan Statistical Area,,,Houston County,Minnesota,27,055,Central,,
+"La Crosse-Onalaska, WI-MN",29100,,,Metropolitan Statistical Area,,,La Crosse County,Wisconsin,55,063,Central,,
+"Lafayette, LA",29180,,318,Metropolitan Statistical Area,,"Lafayette-Opelousas-Morgan City, LA",Acadia Parish,Louisiana,22,001,Outlying,,
+"Lafayette, LA",29180,,318,Metropolitan Statistical Area,,"Lafayette-Opelousas-Morgan City, LA",Iberia Parish,Louisiana,22,045,Central,,
+"Lafayette, LA",29180,,318,Metropolitan Statistical Area,,"Lafayette-Opelousas-Morgan City, LA",Lafayette Parish,Louisiana,22,055,Central,,
+"Lafayette, LA",29180,,318,Metropolitan Statistical Area,,"Lafayette-Opelousas-Morgan City, LA",St. Martin Parish,Louisiana,22,099,Outlying,,
+"Lafayette, LA",29180,,318,Metropolitan Statistical Area,,"Lafayette-Opelousas-Morgan City, LA",Vermilion Parish,Louisiana,22,113,Outlying,,
+"Lafayette-West Lafayette, IN",29200,,320,Metropolitan Statistical Area,,"Lafayette-West Lafayette-Frankfort, IN",Benton County,Indiana,18,007,Outlying,,
+"Lafayette-West Lafayette, IN",29200,,320,Metropolitan Statistical Area,,"Lafayette-West Lafayette-Frankfort, IN",Carroll County,Indiana,18,015,Outlying,,
+"Lafayette-West Lafayette, IN",29200,,320,Metropolitan Statistical Area,,"Lafayette-West Lafayette-Frankfort, IN",Tippecanoe County,Indiana,18,157,Central,,
+"Lafayette-West Lafayette, IN",29200,,320,Metropolitan Statistical Area,,"Lafayette-West Lafayette-Frankfort, IN",Warren County,Indiana,18,171,Outlying,,
+"La Grande, OR",29260,,,Micropolitan Statistical Area,,,Union County,Oregon,41,061,Central,,
+"LaGrange, GA-AL",29300,,122,Micropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Chambers County,Alabama,01,017,Outlying,,
+"LaGrange, GA-AL",29300,,122,Micropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Troup County,Georgia,13,285,Central,,
+"Lake Charles, LA",29340,,324,Metropolitan Statistical Area,,"Lake Charles-Jennings, LA",Calcasieu Parish,Louisiana,22,019,Central,,
+"Lake Charles, LA",29340,,324,Metropolitan Statistical Area,,"Lake Charles-Jennings, LA",Cameron Parish,Louisiana,22,023,Outlying,,
+"Lake City, FL",29380,,264,Micropolitan Statistical Area,,"Gainesville-Lake City, FL",Columbia County,Florida,12,023,Central,,
+"Lake Havasu City-Kingman, AZ",29420,,,Metropolitan Statistical Area,,,Mohave County,Arizona,04,015,Central,,
+"Lakeland-Winter Haven, FL",29460,,422,Metropolitan Statistical Area,,"Orlando-Lakeland-Deltona, FL",Polk County,Florida,12,105,Central,,
+"Lamesa, TX",29500,,,Micropolitan Statistical Area,,,Dawson County,Texas,48,115,Central,,
+"Lancaster, PA",29540,,,Metropolitan Statistical Area,,,Lancaster County,Pennsylvania,42,071,Central,,
+"Lansing-East Lansing, MI",29620,,,Metropolitan Statistical Area,,,Clinton County,Michigan,26,037,Central,,
+"Lansing-East Lansing, MI",29620,,,Metropolitan Statistical Area,,,Eaton County,Michigan,26,045,Central,,
+"Lansing-East Lansing, MI",29620,,,Metropolitan Statistical Area,,,Ingham County,Michigan,26,065,Central,,
+"Lansing-East Lansing, MI",29620,,,Metropolitan Statistical Area,,,Shiawassee County,Michigan,26,155,Outlying,,
+"Laramie, WY",29660,,,Micropolitan Statistical Area,,,Albany County,Wyoming,56,001,Central,,
+"Laredo, TX",29700,,,Metropolitan Statistical Area,,,Webb County,Texas,48,479,Central,,
+"Las Cruces, NM",29740,,238,Metropolitan Statistical Area,,"El Paso-Las Cruces, TX-NM",Do�a Ana County,New Mexico,35,013,Central,,
+"Las Vegas, NM",29780,,106,Micropolitan Statistical Area,,"Albuquerque-Santa Fe-Las Vegas, NM",Mora County,New Mexico,35,033,Outlying,,
+"Las Vegas, NM",29780,,106,Micropolitan Statistical Area,,"Albuquerque-Santa Fe-Las Vegas, NM",San Miguel County,New Mexico,35,047,Central,,
+"Las Vegas-Henderson-Paradise, NV",29820,,332,Metropolitan Statistical Area,,"Las Vegas-Henderson, NV",Clark County,Nevada,32,003,Central,,
+"Laurel, MS",29860,,279,Micropolitan Statistical Area,,"Hattiesburg-Laurel, MS",Jasper County,Mississippi,28,061,Outlying,,
+"Laurel, MS",29860,,279,Micropolitan Statistical Area,,"Hattiesburg-Laurel, MS",Jones County,Mississippi,28,067,Central,,
+"Laurinburg, NC",29900,,246,Micropolitan Statistical Area,,"Fayetteville-Sanford-Lumberton, NC",Scotland County,North Carolina,37,165,Central,,
+"Lawrence, KS",29940,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Douglas County,Kansas,20,045,Central,,
+"Lawrenceburg, TN",29980,,400,Micropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Lawrence County,Tennessee,47,099,Central,,
+"Lawton, OK",30020,,,Metropolitan Statistical Area,,,Comanche County,Oklahoma,40,031,Central,,
+"Lawton, OK",30020,,,Metropolitan Statistical Area,,,Cotton County,Oklahoma,40,033,Outlying,,
+"Lebanon, MO",30060,,,Micropolitan Statistical Area,,,Laclede County,Missouri,29,105,Central,,
+"Lebanon, NH-VT",30100,,,Micropolitan Statistical Area,,,Grafton County,New Hampshire,33,009,Central,,
+"Lebanon, NH-VT",30100,,,Micropolitan Statistical Area,,,Sullivan County,New Hampshire,33,019,Outlying,,
+"Lebanon, NH-VT",30100,,,Micropolitan Statistical Area,,,Orange County,Vermont,50,017,Outlying,,
+"Lebanon, NH-VT",30100,,,Micropolitan Statistical Area,,,Windsor County,Vermont,50,027,Central,,
+"Lebanon, PA",30140,,276,Metropolitan Statistical Area,,"Harrisburg-York-Lebanon, PA",Lebanon County,Pennsylvania,42,075,Central,,
+"Levelland, TX",30220,,352,Micropolitan Statistical Area,,"Lubbock-Plainview-Levelland, TX",Hockley County,Texas,48,219,Central,,
+"Lewisburg, PA",30260,,146,Micropolitan Statistical Area,,"Bloomsburg-Berwick-Sunbury, PA",Union County,Pennsylvania,42,119,Central,,
+"Lewisburg, TN",30280,,400,Micropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Marshall County,Tennessee,47,117,Central,,
+"Lewiston, ID-WA",30300,,,Metropolitan Statistical Area,,,Nez Perce County,Idaho,16,069,Central,,
+"Lewiston, ID-WA",30300,,,Metropolitan Statistical Area,,,Asotin County,Washington,53,003,Central,,
+"Lewiston-Auburn, ME",30340,,438,Metropolitan Statistical Area,,"Portland-Lewiston-South Portland, ME",Androscoggin County,Maine,23,001,Central,,
+"Lewistown, PA",30380,,,Micropolitan Statistical Area,,,Mifflin County,Pennsylvania,42,087,Central,,
+"Lexington, NE",30420,,,Micropolitan Statistical Area,,,Dawson County,Nebraska,31,047,Central,,
+"Lexington, NE",30420,,,Micropolitan Statistical Area,,,Gosper County,Nebraska,31,073,Outlying,,
+"Lexington-Fayette, KY",30460,,336,Metropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Bourbon County,Kentucky,21,017,Outlying,,
+"Lexington-Fayette, KY",30460,,336,Metropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Clark County,Kentucky,21,049,Outlying,,
+"Lexington-Fayette, KY",30460,,336,Metropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Fayette County,Kentucky,21,067,Central,,
+"Lexington-Fayette, KY",30460,,336,Metropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Jessamine County,Kentucky,21,113,Outlying,,
+"Lexington-Fayette, KY",30460,,336,Metropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Scott County,Kentucky,21,209,Outlying,,
+"Lexington-Fayette, KY",30460,,336,Metropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Woodford County,Kentucky,21,239,Outlying,,
+"Liberal, KS",30580,,,Micropolitan Statistical Area,,,Seward County,Kansas,20,175,Central,,
+"Lima, OH",30620,,338,Metropolitan Statistical Area,,"Lima-Van Wert-Celina, OH",Allen County,Ohio,39,003,Central,,
+"Lincoln, IL",30660,,522,Micropolitan Statistical Area,,"Springfield-Jacksonville-Lincoln, IL",Logan County,Illinois,17,107,Central,,
+"Lincoln, NE",30700,,339,Metropolitan Statistical Area,,"Lincoln-Beatrice, NE",Lancaster County,Nebraska,31,109,Central,,
+"Lincoln, NE",30700,,339,Metropolitan Statistical Area,,"Lincoln-Beatrice, NE",Seward County,Nebraska,31,159,Outlying,,
+"Little Rock-North Little Rock-Conway, AR",30780,,340,Metropolitan Statistical Area,,"Little Rock-North Little Rock, AR",Faulkner County,Arkansas,05,045,Outlying,,
+"Little Rock-North Little Rock-Conway, AR",30780,,340,Metropolitan Statistical Area,,"Little Rock-North Little Rock, AR",Grant County,Arkansas,05,053,Outlying,,
+"Little Rock-North Little Rock-Conway, AR",30780,,340,Metropolitan Statistical Area,,"Little Rock-North Little Rock, AR",Lonoke County,Arkansas,05,085,Central,,
+"Little Rock-North Little Rock-Conway, AR",30780,,340,Metropolitan Statistical Area,,"Little Rock-North Little Rock, AR",Perry County,Arkansas,05,105,Outlying,,
+"Little Rock-North Little Rock-Conway, AR",30780,,340,Metropolitan Statistical Area,,"Little Rock-North Little Rock, AR",Pulaski County,Arkansas,05,119,Central,,
+"Little Rock-North Little Rock-Conway, AR",30780,,340,Metropolitan Statistical Area,,"Little Rock-North Little Rock, AR",Saline County,Arkansas,05,125,Central,,
+"Lock Haven, PA",30820,,558,Micropolitan Statistical Area,,"Williamsport-Lock Haven, PA",Clinton County,Pennsylvania,42,035,Central,,
+"Logan, UT-ID",30860,,,Metropolitan Statistical Area,,,Franklin County,Idaho,16,041,Outlying,,
+"Logan, UT-ID",30860,,,Metropolitan Statistical Area,,,Cache County,Utah,49,005,Central,,
+"Logansport, IN",30900,,,Micropolitan Statistical Area,,,Cass County,Indiana,18,017,Central,,
+"London, KY",30940,,,Micropolitan Statistical Area,,,Clay County,Kentucky,21,051,Outlying,,
+"London, KY",30940,,,Micropolitan Statistical Area,,,Knox County,Kentucky,21,121,Central,,
+"London, KY",30940,,,Micropolitan Statistical Area,,,Laurel County,Kentucky,21,125,Central,,
+"London, KY",30940,,,Micropolitan Statistical Area,,,Whitley County,Kentucky,21,235,Central,,
+"Longview, TX",30980,,,Metropolitan Statistical Area,,,Gregg County,Texas,48,183,Central,,
+"Longview, TX",30980,,,Metropolitan Statistical Area,,,Harrison County,Texas,48,203,Outlying,,
+"Longview, TX",30980,,,Metropolitan Statistical Area,,,Rusk County,Texas,48,401,Outlying,,
+"Longview, TX",30980,,,Metropolitan Statistical Area,,,Upshur County,Texas,48,459,Outlying,,
+"Longview, WA",31020,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Cowlitz County,Washington,53,015,Central,,
+"Los Alamos, NM",31060,,106,Micropolitan Statistical Area,,"Albuquerque-Santa Fe-Las Vegas, NM",Los Alamos County,New Mexico,35,028,Central,,
+"Los Angeles-Long Beach-Anaheim, CA",31080,11244,348,Metropolitan Statistical Area,"Anaheim-Santa Ana-Irvine, CA","Los Angeles-Long Beach, CA",Orange County,California,06,059,Central,,
+"Los Angeles-Long Beach-Anaheim, CA",31080,31084,348,Metropolitan Statistical Area,"Los Angeles-Long Beach-Glendale, CA","Los Angeles-Long Beach, CA",Los Angeles County,California,06,037,Central,,
+"Louisville/Jefferson County, KY-IN",31140,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Clark County,Indiana,18,019,Central,,
+"Louisville/Jefferson County, KY-IN",31140,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Floyd County,Indiana,18,043,Central,,
+"Louisville/Jefferson County, KY-IN",31140,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Harrison County,Indiana,18,061,Outlying,,
+"Louisville/Jefferson County, KY-IN",31140,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Washington County,Indiana,18,175,Outlying,,
+"Louisville/Jefferson County, KY-IN",31140,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Bullitt County,Kentucky,21,029,Central,,
+"Louisville/Jefferson County, KY-IN",31140,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Henry County,Kentucky,21,103,Outlying,,
+"Louisville/Jefferson County, KY-IN",31140,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Jefferson County,Kentucky,21,111,Central,,
+"Louisville/Jefferson County, KY-IN",31140,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Oldham County,Kentucky,21,185,Central,,
+"Louisville/Jefferson County, KY-IN",31140,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Shelby County,Kentucky,21,211,Outlying,,
+"Louisville/Jefferson County, KY-IN",31140,,350,Metropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Spencer County,Kentucky,21,215,Outlying,,
+"Lubbock, TX",31180,,352,Metropolitan Statistical Area,,"Lubbock-Plainview-Levelland, TX",Crosby County,Texas,48,107,Outlying,,
+"Lubbock, TX",31180,,352,Metropolitan Statistical Area,,"Lubbock-Plainview-Levelland, TX",Lubbock County,Texas,48,303,Central,,
+"Lubbock, TX",31180,,352,Metropolitan Statistical Area,,"Lubbock-Plainview-Levelland, TX",Lynn County,Texas,48,305,Outlying,,
+"Ludington, MI",31220,,,Micropolitan Statistical Area,,,Mason County,Michigan,26,105,Central,,
+"Lufkin, TX",31260,,,Micropolitan Statistical Area,,,Angelina County,Texas,48,005,Central,,
+"Lumberton, NC",31300,,246,Micropolitan Statistical Area,,"Fayetteville-Sanford-Lumberton, NC",Robeson County,North Carolina,37,155,Central,,
+"Lynchburg, VA",31340,,,Metropolitan Statistical Area,,,Amherst County,Virginia,51,009,Central,,
+"Lynchburg, VA",31340,,,Metropolitan Statistical Area,,,Appomattox County,Virginia,51,011,Outlying,,
+"Lynchburg, VA",31340,,,Metropolitan Statistical Area,,,Bedford County,Virginia,51,019,Central,,
+"Lynchburg, VA",31340,,,Metropolitan Statistical Area,,,Campbell County,Virginia,51,031,Central,,
+"Lynchburg, VA",31340,,,Metropolitan Statistical Area,,,Lynchburg city,Virginia,51,680,Central,,
+"Macomb, IL",31380,,,Micropolitan Statistical Area,,,McDonough County,Illinois,17,109,Central,,
+"Macon-Bibb County, GA",31420,,356,Metropolitan Statistical Area,,"Macon-Bibb County--Warner Robins, GA",Bibb County,Georgia,13,021,Central,,
+"Macon-Bibb County, GA",31420,,356,Metropolitan Statistical Area,,"Macon-Bibb County--Warner Robins, GA",Crawford County,Georgia,13,079,Outlying,,
+"Macon-Bibb County, GA",31420,,356,Metropolitan Statistical Area,,"Macon-Bibb County--Warner Robins, GA",Jones County,Georgia,13,169,Outlying,,
+"Macon-Bibb County, GA",31420,,356,Metropolitan Statistical Area,,"Macon-Bibb County--Warner Robins, GA",Monroe County,Georgia,13,207,Outlying,,
+"Macon-Bibb County, GA",31420,,356,Metropolitan Statistical Area,,"Macon-Bibb County--Warner Robins, GA",Twiggs County,Georgia,13,289,Outlying,,
+"Madera, CA",31460,,260,Metropolitan Statistical Area,,"Fresno-Madera-Hanford, CA",Madera County,California,06,039,Central,,
+"Madison, IN",31500,,,Micropolitan Statistical Area,,,Jefferson County,Indiana,18,077,Central,,
+"Madison, WI",31540,,357,Metropolitan Statistical Area,,"Madison-Janesville-Beloit, WI",Columbia County,Wisconsin,55,021,Outlying,,
+"Madison, WI",31540,,357,Metropolitan Statistical Area,,"Madison-Janesville-Beloit, WI",Dane County,Wisconsin,55,025,Central,,
+"Madison, WI",31540,,357,Metropolitan Statistical Area,,"Madison-Janesville-Beloit, WI",Green County,Wisconsin,55,045,Outlying,,
+"Madison, WI",31540,,357,Metropolitan Statistical Area,,"Madison-Janesville-Beloit, WI",Iowa County,Wisconsin,55,049,Outlying,,
+"Madisonville, KY",31580,,,Micropolitan Statistical Area,,,Hopkins County,Kentucky,21,107,Central,,
+"Magnolia, AR",31620,,,Micropolitan Statistical Area,,,Columbia County,Arkansas,05,027,Central,,
+"Malone, NY",31660,,,Micropolitan Statistical Area,,,Franklin County,New York,36,033,Central,,
+"Malvern, AR",31680,,284,Micropolitan Statistical Area,,"Hot Springs-Malvern, AR",Hot Spring County,Arkansas,05,059,Central,,
+"Manchester-Nashua, NH",31700,,148,Metropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Hillsborough County,New Hampshire,33,011,Central,,
+"Manhattan, KS",31740,,,Metropolitan Statistical Area,,,Geary County,Kansas,20,061,Outlying,,
+"Manhattan, KS",31740,,,Metropolitan Statistical Area,,,Pottawatomie County,Kansas,20,149,Outlying,,
+"Manhattan, KS",31740,,,Metropolitan Statistical Area,,,Riley County,Kansas,20,161,Central,,
+"Manitowoc, WI",31820,,,Micropolitan Statistical Area,,,Manitowoc County,Wisconsin,55,071,Central,,
+"Mankato, MN",31860,,359,Metropolitan Statistical Area,,"Mankato-New Ulm, MN",Blue Earth County,Minnesota,27,013,Central,,
+"Mankato, MN",31860,,359,Metropolitan Statistical Area,,"Mankato-New Ulm, MN",Nicollet County,Minnesota,27,103,Central,,
+"Mansfield, OH",31900,,360,Metropolitan Statistical Area,,"Mansfield-Ashland-Bucyrus, OH",Richland County,Ohio,39,139,Central,,
+"Marietta, OH",31930,,425,Micropolitan Statistical Area,,"Parkersburg-Marietta-Vienna, WV-OH",Washington County,Ohio,39,167,Central,,
+"Marinette, WI-MI",31940,,361,Micropolitan Statistical Area,,"Marinette-Iron Mountain, WI-MI",Menominee County,Michigan,26,109,Central,,
+"Marinette, WI-MI",31940,,361,Micropolitan Statistical Area,,"Marinette-Iron Mountain, WI-MI",Marinette County,Wisconsin,55,075,Central,,
+"Marion, IN",31980,,,Micropolitan Statistical Area,,,Grant County,Indiana,18,053,Central,,
+"Marion, NC",32000,,120,Micropolitan Statistical Area,,"Asheville-Marion-Brevard, NC",McDowell County,North Carolina,37,111,Central,,
+"Marion, OH",32020,,198,Micropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Marion County,Ohio,39,101,Central,,
+"Marquette, MI",32100,,,Micropolitan Statistical Area,,,Marquette County,Michigan,26,103,Central,,
+"Marshall, MN",32140,,,Micropolitan Statistical Area,,,Lyon County,Minnesota,27,083,Central,,
+"Marshall, MO",32180,,,Micropolitan Statistical Area,,,Saline County,Missouri,29,195,Central,,
+"Marshalltown, IA",32260,,,Micropolitan Statistical Area,,,Marshall County,Iowa,19,127,Central,,
+"Martin, TN",32280,,362,Micropolitan Statistical Area,,"Martin-Union City, TN",Weakley County,Tennessee,47,183,Central,,
+"Martinsville, VA",32300,,,Micropolitan Statistical Area,,,Henry County,Virginia,51,089,Central,,
+"Martinsville, VA",32300,,,Micropolitan Statistical Area,,,Martinsville city,Virginia,51,690,Central,,
+"Maryville, MO",32340,,,Micropolitan Statistical Area,,,Nodaway County,Missouri,29,147,Central,,
+"Mason City, IA",32380,,,Micropolitan Statistical Area,,,Cerro Gordo County,Iowa,19,033,Central,,
+"Mason City, IA",32380,,,Micropolitan Statistical Area,,,Worth County,Iowa,19,195,Outlying,,
+"Mayag�ez, PR",32420,,364,Metropolitan Statistical Area,,"Mayag�ez-San Germ�n, PR",Hormigueros Municipio,Puerto Rico,72,067,Central,,
+"Mayag�ez, PR",32420,,364,Metropolitan Statistical Area,,"Mayag�ez-San Germ�n, PR",Las Mar�as Municipio,Puerto Rico,72,083,Outlying,,
+"Mayag�ez, PR",32420,,364,Metropolitan Statistical Area,,"Mayag�ez-San Germ�n, PR",Mayag�ez Municipio,Puerto Rico,72,097,Central,,
+"Mayfield, KY",32460,,424,Micropolitan Statistical Area,,"Paducah-Mayfield, KY-IL",Graves County,Kentucky,21,083,Central,,
+"Maysville, KY",32500,,178,Micropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Mason County,Kentucky,21,161,Central,,
+"McAlester, OK",32540,,,Micropolitan Statistical Area,,,Pittsburg County,Oklahoma,40,121,Central,,
+"McAllen-Edinburg-Mission, TX",32580,,365,Metropolitan Statistical Area,,"McAllen-Edinburg, TX",Hidalgo County,Texas,48,215,Central,,
+"McComb, MS",32620,,,Micropolitan Statistical Area,,,Pike County,Mississippi,28,113,Central,,
+"McMinnville, TN",32660,,,Micropolitan Statistical Area,,,Warren County,Tennessee,47,177,Central,,
+"McPherson, KS",32700,,,Micropolitan Statistical Area,,,McPherson County,Kansas,20,113,Central,,
+"Meadville, PA",32740,,240,Micropolitan Statistical Area,,"Erie-Meadville, PA",Crawford County,Pennsylvania,42,039,Central,,
+"Medford, OR",32780,,366,Metropolitan Statistical Area,,"Medford-Grants Pass, OR",Jackson County,Oregon,41,029,Central,,
+"Memphis, TN-MS-AR",32820,,368,Metropolitan Statistical Area,,"Memphis-Forrest City, TN-MS-AR",Crittenden County,Arkansas,05,035,Central,,
+"Memphis, TN-MS-AR",32820,,368,Metropolitan Statistical Area,,"Memphis-Forrest City, TN-MS-AR",DeSoto County,Mississippi,28,033,Central,,
+"Memphis, TN-MS-AR",32820,,368,Metropolitan Statistical Area,,"Memphis-Forrest City, TN-MS-AR",Marshall County,Mississippi,28,093,Outlying,,
+"Memphis, TN-MS-AR",32820,,368,Metropolitan Statistical Area,,"Memphis-Forrest City, TN-MS-AR",Tate County,Mississippi,28,137,Outlying,,
+"Memphis, TN-MS-AR",32820,,368,Metropolitan Statistical Area,,"Memphis-Forrest City, TN-MS-AR",Tunica County,Mississippi,28,143,Outlying,,
+"Memphis, TN-MS-AR",32820,,368,Metropolitan Statistical Area,,"Memphis-Forrest City, TN-MS-AR",Fayette County,Tennessee,47,047,Outlying,,
+"Memphis, TN-MS-AR",32820,,368,Metropolitan Statistical Area,,"Memphis-Forrest City, TN-MS-AR",Shelby County,Tennessee,47,157,Central,,
+"Memphis, TN-MS-AR",32820,,368,Metropolitan Statistical Area,,"Memphis-Forrest City, TN-MS-AR",Tipton County,Tennessee,47,167,Outlying,,
+"Menomonie, WI",32860,,232,Micropolitan Statistical Area,,"Eau Claire-Menomonie, WI",Dunn County,Wisconsin,55,033,Central,,
+"Merced, CA",32900,,488,Metropolitan Statistical Area,,"San Jose-San Francisco-Oakland, CA",Merced County,California,06,047,Central,,
+"Meridian, MS",32940,,,Micropolitan Statistical Area,,,Clarke County,Mississippi,28,023,Outlying,,
+"Meridian, MS",32940,,,Micropolitan Statistical Area,,,Kemper County,Mississippi,28,069,Outlying,,
+"Meridian, MS",32940,,,Micropolitan Statistical Area,,,Lauderdale County,Mississippi,28,075,Central,,
+"Mexico, MO",33020,,190,Micropolitan Statistical Area,,"Columbia-Moberly-Mexico, MO",Audrain County,Missouri,29,007,Central,,
+"Miami, OK",33060,,309,Micropolitan Statistical Area,,"Joplin-Miami, MO-OK",Ottawa County,Oklahoma,40,115,Central,,
+"Miami-Fort Lauderdale-Pompano Beach, FL",33100,22744,370,Metropolitan Statistical Area,"Fort Lauderdale-Pompano Beach-Sunrise, FL","Miami-Port St. Lucie-Fort Lauderdale, FL",Broward County,Florida,12,011,Central,,
+"Miami-Fort Lauderdale-Pompano Beach, FL",33100,33124,370,Metropolitan Statistical Area,"Miami-Miami Beach-Kendall, FL","Miami-Port St. Lucie-Fort Lauderdale, FL",Miami-Dade County,Florida,12,086,Central,,
+"Miami-Fort Lauderdale-Pompano Beach, FL",33100,48424,370,Metropolitan Statistical Area,"West Palm Beach-Boca Raton-Boynton Beach, FL","Miami-Port St. Lucie-Fort Lauderdale, FL",Palm Beach County,Florida,12,099,Central,,
+"Michigan City-La Porte, IN",33140,,176,Metropolitan Statistical Area,,"Chicago-Naperville, IL-IN-WI",LaPorte County,Indiana,18,091,Central,,
+"Middlesborough, KY",33180,,,Micropolitan Statistical Area,,,Bell County,Kentucky,21,013,Central,,
+"Midland, MI",33220,,474,Metropolitan Statistical Area,,"Saginaw-Midland-Bay City, MI",Midland County,Michigan,26,111,Central,,
+"Midland, TX",33260,,372,Metropolitan Statistical Area,,"Midland-Odessa, TX",Martin County,Texas,48,317,Outlying,,
+"Midland, TX",33260,,372,Metropolitan Statistical Area,,"Midland-Odessa, TX",Midland County,Texas,48,329,Central,,
+"Milledgeville, GA",33300,,,Micropolitan Statistical Area,,,Baldwin County,Georgia,13,009,Central,,
+"Milledgeville, GA",33300,,,Micropolitan Statistical Area,,,Hancock County,Georgia,13,141,Outlying,,
+"Milwaukee-Waukesha, WI",33340,,376,Metropolitan Statistical Area,,"Milwaukee-Racine-Waukesha, WI",Milwaukee County,Wisconsin,55,079,Central,,
+"Milwaukee-Waukesha, WI",33340,,376,Metropolitan Statistical Area,,"Milwaukee-Racine-Waukesha, WI",Ozaukee County,Wisconsin,55,089,Central,,
+"Milwaukee-Waukesha, WI",33340,,376,Metropolitan Statistical Area,,"Milwaukee-Racine-Waukesha, WI",Washington County,Wisconsin,55,131,Outlying,,
+"Milwaukee-Waukesha, WI",33340,,376,Metropolitan Statistical Area,,"Milwaukee-Racine-Waukesha, WI",Waukesha County,Wisconsin,55,133,Central,,
+"Minden, LA",33380,,508,Micropolitan Statistical Area,,"Shreveport-Bossier City-Minden, LA",Webster Parish,Louisiana,22,119,Central,,
+"Mineral Wells, TX",33420,,206,Micropolitan Statistical Area,,"Dallas-Fort Worth, TX-OK",Palo Pinto County,Texas,48,363,Central,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Anoka County,Minnesota,27,003,Central,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Carver County,Minnesota,27,019,Central,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Chisago County,Minnesota,27,025,Outlying,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Dakota County,Minnesota,27,037,Central,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Hennepin County,Minnesota,27,053,Central,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Isanti County,Minnesota,27,059,Outlying,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Le Sueur County,Minnesota,27,079,Outlying,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Mille Lacs County,Minnesota,27,095,Outlying,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Ramsey County,Minnesota,27,123,Central,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Scott County,Minnesota,27,139,Central,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Sherburne County,Minnesota,27,141,Central,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Washington County,Minnesota,27,163,Central,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Wright County,Minnesota,27,171,Central,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Pierce County,Wisconsin,55,093,Outlying,,
+"Minneapolis-St. Paul-Bloomington, MN-WI",33460,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",St. Croix County,Wisconsin,55,109,Outlying,,
+"Minot, ND",33500,,,Micropolitan Statistical Area,,,McHenry County,North Dakota,38,049,Outlying,,
+"Minot, ND",33500,,,Micropolitan Statistical Area,,,Renville County,North Dakota,38,075,Outlying,,
+"Minot, ND",33500,,,Micropolitan Statistical Area,,,Ward County,North Dakota,38,101,Central,,
+"Missoula, MT",33540,,,Metropolitan Statistical Area,,,Missoula County,Montana,30,063,Central,,
+"Mitchell, SD",33580,,,Micropolitan Statistical Area,,,Davison County,South Dakota,46,035,Central,,
+"Mitchell, SD",33580,,,Micropolitan Statistical Area,,,Hanson County,South Dakota,46,061,Outlying,,
+"Moberly, MO",33620,,190,Micropolitan Statistical Area,,"Columbia-Moberly-Mexico, MO",Randolph County,Missouri,29,175,Central,,
+"Mobile, AL",33660,,380,Metropolitan Statistical Area,,"Mobile-Daphne-Fairhope, AL",Mobile County,Alabama,01,097,Central,,
+"Mobile, AL",33660,,380,Metropolitan Statistical Area,,"Mobile-Daphne-Fairhope, AL",Washington County,Alabama,01,129,Outlying,,
+"Modesto, CA",33700,,488,Metropolitan Statistical Area,,"San Jose-San Francisco-Oakland, CA",Stanislaus County,California,06,099,Central,,
+"Monroe, LA",33740,,384,Metropolitan Statistical Area,,"Monroe-Ruston, LA",Morehouse Parish,Louisiana,22,067,Outlying,,
+"Monroe, LA",33740,,384,Metropolitan Statistical Area,,"Monroe-Ruston, LA",Ouachita Parish,Louisiana,22,073,Central,,
+"Monroe, LA",33740,,384,Metropolitan Statistical Area,,"Monroe-Ruston, LA",Union Parish,Louisiana,22,111,Outlying,,
+"Monroe, MI",33780,,220,Metropolitan Statistical Area,,"Detroit-Warren-Ann Arbor, MI",Monroe County,Michigan,26,115,Central,,
+"Montgomery, AL",33860,,388,Metropolitan Statistical Area,,"Montgomery-Selma-Alexander City, AL",Autauga County,Alabama,01,001,Central,,
+"Montgomery, AL",33860,,388,Metropolitan Statistical Area,,"Montgomery-Selma-Alexander City, AL",Elmore County,Alabama,01,051,Central,,
+"Montgomery, AL",33860,,388,Metropolitan Statistical Area,,"Montgomery-Selma-Alexander City, AL",Lowndes County,Alabama,01,085,Outlying,,
+"Montgomery, AL",33860,,388,Metropolitan Statistical Area,,"Montgomery-Selma-Alexander City, AL",Montgomery County,Alabama,01,101,Central,,
+"Montrose, CO",33940,,,Micropolitan Statistical Area,,,Montrose County,Colorado,08,085,Central,,
+"Montrose, CO",33940,,,Micropolitan Statistical Area,,,Ouray County,Colorado,08,091,Outlying,,
+"Morehead City, NC",33980,,404,Micropolitan Statistical Area,,"New Bern-Morehead City, NC",Carteret County,North Carolina,37,031,Central,,
+"Morgan City, LA",34020,,318,Micropolitan Statistical Area,,"Lafayette-Opelousas-Morgan City, LA",St. Mary Parish,Louisiana,22,101,Central,,
+"Morgantown, WV",34060,,390,Metropolitan Statistical Area,,"Morgantown-Fairmont, WV",Monongalia County,West Virginia,54,061,Central,,
+"Morgantown, WV",34060,,390,Metropolitan Statistical Area,,"Morgantown-Fairmont, WV",Preston County,West Virginia,54,077,Outlying,,
+"Morristown, TN",34100,,315,Metropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Grainger County,Tennessee,47,057,Outlying,,
+"Morristown, TN",34100,,315,Metropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Hamblen County,Tennessee,47,063,Central,,
+"Morristown, TN",34100,,315,Metropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Jefferson County,Tennessee,47,089,Central,,
+"Moscow, ID",34140,,446,Micropolitan Statistical Area,,"Pullman-Moscow, WA-ID",Latah County,Idaho,16,057,Central,,
+"Moses Lake, WA",34180,,393,Micropolitan Statistical Area,,"Moses Lake-Othello, WA",Grant County,Washington,53,025,Central,,
+"Moultrie, GA",34220,,,Micropolitan Statistical Area,,,Colquitt County,Georgia,13,071,Central,,
+"Mountain Home, AR",34260,,,Micropolitan Statistical Area,,,Baxter County,Arkansas,05,005,Central,,
+"Mountain Home, ID",34300,,147,Micropolitan Statistical Area,,"Boise City-Mountain Home-Ontario, ID-OR",Elmore County,Idaho,16,039,Central,,
+"Mount Airy, NC",34340,,268,Micropolitan Statistical Area,,"Greensboro--Winston-Salem--High Point, NC",Surry County,North Carolina,37,171,Central,,
+"Mount Gay-Shamrock, WV",34350,,170,Micropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Logan County,West Virginia,54,045,Central,,
+"Mount Pleasant, MI",34380,,394,Micropolitan Statistical Area,,"Mount Pleasant-Alma, MI",Isabella County,Michigan,26,073,Central,,
+"Mount Pleasant, TX",34420,,,Micropolitan Statistical Area,,,Camp County,Texas,48,063,Outlying,,
+"Mount Pleasant, TX",34420,,,Micropolitan Statistical Area,,,Titus County,Texas,48,449,Central,,
+"Mount Sterling, KY",34460,,336,Micropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Bath County,Kentucky,21,011,Outlying,,
+"Mount Sterling, KY",34460,,336,Micropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Menifee County,Kentucky,21,165,Outlying,,
+"Mount Sterling, KY",34460,,336,Micropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Montgomery County,Kentucky,21,173,Central,,
+"Mount Vernon, IL",34500,,,Micropolitan Statistical Area,,,Jefferson County,Illinois,17,081,Central,,
+"Mount Vernon, OH",34540,,198,Micropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Knox County,Ohio,39,083,Central,,
+"Mount Vernon-Anacortes, WA",34580,,500,Metropolitan Statistical Area,,"Seattle-Tacoma, WA",Skagit County,Washington,53,057,Central,,
+"Muncie, IN",34620,,294,Metropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Delaware County,Indiana,18,035,Central,,
+"Murray, KY",34660,,,Micropolitan Statistical Area,,,Calloway County,Kentucky,21,035,Central,,
+"Muscatine, IA",34700,,209,Micropolitan Statistical Area,,"Davenport-Moline, IA-IL",Muscatine County,Iowa,19,139,Central,,
+"Muskegon, MI",34740,,266,Metropolitan Statistical Area,,"Grand Rapids-Kentwood-Muskegon, MI",Muskegon County,Michigan,26,121,Central,,
+"Muskogee, OK",34780,,538,Micropolitan Statistical Area,,"Tulsa-Muskogee-Bartlesville, OK",Muskogee County,Oklahoma,40,101,Central,,
+"Myrtle Beach-Conway-North Myrtle Beach, SC-NC",34820,,396,Metropolitan Statistical Area,,"Myrtle Beach-Conway, SC-NC",Brunswick County,North Carolina,37,019,Central,,
+"Myrtle Beach-Conway-North Myrtle Beach, SC-NC",34820,,396,Metropolitan Statistical Area,,"Myrtle Beach-Conway, SC-NC",Horry County,South Carolina,45,051,Central,,
+"Nacogdoches, TX",34860,,,Micropolitan Statistical Area,,,Nacogdoches County,Texas,48,347,Central,,
+"Napa, CA",34900,,488,Metropolitan Statistical Area,,"San Jose-San Francisco-Oakland, CA",Napa County,California,06,055,Central,,
+"Naples-Marco Island, FL",34940,,163,Metropolitan Statistical Area,,"Cape Coral-Fort Myers-Naples, FL",Collier County,Florida,12,021,Central,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Cannon County,Tennessee,47,015,Outlying,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Cheatham County,Tennessee,47,021,Outlying,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Davidson County,Tennessee,47,037,Central,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Dickson County,Tennessee,47,043,Outlying,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Macon County,Tennessee,47,111,Outlying,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Maury County,Tennessee,47,119,Outlying,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Robertson County,Tennessee,47,147,Outlying,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Rutherford County,Tennessee,47,149,Outlying,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Smith County,Tennessee,47,159,Outlying,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Sumner County,Tennessee,47,165,Central,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Trousdale County,Tennessee,47,169,Outlying,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Williamson County,Tennessee,47,187,Central,,
+"Nashville-Davidson--Murfreesboro--Franklin, TN",34980,,400,Metropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Wilson County,Tennessee,47,189,Central,,
+"Natchez, MS-LA",35020,,,Micropolitan Statistical Area,,,Concordia Parish,Louisiana,22,029,Central,,
+"Natchez, MS-LA",35020,,,Micropolitan Statistical Area,,,Adams County,Mississippi,28,001,Central,,
+"Natchitoches, LA",35060,,,Micropolitan Statistical Area,,,Natchitoches Parish,Louisiana,22,069,Central,,
+"New Bern, NC",35100,,404,Metropolitan Statistical Area,,"New Bern-Morehead City, NC",Craven County,North Carolina,37,049,Central,,
+"New Bern, NC",35100,,404,Metropolitan Statistical Area,,"New Bern-Morehead City, NC",Jones County,North Carolina,37,103,Outlying,,
+"New Bern, NC",35100,,404,Metropolitan Statistical Area,,"New Bern-Morehead City, NC",Pamlico County,North Carolina,37,137,Outlying,,
+"Newberry, SC",35140,,192,Micropolitan Statistical Area,,"Columbia-Orangeburg-Newberry, SC",Newberry County,South Carolina,45,071,Central,,
+"New Castle, IN",35220,,294,Micropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Henry County,Indiana,18,065,Central,,
+"New Castle, PA",35260,,430,Micropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Lawrence County,Pennsylvania,42,073,Central,,
+"New Haven-Milford, CT",35300,,408,Metropolitan Statistical Area,,"New York-Newark, NY-NJ-CT-PA",New Haven County,Connecticut,09,009,Central,,
+"New Orleans-Metairie, LA",35380,,406,Metropolitan Statistical Area,,"New Orleans-Metairie-Hammond, LA-MS",Jefferson Parish,Louisiana,22,051,Central,,
+"New Orleans-Metairie, LA",35380,,406,Metropolitan Statistical Area,,"New Orleans-Metairie-Hammond, LA-MS",Orleans Parish,Louisiana,22,071,Central,,
+"New Orleans-Metairie, LA",35380,,406,Metropolitan Statistical Area,,"New Orleans-Metairie-Hammond, LA-MS",Plaquemines Parish,Louisiana,22,075,Central,,
+"New Orleans-Metairie, LA",35380,,406,Metropolitan Statistical Area,,"New Orleans-Metairie-Hammond, LA-MS",St. Bernard Parish,Louisiana,22,087,Central,,
+"New Orleans-Metairie, LA",35380,,406,Metropolitan Statistical Area,,"New Orleans-Metairie-Hammond, LA-MS",St. Charles Parish,Louisiana,22,089,Central,,
+"New Orleans-Metairie, LA",35380,,406,Metropolitan Statistical Area,,"New Orleans-Metairie-Hammond, LA-MS",St. James Parish,Louisiana,22,093,Outlying,,
+"New Orleans-Metairie, LA",35380,,406,Metropolitan Statistical Area,,"New Orleans-Metairie-Hammond, LA-MS",St. John the Baptist Parish,Louisiana,22,095,Central,,
+"New Orleans-Metairie, LA",35380,,406,Metropolitan Statistical Area,,"New Orleans-Metairie-Hammond, LA-MS",St. Tammany Parish,Louisiana,22,103,Outlying,,
+"New Philadelphia-Dover, OH",35420,,184,Micropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Tuscarawas County,Ohio,39,157,Central,,
+"Newport, OR",35440,,,Micropolitan Statistical Area,,,Lincoln County,Oregon,41,041,Central,,
+"Newport, TN",35460,,315,Micropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Cocke County,Tennessee,47,029,Central,,
+"New Ulm, MN",35580,,359,Micropolitan Statistical Area,,"Mankato-New Ulm, MN",Brown County,Minnesota,27,015,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35004,408,Metropolitan Statistical Area,"Nassau County-Suffolk County, NY","New York-Newark, NY-NJ-CT-PA",Nassau County,New York,36,059,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35004,408,Metropolitan Statistical Area,"Nassau County-Suffolk County, NY","New York-Newark, NY-NJ-CT-PA",Suffolk County,New York,36,103,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,Metropolitan Statistical Area,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Essex County,New Jersey,34,013,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,Metropolitan Statistical Area,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Hunterdon County,New Jersey,34,019,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,Metropolitan Statistical Area,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Morris County,New Jersey,34,027,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,Metropolitan Statistical Area,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Sussex County,New Jersey,34,037,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,Metropolitan Statistical Area,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Union County,New Jersey,34,039,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35084,408,Metropolitan Statistical Area,"Newark, NJ-PA","New York-Newark, NY-NJ-CT-PA",Pike County,Pennsylvania,42,103,Outlying,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35154,408,Metropolitan Statistical Area,"New Brunswick-Lakewood, NJ","New York-Newark, NY-NJ-CT-PA",Middlesex County,New Jersey,34,023,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35154,408,Metropolitan Statistical Area,"New Brunswick-Lakewood, NJ","New York-Newark, NY-NJ-CT-PA",Monmouth County,New Jersey,34,025,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35154,408,Metropolitan Statistical Area,"New Brunswick-Lakewood, NJ","New York-Newark, NY-NJ-CT-PA",Ocean County,New Jersey,34,029,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35154,408,Metropolitan Statistical Area,"New Brunswick-Lakewood, NJ","New York-Newark, NY-NJ-CT-PA",Somerset County,New Jersey,34,035,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,Metropolitan Statistical Area,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Bergen County,New Jersey,34,003,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,Metropolitan Statistical Area,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Hudson County,New Jersey,34,017,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,Metropolitan Statistical Area,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Passaic County,New Jersey,34,031,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,Metropolitan Statistical Area,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Bronx County,New York,36,005,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,Metropolitan Statistical Area,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Kings County,New York,36,047,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,Metropolitan Statistical Area,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",New York County,New York,36,061,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,Metropolitan Statistical Area,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Putnam County,New York,36,079,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,Metropolitan Statistical Area,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Queens County,New York,36,081,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,Metropolitan Statistical Area,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Richmond County,New York,36,085,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,Metropolitan Statistical Area,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Rockland County,New York,36,087,Central,,
+"New York-Newark-Jersey City, NY-NJ-PA",35620,35614,408,Metropolitan Statistical Area,"New York-Jersey City-White Plains, NY-NJ","New York-Newark, NY-NJ-CT-PA",Westchester County,New York,36,119,Central,,
+"Niles, MI",35660,,515,Metropolitan Statistical Area,,"South Bend-Elkhart-Mishawaka, IN-MI",Berrien County,Michigan,26,021,Central,,
+"Nogales, AZ",35700,,536,Micropolitan Statistical Area,,"Tucson-Nogales, AZ",Santa Cruz County,Arizona,04,023,Central,,
+"Norfolk, NE",35740,,,Micropolitan Statistical Area,,,Madison County,Nebraska,31,119,Central,,
+"Norfolk, NE",35740,,,Micropolitan Statistical Area,,,Pierce County,Nebraska,31,139,Outlying,,
+"Norfolk, NE",35740,,,Micropolitan Statistical Area,,,Stanton County,Nebraska,31,167,Outlying,,
+"North Platte, NE",35820,,,Micropolitan Statistical Area,,,Lincoln County,Nebraska,31,111,Central,,
+"North Platte, NE",35820,,,Micropolitan Statistical Area,,,Logan County,Nebraska,31,113,Outlying,,
+"North Platte, NE",35820,,,Micropolitan Statistical Area,,,McPherson County,Nebraska,31,117,Outlying,,
+"North Port-Sarasota-Bradenton, FL",35840,,412,Metropolitan Statistical Area,,"North Port-Sarasota, FL",Manatee County,Florida,12,081,Central,,
+"North Port-Sarasota-Bradenton, FL",35840,,412,Metropolitan Statistical Area,,"North Port-Sarasota, FL",Sarasota County,Florida,12,115,Central,,
+"North Vernon, IN",35860,,294,Micropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Jennings County,Indiana,18,079,Central,,
+"North Wilkesboro, NC",35900,,,Micropolitan Statistical Area,,,Wilkes County,North Carolina,37,193,Central,,
+"Norwalk, OH",35940,,184,Micropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Huron County,Ohio,39,077,Central,,
+"Norwich-New London, CT",35980,,278,Metropolitan Statistical Area,,"Hartford-East Hartford, CT",New London County,Connecticut,09,011,Central,,
+"Oak Harbor, WA",36020,,500,Micropolitan Statistical Area,,"Seattle-Tacoma, WA",Island County,Washington,53,029,Central,,
+"Ocala, FL",36100,,,Metropolitan Statistical Area,,,Marion County,Florida,12,083,Central,,
+"Ocean City, NJ",36140,,428,Metropolitan Statistical Area,,"Philadelphia-Reading-Camden, PA-NJ-DE-MD",Cape May County,New Jersey,34,009,Central,,
+"Odessa, TX",36220,,372,Metropolitan Statistical Area,,"Midland-Odessa, TX",Ector County,Texas,48,135,Central,,
+"Ogden-Clearfield, UT",36260,,482,Metropolitan Statistical Area,,"Salt Lake City-Provo-Orem, UT",Box Elder County,Utah,49,003,Central,,
+"Ogden-Clearfield, UT",36260,,482,Metropolitan Statistical Area,,"Salt Lake City-Provo-Orem, UT",Davis County,Utah,49,011,Central,,
+"Ogden-Clearfield, UT",36260,,482,Metropolitan Statistical Area,,"Salt Lake City-Provo-Orem, UT",Morgan County,Utah,49,029,Outlying,,
+"Ogden-Clearfield, UT",36260,,482,Metropolitan Statistical Area,,"Salt Lake City-Provo-Orem, UT",Weber County,Utah,49,057,Central,,
+"Ogdensburg-Massena, NY",36300,,,Micropolitan Statistical Area,,,St. Lawrence County,New York,36,089,Central,,
+"Oil City, PA",36340,,,Micropolitan Statistical Area,,,Venango County,Pennsylvania,42,121,Central,,
+"Okeechobee, FL",36380,,,Micropolitan Statistical Area,,,Okeechobee County,Florida,12,093,Central,,
+"Oklahoma City, OK",36420,,416,Metropolitan Statistical Area,,"Oklahoma City-Shawnee, OK",Canadian County,Oklahoma,40,017,Central,,
+"Oklahoma City, OK",36420,,416,Metropolitan Statistical Area,,"Oklahoma City-Shawnee, OK",Cleveland County,Oklahoma,40,027,Central,,
+"Oklahoma City, OK",36420,,416,Metropolitan Statistical Area,,"Oklahoma City-Shawnee, OK",Grady County,Oklahoma,40,051,Outlying,,
+"Oklahoma City, OK",36420,,416,Metropolitan Statistical Area,,"Oklahoma City-Shawnee, OK",Lincoln County,Oklahoma,40,081,Outlying,,
+"Oklahoma City, OK",36420,,416,Metropolitan Statistical Area,,"Oklahoma City-Shawnee, OK",Logan County,Oklahoma,40,083,Central,,
+"Oklahoma City, OK",36420,,416,Metropolitan Statistical Area,,"Oklahoma City-Shawnee, OK",McClain County,Oklahoma,40,087,Outlying,,
+"Oklahoma City, OK",36420,,416,Metropolitan Statistical Area,,"Oklahoma City-Shawnee, OK",Oklahoma County,Oklahoma,40,109,Central,,
+"Olean, NY",36460,,160,Micropolitan Statistical Area,,"Buffalo-Cheektowaga-Olean, NY",Cattaraugus County,New York,36,009,Central,,
+"Olympia-Lacey-Tumwater, WA",36500,,500,Metropolitan Statistical Area,,"Seattle-Tacoma, WA",Thurston County,Washington,53,067,Central,,
+"Omaha-Council Bluffs, NE-IA",36540,,420,Metropolitan Statistical Area,,"Omaha-Council Bluffs-Fremont, NE-IA",Harrison County,Iowa,19,085,Outlying,,
+"Omaha-Council Bluffs, NE-IA",36540,,420,Metropolitan Statistical Area,,"Omaha-Council Bluffs-Fremont, NE-IA",Mills County,Iowa,19,129,Outlying,,
+"Omaha-Council Bluffs, NE-IA",36540,,420,Metropolitan Statistical Area,,"Omaha-Council Bluffs-Fremont, NE-IA",Pottawattamie County,Iowa,19,155,Central,,
+"Omaha-Council Bluffs, NE-IA",36540,,420,Metropolitan Statistical Area,,"Omaha-Council Bluffs-Fremont, NE-IA",Cass County,Nebraska,31,025,Outlying,,
+"Omaha-Council Bluffs, NE-IA",36540,,420,Metropolitan Statistical Area,,"Omaha-Council Bluffs-Fremont, NE-IA",Douglas County,Nebraska,31,055,Central,,
+"Omaha-Council Bluffs, NE-IA",36540,,420,Metropolitan Statistical Area,,"Omaha-Council Bluffs-Fremont, NE-IA",Sarpy County,Nebraska,31,153,Central,,
+"Omaha-Council Bluffs, NE-IA",36540,,420,Metropolitan Statistical Area,,"Omaha-Council Bluffs-Fremont, NE-IA",Saunders County,Nebraska,31,155,Outlying,,
+"Omaha-Council Bluffs, NE-IA",36540,,420,Metropolitan Statistical Area,,"Omaha-Council Bluffs-Fremont, NE-IA",Washington County,Nebraska,31,177,Outlying,,
+"Oneonta, NY",36580,,,Micropolitan Statistical Area,,,Otsego County,New York,36,077,Central,,
+"Ontario, OR-ID",36620,,147,Micropolitan Statistical Area,,"Boise City-Mountain Home-Ontario, ID-OR",Payette County,Idaho,16,075,Central,,
+"Ontario, OR-ID",36620,,147,Micropolitan Statistical Area,,"Boise City-Mountain Home-Ontario, ID-OR",Malheur County,Oregon,41,045,Central,,
+"Opelousas, LA",36660,,318,Micropolitan Statistical Area,,"Lafayette-Opelousas-Morgan City, LA",St. Landry Parish,Louisiana,22,097,Central,,
+"Orangeburg, SC",36700,,192,Micropolitan Statistical Area,,"Columbia-Orangeburg-Newberry, SC",Orangeburg County,South Carolina,45,075,Central,,
+"Orlando-Kissimmee-Sanford, FL",36740,,422,Metropolitan Statistical Area,,"Orlando-Lakeland-Deltona, FL",Lake County,Florida,12,069,Outlying,,
+"Orlando-Kissimmee-Sanford, FL",36740,,422,Metropolitan Statistical Area,,"Orlando-Lakeland-Deltona, FL",Orange County,Florida,12,095,Central,,
+"Orlando-Kissimmee-Sanford, FL",36740,,422,Metropolitan Statistical Area,,"Orlando-Lakeland-Deltona, FL",Osceola County,Florida,12,097,Outlying,,
+"Orlando-Kissimmee-Sanford, FL",36740,,422,Metropolitan Statistical Area,,"Orlando-Lakeland-Deltona, FL",Seminole County,Florida,12,117,Central,,
+"Oshkosh-Neenah, WI",36780,,118,Metropolitan Statistical Area,,"Appleton-Oshkosh-Neenah, WI",Winnebago County,Wisconsin,55,139,Central,,
+"Oskaloosa, IA",36820,,218,Micropolitan Statistical Area,,"Des Moines-Ames-West Des Moines, IA",Mahaska County,Iowa,19,123,Central,,
+"Othello, WA",36830,,393,Micropolitan Statistical Area,,"Moses Lake-Othello, WA",Adams County,Washington,53,001,Central,,
+"Ottawa, IL",36837,,176,Micropolitan Statistical Area,,"Chicago-Naperville, IL-IN-WI",Bureau County,Illinois,17,011,Central,,
+"Ottawa, IL",36837,,176,Micropolitan Statistical Area,,"Chicago-Naperville, IL-IN-WI",LaSalle County,Illinois,17,099,Central,,
+"Ottawa, IL",36837,,176,Micropolitan Statistical Area,,"Chicago-Naperville, IL-IN-WI",Putnam County,Illinois,17,155,Outlying,,
+"Ottawa, KS",36840,,312,Micropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Franklin County,Kansas,20,059,Central,,
+"Ottumwa, IA",36900,,,Micropolitan Statistical Area,,,Wapello County,Iowa,19,179,Central,,
+"Owatonna, MN",36940,,378,Micropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Steele County,Minnesota,27,147,Central,,
+"Owensboro, KY",36980,,,Metropolitan Statistical Area,,,Daviess County,Kentucky,21,059,Central,,
+"Owensboro, KY",36980,,,Metropolitan Statistical Area,,,Hancock County,Kentucky,21,091,Outlying,,
+"Owensboro, KY",36980,,,Metropolitan Statistical Area,,,McLean County,Kentucky,21,149,Outlying,,
+"Oxford, MS",37060,,,Micropolitan Statistical Area,,,Lafayette County,Mississippi,28,071,Central,,
+"Oxnard-Thousand Oaks-Ventura, CA",37100,,348,Metropolitan Statistical Area,,"Los Angeles-Long Beach, CA",Ventura County,California,06,111,Central,,
+"Ozark, AL",37120,,222,Micropolitan Statistical Area,,"Dothan-Ozark, AL",Dale County,Alabama,01,045,Central,,
+"Paducah, KY-IL",37140,,424,Micropolitan Statistical Area,,"Paducah-Mayfield, KY-IL",Massac County,Illinois,17,127,Outlying,,
+"Paducah, KY-IL",37140,,424,Micropolitan Statistical Area,,"Paducah-Mayfield, KY-IL",Ballard County,Kentucky,21,007,Outlying,,
+"Paducah, KY-IL",37140,,424,Micropolitan Statistical Area,,"Paducah-Mayfield, KY-IL",Livingston County,Kentucky,21,139,Outlying,,
+"Paducah, KY-IL",37140,,424,Micropolitan Statistical Area,,"Paducah-Mayfield, KY-IL",McCracken County,Kentucky,21,145,Central,,
+"Pahrump, NV",37220,,332,Micropolitan Statistical Area,,"Las Vegas-Henderson, NV",Nye County,Nevada,32,023,Central,,
+"Palatka, FL",37260,,300,Micropolitan Statistical Area,,"Jacksonville-St. Marys-Palatka, FL-GA",Putnam County,Florida,12,107,Central,,
+"Palestine, TX",37300,,,Micropolitan Statistical Area,,,Anderson County,Texas,48,001,Central,,
+"Palm Bay-Melbourne-Titusville, FL",37340,,,Metropolitan Statistical Area,,,Brevard County,Florida,12,009,Central,,
+"Pampa, TX",37420,,108,Micropolitan Statistical Area,,"Amarillo-Pampa-Borger, TX",Gray County,Texas,48,179,Central,,
+"Pampa, TX",37420,,108,Micropolitan Statistical Area,,"Amarillo-Pampa-Borger, TX",Roberts County,Texas,48,393,Outlying,,
+"Panama City, FL",37460,,,Metropolitan Statistical Area,,,Bay County,Florida,12,005,Central,,
+"Paragould, AR",37500,,308,Micropolitan Statistical Area,,"Jonesboro-Paragould, AR",Greene County,Arkansas,05,055,Central,,
+"Paris, TN",37540,,,Micropolitan Statistical Area,,,Henry County,Tennessee,47,079,Central,,
+"Paris, TX",37580,,,Micropolitan Statistical Area,,,Lamar County,Texas,48,277,Central,,
+"Parkersburg-Vienna, WV",37620,,425,Metropolitan Statistical Area,,"Parkersburg-Marietta-Vienna, WV-OH",Wirt County,West Virginia,54,105,Outlying,,
+"Parkersburg-Vienna, WV",37620,,425,Metropolitan Statistical Area,,"Parkersburg-Marietta-Vienna, WV-OH",Wood County,West Virginia,54,107,Central,,
+"Parsons, KS",37660,,,Micropolitan Statistical Area,,,Labette County,Kansas,20,099,Central,,
+"Payson, AZ",37740,,429,Micropolitan Statistical Area,,"Phoenix-Mesa, AZ",Gila County,Arizona,04,007,Central,,
+"Pearsall, TX",37770,,484,Micropolitan Statistical Area,,"San Antonio-New Braunfels-Pearsall, TX",Frio County,Texas,48,163,Central,,
+"Pecos, TX",37780,,,Micropolitan Statistical Area,,,Loving County,Texas,48,301,Outlying,,
+"Pecos, TX",37780,,,Micropolitan Statistical Area,,,Reeves County,Texas,48,389,Central,,
+"Pella, IA",37800,,218,Micropolitan Statistical Area,,"Des Moines-Ames-West Des Moines, IA",Marion County,Iowa,19,125,Central,,
+"Pensacola-Ferry Pass-Brent, FL",37860,,426,Metropolitan Statistical Area,,"Pensacola-Ferry Pass, FL-AL",Escambia County,Florida,12,033,Central,,
+"Pensacola-Ferry Pass-Brent, FL",37860,,426,Metropolitan Statistical Area,,"Pensacola-Ferry Pass, FL-AL",Santa Rosa County,Florida,12,113,Central,,
+"Peoria, IL",37900,,,Metropolitan Statistical Area,,,Fulton County,Illinois,17,057,Outlying,,
+"Peoria, IL",37900,,,Metropolitan Statistical Area,,,Marshall County,Illinois,17,123,Outlying,,
+"Peoria, IL",37900,,,Metropolitan Statistical Area,,,Peoria County,Illinois,17,143,Central,,
+"Peoria, IL",37900,,,Metropolitan Statistical Area,,,Stark County,Illinois,17,175,Outlying,,
+"Peoria, IL",37900,,,Metropolitan Statistical Area,,,Tazewell County,Illinois,17,179,Central,,
+"Peoria, IL",37900,,,Metropolitan Statistical Area,,,Woodford County,Illinois,17,203,Central,,
+"Peru, IN",37940,,316,Micropolitan Statistical Area,,"Kokomo-Peru, IN",Miami County,Indiana,18,103,Central,,
+"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,15804,428,Metropolitan Statistical Area,"Camden, NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Burlington County,New Jersey,34,005,Central,,
+"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,15804,428,Metropolitan Statistical Area,"Camden, NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Camden County,New Jersey,34,007,Central,,
+"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,15804,428,Metropolitan Statistical Area,"Camden, NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Gloucester County,New Jersey,34,015,Central,,
+"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,33874,428,Metropolitan Statistical Area,"Montgomery County-Bucks County-Chester County, PA","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Bucks County,Pennsylvania,42,017,Central,,
+"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,33874,428,Metropolitan Statistical Area,"Montgomery County-Bucks County-Chester County, PA","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Chester County,Pennsylvania,42,029,Central,,
+"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,33874,428,Metropolitan Statistical Area,"Montgomery County-Bucks County-Chester County, PA","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Montgomery County,Pennsylvania,42,091,Central,,
+"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,37964,428,Metropolitan Statistical Area,"Philadelphia, PA","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Delaware County,Pennsylvania,42,045,Central,,
+"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,37964,428,Metropolitan Statistical Area,"Philadelphia, PA","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Philadelphia County,Pennsylvania,42,101,Central,,
+"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,48864,428,Metropolitan Statistical Area,"Wilmington, DE-MD-NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",New Castle County,Delaware,10,003,Central,,
+"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,48864,428,Metropolitan Statistical Area,"Wilmington, DE-MD-NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Cecil County,Maryland,24,015,Central,,
+"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD",37980,48864,428,Metropolitan Statistical Area,"Wilmington, DE-MD-NJ","Philadelphia-Reading-Camden, PA-NJ-DE-MD",Salem County,New Jersey,34,033,Central,,
+"Phoenix-Mesa-Chandler, AZ",38060,,429,Metropolitan Statistical Area,,"Phoenix-Mesa, AZ",Maricopa County,Arizona,04,013,Central,,
+"Phoenix-Mesa-Chandler, AZ",38060,,429,Metropolitan Statistical Area,,"Phoenix-Mesa, AZ",Pinal County,Arizona,04,021,Central,,
+"Picayune, MS",38100,,406,Micropolitan Statistical Area,,"New Orleans-Metairie-Hammond, LA-MS",Pearl River County,Mississippi,28,109,Central,,
+"Pierre, SD",38180,,,Micropolitan Statistical Area,,,Hughes County,South Dakota,46,065,Central,,
+"Pierre, SD",38180,,,Micropolitan Statistical Area,,,Stanley County,South Dakota,46,117,Central,,
+"Pine Bluff, AR",38220,,340,Metropolitan Statistical Area,,"Little Rock-North Little Rock, AR",Cleveland County,Arkansas,05,025,Outlying,,
+"Pine Bluff, AR",38220,,340,Metropolitan Statistical Area,,"Little Rock-North Little Rock, AR",Jefferson County,Arkansas,05,069,Central,,
+"Pine Bluff, AR",38220,,340,Metropolitan Statistical Area,,"Little Rock-North Little Rock, AR",Lincoln County,Arkansas,05,079,Outlying,,
+"Pinehurst-Southern Pines, NC",38240,,246,Micropolitan Statistical Area,,"Fayetteville-Sanford-Lumberton, NC",Moore County,North Carolina,37,125,Central,,
+"Pittsburg, KS",38260,,,Micropolitan Statistical Area,,,Crawford County,Kansas,20,037,Central,,
+"Pittsburgh, PA",38300,,430,Metropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Allegheny County,Pennsylvania,42,003,Central,,
+"Pittsburgh, PA",38300,,430,Metropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Armstrong County,Pennsylvania,42,005,Outlying,,
+"Pittsburgh, PA",38300,,430,Metropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Beaver County,Pennsylvania,42,007,Central,,
+"Pittsburgh, PA",38300,,430,Metropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Butler County,Pennsylvania,42,019,Central,,
+"Pittsburgh, PA",38300,,430,Metropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Fayette County,Pennsylvania,42,051,Outlying,,
+"Pittsburgh, PA",38300,,430,Metropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Washington County,Pennsylvania,42,125,Central,,
+"Pittsburgh, PA",38300,,430,Metropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Westmoreland County,Pennsylvania,42,129,Central,,
+"Pittsfield, MA",38340,,,Metropolitan Statistical Area,,,Berkshire County,Massachusetts,25,003,Central,,
+"Plainview, TX",38380,,352,Micropolitan Statistical Area,,"Lubbock-Plainview-Levelland, TX",Hale County,Texas,48,189,Central,,
+"Platteville, WI",38420,,,Micropolitan Statistical Area,,,Grant County,Wisconsin,55,043,Central,,
+"Plattsburgh, NY",38460,,,Micropolitan Statistical Area,,,Clinton County,New York,36,019,Central,,
+"Plymouth, IN",38500,,515,Micropolitan Statistical Area,,"South Bend-Elkhart-Mishawaka, IN-MI",Marshall County,Indiana,18,099,Central,,
+"Pocatello, ID",38540,,,Metropolitan Statistical Area,,,Bannock County,Idaho,16,005,Central,,
+"Pocatello, ID",38540,,,Metropolitan Statistical Area,,,Power County,Idaho,16,077,Outlying,,
+"Point Pleasant, WV-OH",38580,,170,Micropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Gallia County,Ohio,39,053,Central,,
+"Point Pleasant, WV-OH",38580,,170,Micropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Mason County,West Virginia,54,053,Central,,
+"Ponca City, OK",38620,,,Micropolitan Statistical Area,,,Kay County,Oklahoma,40,071,Central,,
+"Ponce, PR",38660,,434,Metropolitan Statistical Area,,"Ponce-Yauco-Coamo, PR",Adjuntas Municipio,Puerto Rico,72,001,Outlying,,
+"Ponce, PR",38660,,434,Metropolitan Statistical Area,,"Ponce-Yauco-Coamo, PR",Juana D�az Municipio,Puerto Rico,72,075,Outlying,,
+"Ponce, PR",38660,,434,Metropolitan Statistical Area,,"Ponce-Yauco-Coamo, PR",Ponce Municipio,Puerto Rico,72,113,Central,,
+"Ponce, PR",38660,,434,Metropolitan Statistical Area,,"Ponce-Yauco-Coamo, PR",Villalba Municipio,Puerto Rico,72,149,Outlying,,
+"Pontiac, IL",38700,,145,Micropolitan Statistical Area,,"Bloomington-Pontiac, IL",Livingston County,Illinois,17,105,Central,,
+"Poplar Bluff, MO",38740,,,Micropolitan Statistical Area,,,Butler County,Missouri,29,023,Central,,
+"Poplar Bluff, MO",38740,,,Micropolitan Statistical Area,,,Ripley County,Missouri,29,181,Outlying,,
+"Portales, NM",38780,,188,Micropolitan Statistical Area,,"Clovis-Portales, NM",Roosevelt County,New Mexico,35,041,Central,,
+"Port Angeles, WA",38820,,,Micropolitan Statistical Area,,,Clallam County,Washington,53,009,Central,,
+"Portland-South Portland, ME",38860,,438,Metropolitan Statistical Area,,"Portland-Lewiston-South Portland, ME",Cumberland County,Maine,23,005,Central,,
+"Portland-South Portland, ME",38860,,438,Metropolitan Statistical Area,,"Portland-Lewiston-South Portland, ME",Sagadahoc County,Maine,23,023,Outlying,,
+"Portland-South Portland, ME",38860,,438,Metropolitan Statistical Area,,"Portland-Lewiston-South Portland, ME",York County,Maine,23,031,Central,,
+"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Clackamas County,Oregon,41,005,Central,,
+"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Columbia County,Oregon,41,009,Outlying,,
+"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Multnomah County,Oregon,41,051,Central,,
+"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Washington County,Oregon,41,067,Central,,
+"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Yamhill County,Oregon,41,071,Outlying,,
+"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Clark County,Washington,53,011,Central,,
+"Portland-Vancouver-Hillsboro, OR-WA",38900,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Skamania County,Washington,53,059,Outlying,,
+"Port Lavaca, TX",38920,,544,Micropolitan Statistical Area,,"Victoria-Port Lavaca, TX",Calhoun County,Texas,48,057,Central,,
+"Port St. Lucie, FL",38940,,370,Metropolitan Statistical Area,,"Miami-Port St. Lucie-Fort Lauderdale, FL",Martin County,Florida,12,085,Central,,
+"Port St. Lucie, FL",38940,,370,Metropolitan Statistical Area,,"Miami-Port St. Lucie-Fort Lauderdale, FL",St. Lucie County,Florida,12,111,Central,,
+"Portsmouth, OH",39020,,170,Micropolitan Statistical Area,,"Charleston-Huntington-Ashland, WV-OH-KY",Scioto County,Ohio,39,145,Central,,
+"Pottsville, PA",39060,,,Micropolitan Statistical Area,,,Schuylkill County,Pennsylvania,42,107,Central,,
+"Poughkeepsie-Newburgh-Middletown, NY",39100,,408,Metropolitan Statistical Area,,"New York-Newark, NY-NJ-CT-PA",Dutchess County,New York,36,027,Central,,
+"Poughkeepsie-Newburgh-Middletown, NY",39100,,408,Metropolitan Statistical Area,,"New York-Newark, NY-NJ-CT-PA",Orange County,New York,36,071,Central,,
+"Prescott Valley-Prescott, AZ",39150,,,Metropolitan Statistical Area,,,Yavapai County,Arizona,04,025,Central,,
+"Price, UT",39220,,,Micropolitan Statistical Area,,,Carbon County,Utah,49,007,Central,,
+"Prineville, OR",39260,,140,Micropolitan Statistical Area,,"Bend-Prineville, OR",Crook County,Oregon,41,013,Central,,
+"Providence-Warwick, RI-MA",39300,,148,Metropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Bristol County,Massachusetts,25,005,Central,,
+"Providence-Warwick, RI-MA",39300,,148,Metropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Bristol County,Rhode Island,44,001,Central,,
+"Providence-Warwick, RI-MA",39300,,148,Metropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Kent County,Rhode Island,44,003,Central,,
+"Providence-Warwick, RI-MA",39300,,148,Metropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Newport County,Rhode Island,44,005,Central,,
+"Providence-Warwick, RI-MA",39300,,148,Metropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Providence County,Rhode Island,44,007,Central,,
+"Providence-Warwick, RI-MA",39300,,148,Metropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Washington County,Rhode Island,44,009,Central,,
+"Provo-Orem, UT",39340,,482,Metropolitan Statistical Area,,"Salt Lake City-Provo-Orem, UT",Juab County,Utah,49,023,Outlying,,
+"Provo-Orem, UT",39340,,482,Metropolitan Statistical Area,,"Salt Lake City-Provo-Orem, UT",Utah County,Utah,49,049,Central,,
+"Pueblo, CO",39380,,444,Metropolitan Statistical Area,,"Pueblo-Ca�on City, CO",Pueblo County,Colorado,08,101,Central,,
+"Pullman, WA",39420,,446,Micropolitan Statistical Area,,"Pullman-Moscow, WA-ID",Whitman County,Washington,53,075,Central,,
+"Punta Gorda, FL",39460,,412,Metropolitan Statistical Area,,"North Port-Sarasota, FL",Charlotte County,Florida,12,015,Central,,
+"Quincy, IL-MO",39500,,448,Micropolitan Statistical Area,,"Quincy-Hannibal, IL-MO",Adams County,Illinois,17,001,Central,,
+"Quincy, IL-MO",39500,,448,Micropolitan Statistical Area,,"Quincy-Hannibal, IL-MO",Lewis County,Missouri,29,111,Outlying,,
+"Racine, WI",39540,,376,Metropolitan Statistical Area,,"Milwaukee-Racine-Waukesha, WI",Racine County,Wisconsin,55,101,Central,,
+"Raleigh-Cary, NC",39580,,450,Metropolitan Statistical Area,,"Raleigh-Durham-Cary, NC",Franklin County,North Carolina,37,069,Outlying,,
+"Raleigh-Cary, NC",39580,,450,Metropolitan Statistical Area,,"Raleigh-Durham-Cary, NC",Johnston County,North Carolina,37,101,Central,,
+"Raleigh-Cary, NC",39580,,450,Metropolitan Statistical Area,,"Raleigh-Durham-Cary, NC",Wake County,North Carolina,37,183,Central,,
+"Rapid City, SD",39660,,452,Metropolitan Statistical Area,,"Rapid City-Spearfish, SD",Meade County,South Dakota,46,093,Central,,
+"Rapid City, SD",39660,,452,Metropolitan Statistical Area,,"Rapid City-Spearfish, SD",Pennington County,South Dakota,46,103,Central,,
+"Raymondville, TX",39700,,154,Micropolitan Statistical Area,,"Brownsville-Harlingen-Raymondville, TX",Willacy County,Texas,48,489,Central,,
+"Reading, PA",39740,,428,Metropolitan Statistical Area,,"Philadelphia-Reading-Camden, PA-NJ-DE-MD",Berks County,Pennsylvania,42,011,Central,,
+"Red Bluff, CA",39780,,454,Micropolitan Statistical Area,,"Redding-Red Bluff, CA",Tehama County,California,06,103,Central,,
+"Redding, CA",39820,,454,Metropolitan Statistical Area,,"Redding-Red Bluff, CA",Shasta County,California,06,089,Central,,
+"Red Wing, MN",39860,,378,Micropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Goodhue County,Minnesota,27,049,Central,,
+"Reno, NV",39900,,456,Metropolitan Statistical Area,,"Reno-Carson City-Fernley, NV",Storey County,Nevada,32,029,Outlying,,
+"Reno, NV",39900,,456,Metropolitan Statistical Area,,"Reno-Carson City-Fernley, NV",Washoe County,Nevada,32,031,Central,,
+"Rexburg, ID",39940,,292,Micropolitan Statistical Area,,"Idaho Falls-Rexburg-Blackfoot, ID",Fremont County,Idaho,16,043,Outlying,,
+"Rexburg, ID",39940,,292,Micropolitan Statistical Area,,"Idaho Falls-Rexburg-Blackfoot, ID",Madison County,Idaho,16,065,Central,,
+"Richmond, IN",39980,,458,Micropolitan Statistical Area,,"Richmond-Connersville, IN",Wayne County,Indiana,18,177,Central,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Amelia County,Virginia,51,007,Outlying,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Charles City County,Virginia,51,036,Outlying,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Chesterfield County,Virginia,51,041,Central,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Dinwiddie County,Virginia,51,053,Central,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Goochland County,Virginia,51,075,Outlying,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Hanover County,Virginia,51,085,Central,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Henrico County,Virginia,51,087,Central,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,King and Queen County,Virginia,51,097,Outlying,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,King William County,Virginia,51,101,Outlying,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,New Kent County,Virginia,51,127,Outlying,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Powhatan County,Virginia,51,145,Outlying,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Prince George County,Virginia,51,149,Central,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Sussex County,Virginia,51,183,Outlying,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Colonial Heights city,Virginia,51,570,Central,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Hopewell city,Virginia,51,670,Central,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Petersburg city,Virginia,51,730,Central,,
+"Richmond, VA",40060,,,Metropolitan Statistical Area,,,Richmond city,Virginia,51,760,Central,,
+"Richmond-Berea, KY",40080,,336,Micropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Estill County,Kentucky,21,065,Outlying,,
+"Richmond-Berea, KY",40080,,336,Micropolitan Statistical Area,,"Lexington-Fayette--Richmond--Frankfort, KY",Madison County,Kentucky,21,151,Central,,
+"Rio Grande City-Roma, TX",40100,,365,Micropolitan Statistical Area,,"McAllen-Edinburg, TX",Starr County,Texas,48,427,Central,,
+"Riverside-San Bernardino-Ontario, CA",40140,,348,Metropolitan Statistical Area,,"Los Angeles-Long Beach, CA",Riverside County,California,06,065,Central,,
+"Riverside-San Bernardino-Ontario, CA",40140,,348,Metropolitan Statistical Area,,"Los Angeles-Long Beach, CA",San Bernardino County,California,06,071,Central,,
+"Riverton, WY",40180,,,Micropolitan Statistical Area,,,Fremont County,Wyoming,56,013,Central,,
+"Roanoke, VA",40220,,,Metropolitan Statistical Area,,,Botetourt County,Virginia,51,023,Central,,
+"Roanoke, VA",40220,,,Metropolitan Statistical Area,,,Craig County,Virginia,51,045,Outlying,,
+"Roanoke, VA",40220,,,Metropolitan Statistical Area,,,Franklin County,Virginia,51,067,Outlying,,
+"Roanoke, VA",40220,,,Metropolitan Statistical Area,,,Roanoke County,Virginia,51,161,Central,,
+"Roanoke, VA",40220,,,Metropolitan Statistical Area,,,Roanoke city,Virginia,51,770,Central,,
+"Roanoke, VA",40220,,,Metropolitan Statistical Area,,,Salem city,Virginia,51,775,Central,,
+"Roanoke Rapids, NC",40260,,468,Micropolitan Statistical Area,,"Rocky Mount-Wilson-Roanoke Rapids, NC",Halifax County,North Carolina,37,083,Central,,
+"Roanoke Rapids, NC",40260,,468,Micropolitan Statistical Area,,"Rocky Mount-Wilson-Roanoke Rapids, NC",Northampton County,North Carolina,37,131,Outlying,,
+"Rochelle, IL",40300,,466,Micropolitan Statistical Area,,"Rockford-Freeport-Rochelle, IL",Ogle County,Illinois,17,141,Central,,
+"Rochester, MN",40340,,462,Metropolitan Statistical Area,,"Rochester-Austin, MN",Dodge County,Minnesota,27,039,Outlying,,
+"Rochester, MN",40340,,462,Metropolitan Statistical Area,,"Rochester-Austin, MN",Fillmore County,Minnesota,27,045,Outlying,,
+"Rochester, MN",40340,,462,Metropolitan Statistical Area,,"Rochester-Austin, MN",Olmsted County,Minnesota,27,109,Central,,
+"Rochester, MN",40340,,462,Metropolitan Statistical Area,,"Rochester-Austin, MN",Wabasha County,Minnesota,27,157,Outlying,,
+"Rochester, NY",40380,,464,Metropolitan Statistical Area,,"Rochester-Batavia-Seneca Falls, NY",Livingston County,New York,36,051,Outlying,,
+"Rochester, NY",40380,,464,Metropolitan Statistical Area,,"Rochester-Batavia-Seneca Falls, NY",Monroe County,New York,36,055,Central,,
+"Rochester, NY",40380,,464,Metropolitan Statistical Area,,"Rochester-Batavia-Seneca Falls, NY",Ontario County,New York,36,069,Central,,
+"Rochester, NY",40380,,464,Metropolitan Statistical Area,,"Rochester-Batavia-Seneca Falls, NY",Orleans County,New York,36,073,Outlying,,
+"Rochester, NY",40380,,464,Metropolitan Statistical Area,,"Rochester-Batavia-Seneca Falls, NY",Wayne County,New York,36,117,Outlying,,
+"Rochester, NY",40380,,464,Metropolitan Statistical Area,,"Rochester-Batavia-Seneca Falls, NY",Yates County,New York,36,123,Outlying,,
+"Rockford, IL",40420,,466,Metropolitan Statistical Area,,"Rockford-Freeport-Rochelle, IL",Boone County,Illinois,17,007,Central,,
+"Rockford, IL",40420,,466,Metropolitan Statistical Area,,"Rockford-Freeport-Rochelle, IL",Winnebago County,Illinois,17,201,Central,,
+"Rockingham, NC",40460,,,Micropolitan Statistical Area,,,Richmond County,North Carolina,37,153,Central,,
+"Rockport, TX",40530,,204,Micropolitan Statistical Area,,"Corpus Christi-Kingsville-Alice, TX",Aransas County,Texas,48,007,Central,,
+"Rock Springs, WY",40540,,,Micropolitan Statistical Area,,,Sweetwater County,Wyoming,56,037,Central,,
+"Rocky Mount, NC",40580,,468,Metropolitan Statistical Area,,"Rocky Mount-Wilson-Roanoke Rapids, NC",Edgecombe County,North Carolina,37,065,Central,,
+"Rocky Mount, NC",40580,,468,Metropolitan Statistical Area,,"Rocky Mount-Wilson-Roanoke Rapids, NC",Nash County,North Carolina,37,127,Central,,
+"Rolla, MO",40620,,,Micropolitan Statistical Area,,,Phelps County,Missouri,29,161,Central,,
+"Rome, GA",40660,,122,Metropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Floyd County,Georgia,13,115,Central,,
+"Roseburg, OR",40700,,,Micropolitan Statistical Area,,,Douglas County,Oregon,41,019,Central,,
+"Roswell, NM",40740,,,Micropolitan Statistical Area,,,Chaves County,New Mexico,35,005,Central,,
+"Ruidoso, NM",40760,,,Micropolitan Statistical Area,,,Lincoln County,New Mexico,35,027,Central,,
+"Russellville, AR",40780,,,Micropolitan Statistical Area,,,Pope County,Arkansas,05,115,Central,,
+"Russellville, AR",40780,,,Micropolitan Statistical Area,,,Yell County,Arkansas,05,149,Outlying,,
+"Ruston, LA",40820,,384,Micropolitan Statistical Area,,"Monroe-Ruston, LA",Lincoln Parish,Louisiana,22,061,Central,,
+"Rutland, VT",40860,,,Micropolitan Statistical Area,,,Rutland County,Vermont,50,021,Central,,
+"Sacramento-Roseville-Folsom, CA",40900,,472,Metropolitan Statistical Area,,"Sacramento-Roseville, CA",El Dorado County,California,06,017,Central,,
+"Sacramento-Roseville-Folsom, CA",40900,,472,Metropolitan Statistical Area,,"Sacramento-Roseville, CA",Placer County,California,06,061,Central,,
+"Sacramento-Roseville-Folsom, CA",40900,,472,Metropolitan Statistical Area,,"Sacramento-Roseville, CA",Sacramento County,California,06,067,Central,,
+"Sacramento-Roseville-Folsom, CA",40900,,472,Metropolitan Statistical Area,,"Sacramento-Roseville, CA",Yolo County,California,06,113,Outlying,,
+"Safford, AZ",40940,,,Micropolitan Statistical Area,,,Graham County,Arizona,04,009,Central,,
+"Saginaw, MI",40980,,474,Metropolitan Statistical Area,,"Saginaw-Midland-Bay City, MI",Saginaw County,Michigan,26,145,Central,,
+"St. Cloud, MN",41060,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Benton County,Minnesota,27,009,Central,,
+"St. Cloud, MN",41060,,378,Metropolitan Statistical Area,,"Minneapolis-St. Paul, MN-WI",Stearns County,Minnesota,27,145,Central,,
+"St. George, UT",41100,,,Metropolitan Statistical Area,,,Washington County,Utah,49,053,Central,,
+"St. Joseph, MO-KS",41140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Doniphan County,Kansas,20,043,Outlying,,
+"St. Joseph, MO-KS",41140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Andrew County,Missouri,29,003,Outlying,,
+"St. Joseph, MO-KS",41140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Buchanan County,Missouri,29,021,Central,,
+"St. Joseph, MO-KS",41140,,312,Metropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",DeKalb County,Missouri,29,063,Outlying,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Bond County,Illinois,17,005,Outlying,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Calhoun County,Illinois,17,013,Outlying,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Clinton County,Illinois,17,027,Outlying,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Jersey County,Illinois,17,083,Outlying,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Macoupin County,Illinois,17,117,Outlying,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Madison County,Illinois,17,119,Central,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Monroe County,Illinois,17,133,Central,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",St. Clair County,Illinois,17,163,Central,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Franklin County,Missouri,29,071,Outlying,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Jefferson County,Missouri,29,099,Central,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Lincoln County,Missouri,29,113,Outlying,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",St. Charles County,Missouri,29,183,Central,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",St. Louis County,Missouri,29,189,Central,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",Warren County,Missouri,29,219,Outlying,,
+"St. Louis, MO-IL",41180,,476,Metropolitan Statistical Area,,"St. Louis-St. Charles-Farmington, MO-IL",St. Louis city,Missouri,29,510,Central,,
+"St. Marys, GA",41220,,300,Micropolitan Statistical Area,,"Jacksonville-St. Marys-Palatka, FL-GA",Camden County,Georgia,13,039,Central,,
+"St. Marys, PA",41260,,,Micropolitan Statistical Area,,,Elk County,Pennsylvania,42,047,Central,,
+"Salem, OH",41400,,566,Micropolitan Statistical Area,,"Youngstown-Warren, OH-PA",Columbiana County,Ohio,39,029,Central,,
+"Salem, OR",41420,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Marion County,Oregon,41,047,Central,,
+"Salem, OR",41420,,440,Metropolitan Statistical Area,,"Portland-Vancouver-Salem, OR-WA",Polk County,Oregon,41,053,Central,,
+"Salina, KS",41460,,,Micropolitan Statistical Area,,,Ottawa County,Kansas,20,143,Outlying,,
+"Salina, KS",41460,,,Micropolitan Statistical Area,,,Saline County,Kansas,20,169,Central,,
+"Salinas, CA",41500,,,Metropolitan Statistical Area,,,Monterey County,California,06,053,Central,,
+"Salisbury, MD-DE",41540,,480,Metropolitan Statistical Area,,"Salisbury-Cambridge, MD-DE",Sussex County,Delaware,10,005,Central,,
+"Salisbury, MD-DE",41540,,480,Metropolitan Statistical Area,,"Salisbury-Cambridge, MD-DE",Somerset County,Maryland,24,039,Outlying,,
+"Salisbury, MD-DE",41540,,480,Metropolitan Statistical Area,,"Salisbury-Cambridge, MD-DE",Wicomico County,Maryland,24,045,Central,,
+"Salisbury, MD-DE",41540,,480,Metropolitan Statistical Area,,"Salisbury-Cambridge, MD-DE",Worcester County,Maryland,24,047,Outlying,,
+"Salt Lake City, UT",41620,,482,Metropolitan Statistical Area,,"Salt Lake City-Provo-Orem, UT",Salt Lake County,Utah,49,035,Central,,
+"Salt Lake City, UT",41620,,482,Metropolitan Statistical Area,,"Salt Lake City-Provo-Orem, UT",Tooele County,Utah,49,045,Outlying,,
+"San Angelo, TX",41660,,,Metropolitan Statistical Area,,,Irion County,Texas,48,235,Outlying,,
+"San Angelo, TX",41660,,,Metropolitan Statistical Area,,,Sterling County,Texas,48,431,Outlying,,
+"San Angelo, TX",41660,,,Metropolitan Statistical Area,,,Tom Green County,Texas,48,451,Central,,
+"San Antonio-New Braunfels, TX",41700,,484,Metropolitan Statistical Area,,"San Antonio-New Braunfels-Pearsall, TX",Atascosa County,Texas,48,013,Outlying,,
+"San Antonio-New Braunfels, TX",41700,,484,Metropolitan Statistical Area,,"San Antonio-New Braunfels-Pearsall, TX",Bandera County,Texas,48,019,Outlying,,
+"San Antonio-New Braunfels, TX",41700,,484,Metropolitan Statistical Area,,"San Antonio-New Braunfels-Pearsall, TX",Bexar County,Texas,48,029,Central,,
+"San Antonio-New Braunfels, TX",41700,,484,Metropolitan Statistical Area,,"San Antonio-New Braunfels-Pearsall, TX",Comal County,Texas,48,091,Central,,
+"San Antonio-New Braunfels, TX",41700,,484,Metropolitan Statistical Area,,"San Antonio-New Braunfels-Pearsall, TX",Guadalupe County,Texas,48,187,Central,,
+"San Antonio-New Braunfels, TX",41700,,484,Metropolitan Statistical Area,,"San Antonio-New Braunfels-Pearsall, TX",Kendall County,Texas,48,259,Outlying,,
+"San Antonio-New Braunfels, TX",41700,,484,Metropolitan Statistical Area,,"San Antonio-New Braunfels-Pearsall, TX",Medina County,Texas,48,325,Outlying,,
+"San Antonio-New Braunfels, TX",41700,,484,Metropolitan Statistical Area,,"San Antonio-New Braunfels-Pearsall, TX",Wilson County,Texas,48,493,Outlying,,
+"San Diego-Chula Vista-Carlsbad, CA",41740,,,Metropolitan Statistical Area,,,San Diego County,California,06,073,Central,,
+"Sandpoint, ID",41760,,,Micropolitan Statistical Area,,,Bonner County,Idaho,16,017,Central,,
+"Sandusky, OH",41780,,184,Micropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Erie County,Ohio,39,043,Central,,
+"Sanford, NC",41820,,246,Micropolitan Statistical Area,,"Fayetteville-Sanford-Lumberton, NC",Lee County,North Carolina,37,105,Central,,
+"San Francisco-Oakland-Berkeley, CA",41860,36084,488,Metropolitan Statistical Area,"Oakland-Berkeley-Livermore, CA","San Jose-San Francisco-Oakland, CA",Alameda County,California,06,001,Central,,
+"San Francisco-Oakland-Berkeley, CA",41860,36084,488,Metropolitan Statistical Area,"Oakland-Berkeley-Livermore, CA","San Jose-San Francisco-Oakland, CA",Contra Costa County,California,06,013,Outlying,,
+"San Francisco-Oakland-Berkeley, CA",41860,41884,488,Metropolitan Statistical Area,"San Francisco-San Mateo-Redwood City, CA","San Jose-San Francisco-Oakland, CA",San Francisco County,California,06,075,Central,,
+"San Francisco-Oakland-Berkeley, CA",41860,41884,488,Metropolitan Statistical Area,"San Francisco-San Mateo-Redwood City, CA","San Jose-San Francisco-Oakland, CA",San Mateo County,California,06,081,Central,,
+"San Francisco-Oakland-Berkeley, CA",41860,42034,488,Metropolitan Statistical Area,"San Rafael, CA","San Jose-San Francisco-Oakland, CA",Marin County,California,06,041,Central,,
+"San Germ�n, PR",41900,,364,Metropolitan Statistical Area,,"Mayag�ez-San Germ�n, PR",Cabo Rojo Municipio,Puerto Rico,72,023,Central,,
+"San Germ�n, PR",41900,,364,Metropolitan Statistical Area,,"Mayag�ez-San Germ�n, PR",Lajas Municipio,Puerto Rico,72,079,Central,,
+"San Germ�n, PR",41900,,364,Metropolitan Statistical Area,,"Mayag�ez-San Germ�n, PR",Sabana Grande Municipio,Puerto Rico,72,121,Central,,
+"San Germ�n, PR",41900,,364,Metropolitan Statistical Area,,"Mayag�ez-San Germ�n, PR",San Germ�n Municipio,Puerto Rico,72,125,Central,,
+"San Jose-Sunnyvale-Santa Clara, CA",41940,,488,Metropolitan Statistical Area,,"San Jose-San Francisco-Oakland, CA",San Benito County,California,06,069,Outlying,,
+"San Jose-Sunnyvale-Santa Clara, CA",41940,,488,Metropolitan Statistical Area,,"San Jose-San Francisco-Oakland, CA",Santa Clara County,California,06,085,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Aguas Buenas Municipio,Puerto Rico,72,007,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Aibonito Municipio,Puerto Rico,72,009,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Barceloneta Municipio,Puerto Rico,72,017,Outlying,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Barranquitas Municipio,Puerto Rico,72,019,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Bayam�n Municipio,Puerto Rico,72,021,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Caguas Municipio,Puerto Rico,72,025,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Can�vanas Municipio,Puerto Rico,72,029,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Carolina Municipio,Puerto Rico,72,031,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Cata�o Municipio,Puerto Rico,72,033,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Cayey Municipio,Puerto Rico,72,035,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Ceiba Municipio,Puerto Rico,72,037,Outlying,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Ciales Municipio,Puerto Rico,72,039,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Cidra Municipio,Puerto Rico,72,041,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Comer�o Municipio,Puerto Rico,72,045,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Corozal Municipio,Puerto Rico,72,047,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Dorado Municipio,Puerto Rico,72,051,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Fajardo Municipio,Puerto Rico,72,053,Outlying,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Florida Municipio,Puerto Rico,72,054,Outlying,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Guaynabo Municipio,Puerto Rico,72,061,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Gurabo Municipio,Puerto Rico,72,063,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Humacao Municipio,Puerto Rico,72,069,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Juncos Municipio,Puerto Rico,72,077,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Las Piedras Municipio,Puerto Rico,72,085,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Lo�za Municipio,Puerto Rico,72,087,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Luquillo Municipio,Puerto Rico,72,089,Outlying,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Manat� Municipio,Puerto Rico,72,091,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Maunabo Municipio,Puerto Rico,72,095,Outlying,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Morovis Municipio,Puerto Rico,72,101,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Naguabo Municipio,Puerto Rico,72,103,Outlying,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Naranjito Municipio,Puerto Rico,72,105,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Orocovis Municipio,Puerto Rico,72,107,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",R�o Grande Municipio,Puerto Rico,72,119,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",San Juan Municipio,Puerto Rico,72,127,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",San Lorenzo Municipio,Puerto Rico,72,129,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Toa Alta Municipio,Puerto Rico,72,135,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Toa Baja Municipio,Puerto Rico,72,137,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Trujillo Alto Municipio,Puerto Rico,72,139,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Vega Alta Municipio,Puerto Rico,72,143,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Vega Baja Municipio,Puerto Rico,72,145,Central,,
+"San Juan-Bayam�n-Caguas, PR",41980,,490,Metropolitan Statistical Area,,"San Juan-Bayam�n, PR",Yabucoa Municipio,Puerto Rico,72,151,Central,,
+"San Luis Obispo-Paso Robles, CA",42020,,,Metropolitan Statistical Area,,,San Luis Obispo County,California,06,079,Central,,
+"Santa Cruz-Watsonville, CA",42100,,488,Metropolitan Statistical Area,,"San Jose-San Francisco-Oakland, CA",Santa Cruz County,California,06,087,Central,,
+"Santa Fe, NM",42140,,106,Metropolitan Statistical Area,,"Albuquerque-Santa Fe-Las Vegas, NM",Santa Fe County,New Mexico,35,049,Central,,
+"Santa Isabel, PR",42180,,434,Micropolitan Statistical Area,,"Ponce-Yauco-Coamo, PR",Santa Isabel Municipio,Puerto Rico,72,133,Central,,
+"Santa Maria-Santa Barbara, CA",42200,,,Metropolitan Statistical Area,,,Santa Barbara County,California,06,083,Central,,
+"Santa Rosa-Petaluma, CA",42220,,488,Metropolitan Statistical Area,,"San Jose-San Francisco-Oakland, CA",Sonoma County,California,06,097,Central,,
+"Sault Ste. Marie, MI",42300,,,Micropolitan Statistical Area,,,Chippewa County,Michigan,26,033,Central,,
+"Savannah, GA",42340,,496,Metropolitan Statistical Area,,"Savannah-Hinesville-Statesboro, GA",Bryan County,Georgia,13,029,Central,,
+"Savannah, GA",42340,,496,Metropolitan Statistical Area,,"Savannah-Hinesville-Statesboro, GA",Chatham County,Georgia,13,051,Central,,
+"Savannah, GA",42340,,496,Metropolitan Statistical Area,,"Savannah-Hinesville-Statesboro, GA",Effingham County,Georgia,13,103,Outlying,,
+"Sayre, PA",42380,,,Micropolitan Statistical Area,,,Bradford County,Pennsylvania,42,015,Central,,
+"Scottsbluff, NE",42420,,,Micropolitan Statistical Area,,,Banner County,Nebraska,31,007,Outlying,,
+"Scottsbluff, NE",42420,,,Micropolitan Statistical Area,,,Scotts Bluff County,Nebraska,31,157,Central,,
+"Scottsbluff, NE",42420,,,Micropolitan Statistical Area,,,Sioux County,Nebraska,31,165,Outlying,,
+"Scottsboro, AL",42460,,497,Micropolitan Statistical Area,,"Scottsboro-Fort Payne, AL",Jackson County,Alabama,01,071,Central,,
+"Scottsburg, IN",42500,,350,Micropolitan Statistical Area,,"Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",Scott County,Indiana,18,143,Central,,
+"Scranton--Wilkes-Barre, PA",42540,,,Metropolitan Statistical Area,,,Lackawanna County,Pennsylvania,42,069,Central,,
+"Scranton--Wilkes-Barre, PA",42540,,,Metropolitan Statistical Area,,,Luzerne County,Pennsylvania,42,079,Central,,
+"Scranton--Wilkes-Barre, PA",42540,,,Metropolitan Statistical Area,,,Wyoming County,Pennsylvania,42,131,Outlying,,
+"Searcy, AR",42620,,340,Micropolitan Statistical Area,,"Little Rock-North Little Rock, AR",White County,Arkansas,05,145,Central,,
+"Seattle-Tacoma-Bellevue, WA",42660,42644,500,Metropolitan Statistical Area,"Seattle-Bellevue-Kent, WA","Seattle-Tacoma, WA",King County,Washington,53,033,Central,,
+"Seattle-Tacoma-Bellevue, WA",42660,42644,500,Metropolitan Statistical Area,"Seattle-Bellevue-Kent, WA","Seattle-Tacoma, WA",Snohomish County,Washington,53,061,Central,,
+"Seattle-Tacoma-Bellevue, WA",42660,45104,500,Metropolitan Statistical Area,"Tacoma-Lakewood, WA","Seattle-Tacoma, WA",Pierce County,Washington,53,053,Central,,
+"Sebastian-Vero Beach, FL",42680,,370,Metropolitan Statistical Area,,"Miami-Port St. Lucie-Fort Lauderdale, FL",Indian River County,Florida,12,061,Central,,
+"Sebring-Avon Park, FL",42700,,,Metropolitan Statistical Area,,,Highlands County,Florida,12,055,Central,,
+"Sedalia, MO",42740,,,Micropolitan Statistical Area,,,Pettis County,Missouri,29,159,Central,,
+"Selinsgrove, PA",42780,,146,Micropolitan Statistical Area,,"Bloomsburg-Berwick-Sunbury, PA",Snyder County,Pennsylvania,42,109,Central,,
+"Selma, AL",42820,,388,Micropolitan Statistical Area,,"Montgomery-Selma-Alexander City, AL",Dallas County,Alabama,01,047,Central,,
+"Seneca, SC",42860,,273,Micropolitan Statistical Area,,"Greenville-Spartanburg-Anderson, SC",Oconee County,South Carolina,45,073,Central,,
+"Seneca Falls, NY",42900,,464,Micropolitan Statistical Area,,"Rochester-Batavia-Seneca Falls, NY",Seneca County,New York,36,099,Central,,
+"Sevierville, TN",42940,,315,Micropolitan Statistical Area,,"Knoxville-Morristown-Sevierville, TN",Sevier County,Tennessee,47,155,Central,,
+"Seymour, IN",42980,,294,Micropolitan Statistical Area,,"Indianapolis-Carmel-Muncie, IN",Jackson County,Indiana,18,071,Central,,
+"Shawano, WI",43020,,267,Micropolitan Statistical Area,,"Green Bay-Shawano, WI",Menominee County,Wisconsin,55,078,Outlying,,
+"Shawano, WI",43020,,267,Micropolitan Statistical Area,,"Green Bay-Shawano, WI",Shawano County,Wisconsin,55,115,Central,,
+"Shawnee, OK",43060,,416,Micropolitan Statistical Area,,"Oklahoma City-Shawnee, OK",Pottawatomie County,Oklahoma,40,125,Central,,
+"Sheboygan, WI",43100,,,Metropolitan Statistical Area,,,Sheboygan County,Wisconsin,55,117,Central,,
+"Shelby, NC",43140,,172,Micropolitan Statistical Area,,"Charlotte-Concord, NC-SC",Cleveland County,North Carolina,37,045,Central,,
+"Shelbyville, TN",43180,,400,Micropolitan Statistical Area,,"Nashville-Davidson--Murfreesboro, TN",Bedford County,Tennessee,47,003,Central,,
+"Shelton, WA",43220,,500,Micropolitan Statistical Area,,"Seattle-Tacoma, WA",Mason County,Washington,53,045,Central,,
+"Sheridan, WY",43260,,,Micropolitan Statistical Area,,,Sheridan County,Wyoming,56,033,Central,,
+"Sherman-Denison, TX",43300,,206,Metropolitan Statistical Area,,"Dallas-Fort Worth, TX-OK",Grayson County,Texas,48,181,Central,,
+"Show Low, AZ",43320,,,Micropolitan Statistical Area,,,Navajo County,Arizona,04,017,Central,,
+"Shreveport-Bossier City, LA",43340,,508,Metropolitan Statistical Area,,"Shreveport-Bossier City-Minden, LA",Bossier Parish,Louisiana,22,015,Central,,
+"Shreveport-Bossier City, LA",43340,,508,Metropolitan Statistical Area,,"Shreveport-Bossier City-Minden, LA",Caddo Parish,Louisiana,22,017,Central,,
+"Shreveport-Bossier City, LA",43340,,508,Metropolitan Statistical Area,,"Shreveport-Bossier City-Minden, LA",De Soto Parish,Louisiana,22,031,Outlying,,
+"Sidney, OH",43380,,212,Micropolitan Statistical Area,,"Dayton-Springfield-Kettering, OH",Shelby County,Ohio,39,149,Central,,
+"Sierra Vista-Douglas, AZ",43420,,,Metropolitan Statistical Area,,,Cochise County,Arizona,04,003,Central,,
+"Sikeston, MO",43460,,164,Micropolitan Statistical Area,,"Cape Girardeau-Sikeston, MO-IL",Scott County,Missouri,29,201,Central,,
+"Silver City, NM",43500,,,Micropolitan Statistical Area,,,Grant County,New Mexico,35,017,Central,,
+"Sioux City, IA-NE-SD",43580,,,Metropolitan Statistical Area,,,Woodbury County,Iowa,19,193,Central,,
+"Sioux City, IA-NE-SD",43580,,,Metropolitan Statistical Area,,,Dakota County,Nebraska,31,043,Central,,
+"Sioux City, IA-NE-SD",43580,,,Metropolitan Statistical Area,,,Dixon County,Nebraska,31,051,Outlying,,
+"Sioux City, IA-NE-SD",43580,,,Metropolitan Statistical Area,,,Union County,South Dakota,46,127,Central,,
+"Sioux Falls, SD",43620,,,Metropolitan Statistical Area,,,Lincoln County,South Dakota,46,083,Central,,
+"Sioux Falls, SD",43620,,,Metropolitan Statistical Area,,,McCook County,South Dakota,46,087,Outlying,,
+"Sioux Falls, SD",43620,,,Metropolitan Statistical Area,,,Minnehaha County,South Dakota,46,099,Central,,
+"Sioux Falls, SD",43620,,,Metropolitan Statistical Area,,,Turner County,South Dakota,46,125,Outlying,,
+"Snyder, TX",43660,,,Micropolitan Statistical Area,,,Scurry County,Texas,48,415,Central,,
+"Somerset, KY",43700,,,Micropolitan Statistical Area,,,Pulaski County,Kentucky,21,199,Central,,
+"Somerset, PA",43740,,306,Micropolitan Statistical Area,,"Johnstown-Somerset, PA",Somerset County,Pennsylvania,42,111,Central,,
+"Sonora, CA",43760,,,Micropolitan Statistical Area,,,Tuolumne County,California,06,109,Central,,
+"South Bend-Mishawaka, IN-MI",43780,,515,Metropolitan Statistical Area,,"South Bend-Elkhart-Mishawaka, IN-MI",St. Joseph County,Indiana,18,141,Central,,
+"South Bend-Mishawaka, IN-MI",43780,,515,Metropolitan Statistical Area,,"South Bend-Elkhart-Mishawaka, IN-MI",Cass County,Michigan,26,027,Central,,
+"Spartanburg, SC",43900,,273,Metropolitan Statistical Area,,"Greenville-Spartanburg-Anderson, SC",Spartanburg County,South Carolina,45,083,Central,,
+"Spearfish, SD",43940,,452,Micropolitan Statistical Area,,"Rapid City-Spearfish, SD",Lawrence County,South Dakota,46,081,Central,,
+"Spencer, IA",43980,,517,Micropolitan Statistical Area,,"Spencer-Spirit Lake, IA",Clay County,Iowa,19,041,Central,,
+"Spirit Lake, IA",44020,,517,Micropolitan Statistical Area,,"Spencer-Spirit Lake, IA",Dickinson County,Iowa,19,059,Central,,
+"Spokane-Spokane Valley, WA",44060,,518,Metropolitan Statistical Area,,"Spokane-Spokane Valley-Coeur d'Alene, WA-ID",Spokane County,Washington,53,063,Central,,
+"Spokane-Spokane Valley, WA",44060,,518,Metropolitan Statistical Area,,"Spokane-Spokane Valley-Coeur d'Alene, WA-ID",Stevens County,Washington,53,065,Outlying,,
+"Springfield, IL",44100,,522,Metropolitan Statistical Area,,"Springfield-Jacksonville-Lincoln, IL",Menard County,Illinois,17,129,Outlying,,
+"Springfield, IL",44100,,522,Metropolitan Statistical Area,,"Springfield-Jacksonville-Lincoln, IL",Sangamon County,Illinois,17,167,Central,,
+"Springfield, MA",44140,,,Metropolitan Statistical Area,,,Franklin County,Massachusetts,25,011,Outlying,,
+"Springfield, MA",44140,,,Metropolitan Statistical Area,,,Hampden County,Massachusetts,25,013,Central,,
+"Springfield, MA",44140,,,Metropolitan Statistical Area,,,Hampshire County,Massachusetts,25,015,Central,,
+"Springfield, MO",44180,,,Metropolitan Statistical Area,,,Christian County,Missouri,29,043,Central,,
+"Springfield, MO",44180,,,Metropolitan Statistical Area,,,Dallas County,Missouri,29,059,Outlying,,
+"Springfield, MO",44180,,,Metropolitan Statistical Area,,,Greene County,Missouri,29,077,Central,,
+"Springfield, MO",44180,,,Metropolitan Statistical Area,,,Polk County,Missouri,29,167,Outlying,,
+"Springfield, MO",44180,,,Metropolitan Statistical Area,,,Webster County,Missouri,29,225,Outlying,,
+"Springfield, OH",44220,,212,Metropolitan Statistical Area,,"Dayton-Springfield-Kettering, OH",Clark County,Ohio,39,023,Central,,
+"Starkville, MS",44260,,,Micropolitan Statistical Area,,,Oktibbeha County,Mississippi,28,105,Central,,
+"Starkville, MS",44260,,,Micropolitan Statistical Area,,,Webster County,Mississippi,28,155,Outlying,,
+"State College, PA",44300,,524,Metropolitan Statistical Area,,"State College-DuBois, PA",Centre County,Pennsylvania,42,027,Central,,
+"Statesboro, GA",44340,,496,Micropolitan Statistical Area,,"Savannah-Hinesville-Statesboro, GA",Bulloch County,Georgia,13,031,Central,,
+"Staunton, VA",44420,,277,Metropolitan Statistical Area,,"Harrisonburg-Staunton, VA",Augusta County,Virginia,51,015,Central,,
+"Staunton, VA",44420,,277,Metropolitan Statistical Area,,"Harrisonburg-Staunton, VA",Staunton city,Virginia,51,790,Central,,
+"Staunton, VA",44420,,277,Metropolitan Statistical Area,,"Harrisonburg-Staunton, VA",Waynesboro city,Virginia,51,820,Central,,
+"Steamboat Springs, CO",44460,,525,Micropolitan Statistical Area,,"Steamboat Springs-Craig, CO",Routt County,Colorado,08,107,Central,,
+"Stephenville, TX",44500,,,Micropolitan Statistical Area,,,Erath County,Texas,48,143,Central,,
+"Sterling, CO",44540,,,Micropolitan Statistical Area,,,Logan County,Colorado,08,075,Central,,
+"Sterling, IL",44580,,221,Micropolitan Statistical Area,,"Dixon-Sterling, IL",Whiteside County,Illinois,17,195,Central,,
+"Stevens Point, WI",44620,,554,Micropolitan Statistical Area,,"Wausau-Stevens Point-Wisconsin Rapids, WI",Portage County,Wisconsin,55,097,Central,,
+"Stillwater, OK",44660,,,Micropolitan Statistical Area,,,Payne County,Oklahoma,40,119,Central,,
+"Stockton, CA",44700,,488,Metropolitan Statistical Area,,"San Jose-San Francisco-Oakland, CA",San Joaquin County,California,06,077,Central,,
+"Storm Lake, IA",44740,,,Micropolitan Statistical Area,,,Buena Vista County,Iowa,19,021,Central,,
+"Sturgis, MI",44780,,310,Micropolitan Statistical Area,,"Kalamazoo-Battle Creek-Portage, MI",St. Joseph County,Michigan,26,149,Central,,
+"Sulphur Springs, TX",44860,,,Micropolitan Statistical Area,,,Hopkins County,Texas,48,223,Central,,
+"Summerville, GA",44900,,174,Micropolitan Statistical Area,,"Chattanooga-Cleveland-Dalton, TN-GA",Chattooga County,Georgia,13,055,Central,,
+"Sumter, SC",44940,,,Metropolitan Statistical Area,,,Clarendon County,South Carolina,45,027,Outlying,,
+"Sumter, SC",44940,,,Metropolitan Statistical Area,,,Sumter County,South Carolina,45,085,Central,,
+"Sunbury, PA",44980,,146,Micropolitan Statistical Area,,"Bloomsburg-Berwick-Sunbury, PA",Northumberland County,Pennsylvania,42,097,Central,,
+"Susanville, CA",45000,,,Micropolitan Statistical Area,,,Lassen County,California,06,035,Central,,
+"Sweetwater, TX",45020,,,Micropolitan Statistical Area,,,Nolan County,Texas,48,353,Central,,
+"Syracuse, NY",45060,,532,Metropolitan Statistical Area,,"Syracuse-Auburn, NY",Madison County,New York,36,053,Outlying,,
+"Syracuse, NY",45060,,532,Metropolitan Statistical Area,,"Syracuse-Auburn, NY",Onondaga County,New York,36,067,Central,,
+"Syracuse, NY",45060,,532,Metropolitan Statistical Area,,"Syracuse-Auburn, NY",Oswego County,New York,36,075,Outlying,,
+"Tahlequah, OK",45140,,,Micropolitan Statistical Area,,,Cherokee County,Oklahoma,40,021,Central,,
+"Talladega-Sylacauga, AL",45180,,142,Micropolitan Statistical Area,,"Birmingham-Hoover-Talladega, AL",Talladega County,Alabama,01,121,Central,,
+"Tallahassee, FL",45220,,,Metropolitan Statistical Area,,,Gadsden County,Florida,12,039,Outlying,,
+"Tallahassee, FL",45220,,,Metropolitan Statistical Area,,,Jefferson County,Florida,12,065,Outlying,,
+"Tallahassee, FL",45220,,,Metropolitan Statistical Area,,,Leon County,Florida,12,073,Central,,
+"Tallahassee, FL",45220,,,Metropolitan Statistical Area,,,Wakulla County,Florida,12,129,Outlying,,
+"Tampa-St. Petersburg-Clearwater, FL",45300,,,Metropolitan Statistical Area,,,Hernando County,Florida,12,053,Outlying,,
+"Tampa-St. Petersburg-Clearwater, FL",45300,,,Metropolitan Statistical Area,,,Hillsborough County,Florida,12,057,Central,,
+"Tampa-St. Petersburg-Clearwater, FL",45300,,,Metropolitan Statistical Area,,,Pasco County,Florida,12,101,Central,,
+"Tampa-St. Petersburg-Clearwater, FL",45300,,,Metropolitan Statistical Area,,,Pinellas County,Florida,12,103,Central,,
+"Taos, NM",45340,,,Micropolitan Statistical Area,,,Taos County,New Mexico,35,055,Central,,
+"Taylorville, IL",45380,,522,Micropolitan Statistical Area,,"Springfield-Jacksonville-Lincoln, IL",Christian County,Illinois,17,021,Central,,
+"Terre Haute, IN",45460,,,Metropolitan Statistical Area,,,Clay County,Indiana,18,021,Central,,
+"Terre Haute, IN",45460,,,Metropolitan Statistical Area,,,Parke County,Indiana,18,121,Outlying,,
+"Terre Haute, IN",45460,,,Metropolitan Statistical Area,,,Sullivan County,Indiana,18,153,Outlying,,
+"Terre Haute, IN",45460,,,Metropolitan Statistical Area,,,Vermillion County,Indiana,18,165,Outlying,,
+"Terre Haute, IN",45460,,,Metropolitan Statistical Area,,,Vigo County,Indiana,18,167,Central,,
+"Texarkana, TX-AR",45500,,,Metropolitan Statistical Area,,,Little River County,Arkansas,05,081,Outlying,,
+"Texarkana, TX-AR",45500,,,Metropolitan Statistical Area,,,Miller County,Arkansas,05,091,Central,,
+"Texarkana, TX-AR",45500,,,Metropolitan Statistical Area,,,Bowie County,Texas,48,037,Central,,
+"The Dalles, OR",45520,,,Micropolitan Statistical Area,,,Wasco County,Oregon,41,065,Central,,
+"The Villages, FL",45540,,422,Metropolitan Statistical Area,,"Orlando-Lakeland-Deltona, FL",Sumter County,Florida,12,119,Central,,
+"Thomaston, GA",45580,,122,Micropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Upson County,Georgia,13,293,Central,,
+"Thomasville, GA",45620,,,Micropolitan Statistical Area,,,Thomas County,Georgia,13,275,Central,,
+"Tiffin, OH",45660,,534,Micropolitan Statistical Area,,"Toledo-Findlay-Tiffin, OH",Seneca County,Ohio,39,147,Central,,
+"Tifton, GA",45700,,,Micropolitan Statistical Area,,,Tift County,Georgia,13,277,Central,,
+"Toccoa, GA",45740,,122,Micropolitan Statistical Area,,"Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",Stephens County,Georgia,13,257,Central,,
+"Toledo, OH",45780,,534,Metropolitan Statistical Area,,"Toledo-Findlay-Tiffin, OH",Fulton County,Ohio,39,051,Outlying,,
+"Toledo, OH",45780,,534,Metropolitan Statistical Area,,"Toledo-Findlay-Tiffin, OH",Lucas County,Ohio,39,095,Central,,
+"Toledo, OH",45780,,534,Metropolitan Statistical Area,,"Toledo-Findlay-Tiffin, OH",Ottawa County,Ohio,39,123,Outlying,,
+"Toledo, OH",45780,,534,Metropolitan Statistical Area,,"Toledo-Findlay-Tiffin, OH",Wood County,Ohio,39,173,Central,,
+"Topeka, KS",45820,,,Metropolitan Statistical Area,,,Jackson County,Kansas,20,085,Outlying,,
+"Topeka, KS",45820,,,Metropolitan Statistical Area,,,Jefferson County,Kansas,20,087,Outlying,,
+"Topeka, KS",45820,,,Metropolitan Statistical Area,,,Osage County,Kansas,20,139,Outlying,,
+"Topeka, KS",45820,,,Metropolitan Statistical Area,,,Shawnee County,Kansas,20,177,Central,,
+"Topeka, KS",45820,,,Metropolitan Statistical Area,,,Wabaunsee County,Kansas,20,197,Outlying,,
+"Torrington, CT",45860,,408,Micropolitan Statistical Area,,"New York-Newark, NY-NJ-CT-PA",Litchfield County,Connecticut,09,005,Central,,
+"Traverse City, MI",45900,,,Micropolitan Statistical Area,,,Benzie County,Michigan,26,019,Outlying,,
+"Traverse City, MI",45900,,,Micropolitan Statistical Area,,,Grand Traverse County,Michigan,26,055,Central,,
+"Traverse City, MI",45900,,,Micropolitan Statistical Area,,,Kalkaska County,Michigan,26,079,Outlying,,
+"Traverse City, MI",45900,,,Micropolitan Statistical Area,,,Leelanau County,Michigan,26,089,Outlying,,
+"Trenton-Princeton, NJ",45940,,408,Metropolitan Statistical Area,,"New York-Newark, NY-NJ-CT-PA",Mercer County,New Jersey,34,021,Central,,
+"Troy, AL",45980,,,Micropolitan Statistical Area,,,Pike County,Alabama,01,109,Central,,
+"Truckee-Grass Valley, CA",46020,,472,Micropolitan Statistical Area,,"Sacramento-Roseville, CA",Nevada County,California,06,057,Central,,
+"Tucson, AZ",46060,,536,Metropolitan Statistical Area,,"Tucson-Nogales, AZ",Pima County,Arizona,04,019,Central,,
+"Tullahoma-Manchester, TN",46100,,,Micropolitan Statistical Area,,,Coffee County,Tennessee,47,031,Central,,
+"Tullahoma-Manchester, TN",46100,,,Micropolitan Statistical Area,,,Franklin County,Tennessee,47,051,Outlying,,
+"Tullahoma-Manchester, TN",46100,,,Micropolitan Statistical Area,,,Moore County,Tennessee,47,127,Outlying,,
+"Tulsa, OK",46140,,538,Metropolitan Statistical Area,,"Tulsa-Muskogee-Bartlesville, OK",Creek County,Oklahoma,40,037,Central,,
+"Tulsa, OK",46140,,538,Metropolitan Statistical Area,,"Tulsa-Muskogee-Bartlesville, OK",Okmulgee County,Oklahoma,40,111,Outlying,,
+"Tulsa, OK",46140,,538,Metropolitan Statistical Area,,"Tulsa-Muskogee-Bartlesville, OK",Osage County,Oklahoma,40,113,Central,,
+"Tulsa, OK",46140,,538,Metropolitan Statistical Area,,"Tulsa-Muskogee-Bartlesville, OK",Pawnee County,Oklahoma,40,117,Outlying,,
+"Tulsa, OK",46140,,538,Metropolitan Statistical Area,,"Tulsa-Muskogee-Bartlesville, OK",Rogers County,Oklahoma,40,131,Outlying,,
+"Tulsa, OK",46140,,538,Metropolitan Statistical Area,,"Tulsa-Muskogee-Bartlesville, OK",Tulsa County,Oklahoma,40,143,Central,,
+"Tulsa, OK",46140,,538,Metropolitan Statistical Area,,"Tulsa-Muskogee-Bartlesville, OK",Wagoner County,Oklahoma,40,145,Central,,
+"Tupelo, MS",46180,,539,Micropolitan Statistical Area,,"Tupelo-Corinth, MS",Itawamba County,Mississippi,28,057,Outlying,,
+"Tupelo, MS",46180,,539,Micropolitan Statistical Area,,"Tupelo-Corinth, MS",Lee County,Mississippi,28,081,Central,,
+"Tupelo, MS",46180,,539,Micropolitan Statistical Area,,"Tupelo-Corinth, MS",Pontotoc County,Mississippi,28,115,Outlying,,
+"Tupelo, MS",46180,,539,Micropolitan Statistical Area,,"Tupelo-Corinth, MS",Prentiss County,Mississippi,28,117,Outlying,,
+"Tuscaloosa, AL",46220,,,Metropolitan Statistical Area,,,Greene County,Alabama,01,063,Outlying,,
+"Tuscaloosa, AL",46220,,,Metropolitan Statistical Area,,,Hale County,Alabama,01,065,Outlying,,
+"Tuscaloosa, AL",46220,,,Metropolitan Statistical Area,,,Pickens County,Alabama,01,107,Outlying,,
+"Tuscaloosa, AL",46220,,,Metropolitan Statistical Area,,,Tuscaloosa County,Alabama,01,125,Central,,
+"Twin Falls, ID",46300,,,Metropolitan Statistical Area,,,Jerome County,Idaho,16,053,Outlying,,
+"Twin Falls, ID",46300,,,Metropolitan Statistical Area,,,Twin Falls County,Idaho,16,083,Central,,
+"Tyler, TX",46340,,540,Metropolitan Statistical Area,,"Tyler-Jacksonville, TX",Smith County,Texas,48,423,Central,,
+"Ukiah, CA",46380,,,Micropolitan Statistical Area,,,Mendocino County,California,06,045,Central,,
+"Union, SC",46420,,273,Micropolitan Statistical Area,,"Greenville-Spartanburg-Anderson, SC",Union County,South Carolina,45,087,Central,,
+"Union City, TN",46460,,362,Micropolitan Statistical Area,,"Martin-Union City, TN",Obion County,Tennessee,47,131,Central,,
+"Urbana, OH",46500,,212,Micropolitan Statistical Area,,"Dayton-Springfield-Kettering, OH",Champaign County,Ohio,39,021,Central,,
+"Urban Honolulu, HI",46520,,,Metropolitan Statistical Area,,,Honolulu County,Hawaii,15,003,Central,,
+"Utica-Rome, NY",46540,,,Metropolitan Statistical Area,,,Herkimer County,New York,36,043,Outlying,,
+"Utica-Rome, NY",46540,,,Metropolitan Statistical Area,,,Oneida County,New York,36,065,Central,,
+"Uvalde, TX",46620,,,Micropolitan Statistical Area,,,Uvalde County,Texas,48,463,Central,,
+"Valdosta, GA",46660,,,Metropolitan Statistical Area,,,Brooks County,Georgia,13,027,Outlying,,
+"Valdosta, GA",46660,,,Metropolitan Statistical Area,,,Echols County,Georgia,13,101,Outlying,,
+"Valdosta, GA",46660,,,Metropolitan Statistical Area,,,Lanier County,Georgia,13,173,Outlying,,
+"Valdosta, GA",46660,,,Metropolitan Statistical Area,,,Lowndes County,Georgia,13,185,Central,,
+"Vallejo, CA",46700,,488,Metropolitan Statistical Area,,"San Jose-San Francisco-Oakland, CA",Solano County,California,06,095,Central,,
+"Van Wert, OH",46780,,338,Micropolitan Statistical Area,,"Lima-Van Wert-Celina, OH",Van Wert County,Ohio,39,161,Central,,
+"Vermillion, SD",46820,,,Micropolitan Statistical Area,,,Clay County,South Dakota,46,027,Central,,
+"Vernal, UT",46860,,,Micropolitan Statistical Area,,,Uintah County,Utah,49,047,Central,,
+"Vernon, TX",46900,,,Micropolitan Statistical Area,,,Wilbarger County,Texas,48,487,Central,,
+"Vicksburg, MS",46980,,298,Micropolitan Statistical Area,,"Jackson-Vicksburg-Brookhaven, MS",Warren County,Mississippi,28,149,Central,,
+"Victoria, TX",47020,,544,Metropolitan Statistical Area,,"Victoria-Port Lavaca, TX",Goliad County,Texas,48,175,Outlying,,
+"Victoria, TX",47020,,544,Metropolitan Statistical Area,,"Victoria-Port Lavaca, TX",Victoria County,Texas,48,469,Central,,
+"Vidalia, GA",47080,,,Micropolitan Statistical Area,,,Montgomery County,Georgia,13,209,Outlying,,
+"Vidalia, GA",47080,,,Micropolitan Statistical Area,,,Toombs County,Georgia,13,279,Central,,
+"Vincennes, IN",47180,,,Micropolitan Statistical Area,,,Knox County,Indiana,18,083,Central,,
+"Vineland-Bridgeton, NJ",47220,,428,Metropolitan Statistical Area,,"Philadelphia-Reading-Camden, PA-NJ-DE-MD",Cumberland County,New Jersey,34,011,Central,,
+"Vineyard Haven, MA",47240,,,Micropolitan Statistical Area,,,Dukes County,Massachusetts,25,007,Central,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Camden County,North Carolina,37,029,Outlying,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Currituck County,North Carolina,37,053,Outlying,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Gates County,North Carolina,37,073,Outlying,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Gloucester County,Virginia,51,073,Central,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Isle of Wight County,Virginia,51,093,Outlying,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",James City County,Virginia,51,095,Outlying,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Mathews County,Virginia,51,115,Outlying,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Southampton County,Virginia,51,175,Outlying,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",York County,Virginia,51,199,Central,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Chesapeake city,Virginia,51,550,Central,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Franklin city,Virginia,51,620,Outlying,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Hampton city,Virginia,51,650,Central,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Newport News city,Virginia,51,700,Central,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Norfolk city,Virginia,51,710,Central,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Poquoson city,Virginia,51,735,Central,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Portsmouth city,Virginia,51,740,Central,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Suffolk city,Virginia,51,800,Central,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Virginia Beach city,Virginia,51,810,Central,,
+"Virginia Beach-Norfolk-Newport News, VA-NC",47260,,545,Metropolitan Statistical Area,,"Virginia Beach-Norfolk, VA-NC",Williamsburg city,Virginia,51,830,Outlying,,
+"Visalia, CA",47300,,,Metropolitan Statistical Area,,,Tulare County,California,06,107,Central,,
+"Wabash, IN",47340,,,Micropolitan Statistical Area,,,Wabash County,Indiana,18,169,Central,,
+"Waco, TX",47380,,,Metropolitan Statistical Area,,,Falls County,Texas,48,145,Outlying,,
+"Waco, TX",47380,,,Metropolitan Statistical Area,,,McLennan County,Texas,48,309,Central,,
+"Wahpeton, ND-MN",47420,,244,Micropolitan Statistical Area,,"Fargo-Wahpeton, ND-MN",Wilkin County,Minnesota,27,167,Outlying,,
+"Wahpeton, ND-MN",47420,,244,Micropolitan Statistical Area,,"Fargo-Wahpeton, ND-MN",Richland County,North Dakota,38,077,Central,,
+"Walla Walla, WA",47460,,313,Metropolitan Statistical Area,,"Kennewick-Richland-Walla Walla, WA",Walla Walla County,Washington,53,071,Central,,
+"Wapakoneta, OH",47540,,338,Micropolitan Statistical Area,,"Lima-Van Wert-Celina, OH",Auglaize County,Ohio,39,011,Central,,
+"Warner Robins, GA",47580,,356,Metropolitan Statistical Area,,"Macon-Bibb County--Warner Robins, GA",Houston County,Georgia,13,153,Central,,
+"Warner Robins, GA",47580,,356,Metropolitan Statistical Area,,"Macon-Bibb County--Warner Robins, GA",Peach County,Georgia,13,225,Outlying,,
+"Warren, PA",47620,,,Micropolitan Statistical Area,,,Warren County,Pennsylvania,42,123,Central,,
+"Warrensburg, MO",47660,,312,Micropolitan Statistical Area,,"Kansas City-Overland Park-Kansas City, MO-KS",Johnson County,Missouri,29,101,Central,,
+"Warsaw, IN",47700,,515,Micropolitan Statistical Area,,"South Bend-Elkhart-Mishawaka, IN-MI",Kosciusko County,Indiana,18,085,Central,,
+"Washington, IN",47780,,,Micropolitan Statistical Area,,,Daviess County,Indiana,18,027,Central,,
+"Washington, NC",47820,,272,Micropolitan Statistical Area,,"Greenville-Kinston-Washington, NC",Beaufort County,North Carolina,37,013,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,23224,548,Metropolitan Statistical Area,"Frederick-Gaithersburg-Rockville, MD","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Frederick County,Maryland,24,021,Outlying,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,23224,548,Metropolitan Statistical Area,"Frederick-Gaithersburg-Rockville, MD","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Montgomery County,Maryland,24,031,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",District of Columbia,District of Columbia,11,001,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Calvert County,Maryland,24,009,Outlying,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Charles County,Maryland,24,017,Outlying,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Prince George's County,Maryland,24,033,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Arlington County,Virginia,51,013,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Clarke County,Virginia,51,043,Outlying,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Culpeper County,Virginia,51,047,Outlying,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Fairfax County,Virginia,51,059,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Fauquier County,Virginia,51,061,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Loudoun County,Virginia,51,107,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Madison County,Virginia,51,113,Outlying,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Prince William County,Virginia,51,153,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Rappahannock County,Virginia,51,157,Outlying,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Spotsylvania County,Virginia,51,177,Outlying,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Stafford County,Virginia,51,179,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Warren County,Virginia,51,187,Outlying,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Alexandria city,Virginia,51,510,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Fairfax city,Virginia,51,600,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Falls Church city,Virginia,51,610,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Fredericksburg city,Virginia,51,630,Outlying,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Manassas city,Virginia,51,683,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Manassas Park city,Virginia,51,685,Central,,
+"Washington-Arlington-Alexandria, DC-VA-MD-WV",47900,47894,548,Metropolitan Statistical Area,"Washington-Arlington-Alexandria, DC-VA-MD-WV","Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Jefferson County,West Virginia,54,037,Outlying,,
+"Washington Court House, OH",47920,,198,Micropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Fayette County,Ohio,39,047,Central,,
+"Waterloo-Cedar Falls, IA",47940,,,Metropolitan Statistical Area,,,Black Hawk County,Iowa,19,013,Central,,
+"Waterloo-Cedar Falls, IA",47940,,,Metropolitan Statistical Area,,,Bremer County,Iowa,19,017,Outlying,,
+"Waterloo-Cedar Falls, IA",47940,,,Metropolitan Statistical Area,,,Grundy County,Iowa,19,075,Outlying,,
+"Watertown, SD",47980,,,Micropolitan Statistical Area,,,Codington County,South Dakota,46,029,Central,,
+"Watertown, SD",47980,,,Micropolitan Statistical Area,,,Hamlin County,South Dakota,46,057,Outlying,,
+"Watertown-Fort Atkinson, WI",48020,,376,Micropolitan Statistical Area,,"Milwaukee-Racine-Waukesha, WI",Jefferson County,Wisconsin,55,055,Central,,
+"Watertown-Fort Drum, NY",48060,,,Metropolitan Statistical Area,,,Jefferson County,New York,36,045,Central,,
+"Wauchula, FL",48100,,422,Micropolitan Statistical Area,,"Orlando-Lakeland-Deltona, FL",Hardee County,Florida,12,049,Central,,
+"Wausau-Weston, WI",48140,,554,Metropolitan Statistical Area,,"Wausau-Stevens Point-Wisconsin Rapids, WI",Lincoln County,Wisconsin,55,069,Outlying,,
+"Wausau-Weston, WI",48140,,554,Metropolitan Statistical Area,,"Wausau-Stevens Point-Wisconsin Rapids, WI",Marathon County,Wisconsin,55,073,Central,,
+"Waycross, GA",48180,,,Micropolitan Statistical Area,,,Pierce County,Georgia,13,229,Outlying,,
+"Waycross, GA",48180,,,Micropolitan Statistical Area,,,Ware County,Georgia,13,299,Central,,
+"Weatherford, OK",48220,,,Micropolitan Statistical Area,,,Custer County,Oklahoma,40,039,Central,,
+"Weirton-Steubenville, WV-OH",48260,,430,Metropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Jefferson County,Ohio,39,081,Central,,
+"Weirton-Steubenville, WV-OH",48260,,430,Metropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Brooke County,West Virginia,54,009,Central,,
+"Weirton-Steubenville, WV-OH",48260,,430,Metropolitan Statistical Area,,"Pittsburgh-New Castle-Weirton, PA-OH-WV",Hancock County,West Virginia,54,029,Central,,
+"Wenatchee, WA",48300,,,Metropolitan Statistical Area,,,Chelan County,Washington,53,007,Central,,
+"Wenatchee, WA",48300,,,Metropolitan Statistical Area,,,Douglas County,Washington,53,017,Central,,
+"West Plains, MO",48460,,,Micropolitan Statistical Area,,,Howell County,Missouri,29,091,Central,,
+"West Point, MS",48500,,200,Micropolitan Statistical Area,,"Columbus-West Point, MS",Clay County,Mississippi,28,025,Central,,
+"Wheeling, WV-OH",48540,,,Metropolitan Statistical Area,,,Belmont County,Ohio,39,013,Central,,
+"Wheeling, WV-OH",48540,,,Metropolitan Statistical Area,,,Marshall County,West Virginia,54,051,Central,,
+"Wheeling, WV-OH",48540,,,Metropolitan Statistical Area,,,Ohio County,West Virginia,54,069,Central,,
+"Whitewater, WI",48580,,376,Micropolitan Statistical Area,,"Milwaukee-Racine-Waukesha, WI",Walworth County,Wisconsin,55,127,Central,,
+"Wichita, KS",48620,,556,Metropolitan Statistical Area,,"Wichita-Winfield, KS",Butler County,Kansas,20,015,Outlying,,
+"Wichita, KS",48620,,556,Metropolitan Statistical Area,,"Wichita-Winfield, KS",Harvey County,Kansas,20,079,Outlying,,
+"Wichita, KS",48620,,556,Metropolitan Statistical Area,,"Wichita-Winfield, KS",Sedgwick County,Kansas,20,173,Central,,
+"Wichita, KS",48620,,556,Metropolitan Statistical Area,,"Wichita-Winfield, KS",Sumner County,Kansas,20,191,Outlying,,
+"Wichita Falls, TX",48660,,,Metropolitan Statistical Area,,,Archer County,Texas,48,009,Outlying,,
+"Wichita Falls, TX",48660,,,Metropolitan Statistical Area,,,Clay County,Texas,48,077,Outlying,,
+"Wichita Falls, TX",48660,,,Metropolitan Statistical Area,,,Wichita County,Texas,48,485,Central,,
+"Williamsport, PA",48700,,558,Metropolitan Statistical Area,,"Williamsport-Lock Haven, PA",Lycoming County,Pennsylvania,42,081,Central,,
+"Williston, ND",48780,,,Micropolitan Statistical Area,,,Williams County,North Dakota,38,105,Central,,
+"Willmar, MN",48820,,,Micropolitan Statistical Area,,,Kandiyohi County,Minnesota,27,067,Central,,
+"Wilmington, NC",48900,,,Metropolitan Statistical Area,,,New Hanover County,North Carolina,37,129,Central,,
+"Wilmington, NC",48900,,,Metropolitan Statistical Area,,,Pender County,North Carolina,37,141,Outlying,,
+"Wilmington, OH",48940,,178,Micropolitan Statistical Area,,"Cincinnati-Wilmington-Maysville, OH-KY-IN",Clinton County,Ohio,39,027,Central,,
+"Wilson, NC",48980,,468,Micropolitan Statistical Area,,"Rocky Mount-Wilson-Roanoke Rapids, NC",Wilson County,North Carolina,37,195,Central,,
+"Winchester, VA-WV",49020,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Frederick County,Virginia,51,069,Central,,
+"Winchester, VA-WV",49020,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Winchester city,Virginia,51,840,Central,,
+"Winchester, VA-WV",49020,,548,Metropolitan Statistical Area,,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",Hampshire County,West Virginia,54,027,Outlying,,
+"Winfield, KS",49060,,556,Micropolitan Statistical Area,,"Wichita-Winfield, KS",Cowley County,Kansas,20,035,Central,,
+"Winnemucca, NV",49080,,,Micropolitan Statistical Area,,,Humboldt County,Nevada,32,013,Central,,
+"Winona, MN",49100,,,Micropolitan Statistical Area,,,Winona County,Minnesota,27,169,Central,,
+"Winston-Salem, NC",49180,,268,Metropolitan Statistical Area,,"Greensboro--Winston-Salem--High Point, NC",Davidson County,North Carolina,37,057,Central,,
+"Winston-Salem, NC",49180,,268,Metropolitan Statistical Area,,"Greensboro--Winston-Salem--High Point, NC",Davie County,North Carolina,37,059,Central,,
+"Winston-Salem, NC",49180,,268,Metropolitan Statistical Area,,"Greensboro--Winston-Salem--High Point, NC",Forsyth County,North Carolina,37,067,Central,,
+"Winston-Salem, NC",49180,,268,Metropolitan Statistical Area,,"Greensboro--Winston-Salem--High Point, NC",Stokes County,North Carolina,37,169,Central,,
+"Winston-Salem, NC",49180,,268,Metropolitan Statistical Area,,"Greensboro--Winston-Salem--High Point, NC",Yadkin County,North Carolina,37,197,Outlying,,
+"Wisconsin Rapids-Marshfield, WI",49220,,554,Micropolitan Statistical Area,,"Wausau-Stevens Point-Wisconsin Rapids, WI",Wood County,Wisconsin,55,141,Central,,
+"Woodward, OK",49260,,,Micropolitan Statistical Area,,,Ellis County,Oklahoma,40,045,Outlying,,
+"Woodward, OK",49260,,,Micropolitan Statistical Area,,,Woodward County,Oklahoma,40,153,Central,,
+"Wooster, OH",49300,,184,Micropolitan Statistical Area,,"Cleveland-Akron-Canton, OH",Wayne County,Ohio,39,169,Central,,
+"Worcester, MA-CT",49340,,148,Metropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Windham County,Connecticut,09,015,Central,,
+"Worcester, MA-CT",49340,,148,Metropolitan Statistical Area,,"Boston-Worcester-Providence, MA-RI-NH-CT",Worcester County,Massachusetts,25,027,Central,,
+"Worthington, MN",49380,,,Micropolitan Statistical Area,,,Nobles County,Minnesota,27,105,Central,,
+"Yakima, WA",49420,,,Metropolitan Statistical Area,,,Yakima County,Washington,53,077,Central,,
+"Yankton, SD",49460,,,Micropolitan Statistical Area,,,Yankton County,South Dakota,46,135,Central,,
+"Yauco, PR",49500,,434,Metropolitan Statistical Area,,"Ponce-Yauco-Coamo, PR",Gu�nica Municipio,Puerto Rico,72,055,Central,,
+"Yauco, PR",49500,,434,Metropolitan Statistical Area,,"Ponce-Yauco-Coamo, PR",Guayanilla Municipio,Puerto Rico,72,059,Central,,
+"Yauco, PR",49500,,434,Metropolitan Statistical Area,,"Ponce-Yauco-Coamo, PR",Pe�uelas Municipio,Puerto Rico,72,111,Central,,
+"Yauco, PR",49500,,434,Metropolitan Statistical Area,,"Ponce-Yauco-Coamo, PR",Yauco Municipio,Puerto Rico,72,153,Central,,
+"York-Hanover, PA",49620,,276,Metropolitan Statistical Area,,"Harrisburg-York-Lebanon, PA",York County,Pennsylvania,42,133,Central,,
+"Youngstown-Warren-Boardman, OH-PA",49660,,566,Metropolitan Statistical Area,,"Youngstown-Warren, OH-PA",Mahoning County,Ohio,39,099,Central,,
+"Youngstown-Warren-Boardman, OH-PA",49660,,566,Metropolitan Statistical Area,,"Youngstown-Warren, OH-PA",Trumbull County,Ohio,39,155,Central,,
+"Youngstown-Warren-Boardman, OH-PA",49660,,566,Metropolitan Statistical Area,,"Youngstown-Warren, OH-PA",Mercer County,Pennsylvania,42,085,Central,,
+"Yuba City, CA",49700,,472,Metropolitan Statistical Area,,"Sacramento-Roseville, CA",Sutter County,California,06,101,Central,,
+"Yuba City, CA",49700,,472,Metropolitan Statistical Area,,"Sacramento-Roseville, CA",Yuba County,California,06,115,Central,,
+"Yuma, AZ",49740,,,Metropolitan Statistical Area,,,Yuma County,Arizona,04,027,Central,,
+"Zanesville, OH",49780,,198,Micropolitan Statistical Area,,"Columbus-Marion-Zanesville, OH",Muskingum County,Ohio,39,119,Central,,
+"Zapata, TX",49820,,,Micropolitan Statistical Area,,,Zapata County,Texas,48,505,Central,,

--- a/msa-components-2018.json
+++ b/msa-components-2018.json
@@ -1,9 +1,73 @@
 {
+    "Aberdeen, SD": [
+       {
+          "CBSA Code": 10100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Brown County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 10100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Edmunds County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Aberdeen, WA": [
+       {
+          "CBSA Code": 10140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Grays Harbor County"
+          },
+          "State Name": "Washington",
+          "FIPS State Code": 53,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Abilene, TX": [
        {
           "CBSA Code": 10180,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20,6 +84,9 @@
           "CBSA Code": 10180,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -36,6 +103,9 @@
           "CBSA Code": 10180,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -49,11 +119,56 @@
           }
        }
     ],
+    "Ada, OK": [
+       {
+          "CBSA Code": 10220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pontotoc County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 123,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Adrian, MI": [
+       {
+          "CBSA Code": 10300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 220,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Detroit-Warren-Ann Arbor, MI",
+          "County": {
+             "County Equivalent": "Lenawee County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 91,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Aguadilla-Isabela, PR": [
        {
           "CBSA Code": 10380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -70,6 +185,9 @@
           "CBSA Code": 10380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -86,10 +204,13 @@
           "CBSA Code": 10380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
-             "County Equivalent": "Añasco Municipio"
+             "County Equivalent": "A�asco Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -102,6 +223,9 @@
           "CBSA Code": 10380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -118,6 +242,9 @@
           "CBSA Code": 10380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -134,6 +261,9 @@
           "CBSA Code": 10380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -150,10 +280,13 @@
           "CBSA Code": 10380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
-             "County Equivalent": "Rincón Municipio"
+             "County Equivalent": "Rinc�n Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -166,10 +299,13 @@
           "CBSA Code": 10380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
-             "County Equivalent": "San Sebastián Municipio"
+             "County Equivalent": "San Sebasti�n Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -182,6 +318,9 @@
           "CBSA Code": 10380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -200,6 +339,9 @@
           "CBSA Code": 10420,
           "Metropolitan Division Code": null,
           "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cleveland-Akron-Canton, OH",
           "County": {
@@ -216,6 +358,9 @@
           "CBSA Code": 10420,
           "Metropolitan Division Code": null,
           "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cleveland-Akron-Canton, OH",
           "County": {
@@ -229,11 +374,35 @@
           }
        }
     ],
+    "Alamogordo, NM": [
+       {
+          "CBSA Code": 10460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Otero County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 35,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Albany, GA": [
        {
           "CBSA Code": 10500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -250,6 +419,9 @@
           "CBSA Code": 10500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -266,6 +438,9 @@
           "CBSA Code": 10500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -282,6 +457,9 @@
           "CBSA Code": 10500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -300,6 +478,9 @@
           "CBSA Code": 10540,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -318,6 +499,9 @@
           "CBSA Code": 10580,
           "Metropolitan Division Code": null,
           "CSA Code": 104,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albany-Schenectady, NY",
           "County": {
@@ -334,6 +518,9 @@
           "CBSA Code": 10580,
           "Metropolitan Division Code": null,
           "CSA Code": 104,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albany-Schenectady, NY",
           "County": {
@@ -350,6 +537,9 @@
           "CBSA Code": 10580,
           "Metropolitan Division Code": null,
           "CSA Code": 104,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albany-Schenectady, NY",
           "County": {
@@ -366,6 +556,9 @@
           "CBSA Code": 10580,
           "Metropolitan Division Code": null,
           "CSA Code": 104,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albany-Schenectady, NY",
           "County": {
@@ -382,6 +575,9 @@
           "CBSA Code": 10580,
           "Metropolitan Division Code": null,
           "CSA Code": 104,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albany-Schenectady, NY",
           "County": {
@@ -395,11 +591,77 @@
           }
        }
     ],
+    "Albemarle, NC": [
+       {
+          "CBSA Code": 10620,
+          "Metropolitan Division Code": null,
+          "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Charlotte-Concord, NC-SC",
+          "County": {
+             "County Equivalent": "Stanly County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 167,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Albert Lea, MN": [
+       {
+          "CBSA Code": 10660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Freeborn County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 47,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Albertville, AL": [
+       {
+          "CBSA Code": 10700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Marshall County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 95,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Albuquerque, NM": [
        {
           "CBSA Code": 10740,
           "Metropolitan Division Code": null,
           "CSA Code": 106,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albuquerque-Santa Fe-Las Vegas, NM",
           "County": {
@@ -416,6 +678,9 @@
           "CBSA Code": 10740,
           "Metropolitan Division Code": null,
           "CSA Code": 106,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albuquerque-Santa Fe-Las Vegas, NM",
           "County": {
@@ -432,6 +697,9 @@
           "CBSA Code": 10740,
           "Metropolitan Division Code": null,
           "CSA Code": 106,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albuquerque-Santa Fe-Las Vegas, NM",
           "County": {
@@ -448,6 +716,9 @@
           "CBSA Code": 10740,
           "Metropolitan Division Code": null,
           "CSA Code": 106,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albuquerque-Santa Fe-Las Vegas, NM",
           "County": {
@@ -461,11 +732,54 @@
           }
        }
     ],
+    "Alexander City, AL": [
+       {
+          "CBSA Code": 10760,
+          "Metropolitan Division Code": null,
+          "CSA Code": 388,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Montgomery-Selma-Alexander City, AL",
+          "County": {
+             "County Equivalent": "Coosa County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 37,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 10760,
+          "Metropolitan Division Code": null,
+          "CSA Code": 388,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Montgomery-Selma-Alexander City, AL",
+          "County": {
+             "County Equivalent": "Tallapoosa County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 123,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Alexandria, LA": [
        {
           "CBSA Code": 10780,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -482,6 +796,9 @@
           "CBSA Code": 10780,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -495,11 +812,75 @@
           }
        }
     ],
+    "Alexandria, MN": [
+       {
+          "CBSA Code": 10820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Douglas County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 41,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Alice, TX": [
+       {
+          "CBSA Code": 10860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 204,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Corpus Christi-Kingsville-Alice, TX",
+          "County": {
+             "County Equivalent": "Duval County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 131,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 10860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 204,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Corpus Christi-Kingsville-Alice, TX",
+          "County": {
+             "County Equivalent": "Jim Wells County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 249,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Allentown-Bethlehem-Easton, PA-NJ": [
        {
           "CBSA Code": 10900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -516,6 +897,9 @@
           "CBSA Code": 10900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -532,6 +916,9 @@
           "CBSA Code": 10900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -548,6 +935,9 @@
           "CBSA Code": 10900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -561,11 +951,56 @@
           }
        }
     ],
+    "Alma, MI": [
+       {
+          "CBSA Code": 10940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 394,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Mount Pleasant-Alma, MI",
+          "County": {
+             "County Equivalent": "Gratiot County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 57,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Alpena, MI": [
+       {
+          "CBSA Code": 10980,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Alpena County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Altoona, PA": [
        {
           "CBSA Code": 11020,
           "Metropolitan Division Code": null,
           "CSA Code": 107,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Altoona-Huntingdon, PA",
           "County": {
@@ -579,11 +1014,35 @@
           }
        }
     ],
+    "Altus, OK": [
+       {
+          "CBSA Code": 11060,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Jackson County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 65,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Amarillo, TX": [
        {
           "CBSA Code": 11100,
           "Metropolitan Division Code": null,
           "CSA Code": 108,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Amarillo-Pampa-Borger, TX",
           "County": {
@@ -600,6 +1059,9 @@
           "CBSA Code": 11100,
           "Metropolitan Division Code": null,
           "CSA Code": 108,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Amarillo-Pampa-Borger, TX",
           "County": {
@@ -616,6 +1078,9 @@
           "CBSA Code": 11100,
           "Metropolitan Division Code": null,
           "CSA Code": 108,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Amarillo-Pampa-Borger, TX",
           "County": {
@@ -632,6 +1097,9 @@
           "CBSA Code": 11100,
           "Metropolitan Division Code": null,
           "CSA Code": 108,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Amarillo-Pampa-Borger, TX",
           "County": {
@@ -648,6 +1116,9 @@
           "CBSA Code": 11100,
           "Metropolitan Division Code": null,
           "CSA Code": 108,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Amarillo-Pampa-Borger, TX",
           "County": {
@@ -661,11 +1132,54 @@
           }
        }
     ],
+    "Americus, GA": [
+       {
+          "CBSA Code": 11140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Schley County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 249,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 11140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Sumter County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 261,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Ames, IA": [
        {
           "CBSA Code": 11180,
           "Metropolitan Division Code": null,
           "CSA Code": 218,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Des Moines-Ames-West Des Moines, IA",
           "County": {
@@ -682,6 +1196,9 @@
           "CBSA Code": 11180,
           "Metropolitan Division Code": null,
           "CSA Code": 218,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Des Moines-Ames-West Des Moines, IA",
           "County": {
@@ -695,11 +1212,35 @@
           }
        }
     ],
+    "Amsterdam, NY": [
+       {
+          "CBSA Code": 11220,
+          "Metropolitan Division Code": null,
+          "CSA Code": 104,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Albany-Schenectady, NY",
+          "County": {
+             "County Equivalent": "Montgomery County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 57,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Anchorage, AK": [
        {
           "CBSA Code": 11260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -716,6 +1257,9 @@
           "CBSA Code": 11260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -729,11 +1273,56 @@
           }
        }
     ],
+    "Andrews, TX": [
+       {
+          "CBSA Code": 11380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Andrews County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 3,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Angola, IN": [
+       {
+          "CBSA Code": 11420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 258,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Fort Wayne-Huntington-Auburn, IN",
+          "County": {
+             "County Equivalent": "Steuben County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 151,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Ann Arbor, MI": [
        {
           "CBSA Code": 11460,
           "Metropolitan Division Code": null,
           "CSA Code": 220,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Detroit-Warren-Ann Arbor, MI",
           "County": {
@@ -752,6 +1341,9 @@
           "CBSA Code": 11500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -770,6 +1362,9 @@
           "CBSA Code": 11540,
           "Metropolitan Division Code": null,
           "CSA Code": 118,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Appleton-Oshkosh-Neenah, WI",
           "County": {
@@ -786,6 +1381,9 @@
           "CBSA Code": 11540,
           "Metropolitan Division Code": null,
           "CSA Code": 118,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Appleton-Oshkosh-Neenah, WI",
           "County": {
@@ -799,13 +1397,77 @@
           }
        }
     ],
+    "Arcadia, FL": [
+       {
+          "CBSA Code": 11580,
+          "Metropolitan Division Code": null,
+          "CSA Code": 412,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "North Port-Sarasota, FL",
+          "County": {
+             "County Equivalent": "DeSoto County"
+          },
+          "State Name": "Florida",
+          "FIPS State Code": 12,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Ardmore, OK": [
+       {
+          "CBSA Code": 11620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Carter County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 19,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 11620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Love County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 85,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Arecibo, PR": [
        {
           "CBSA Code": 11640,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Arecibo Municipio"
           },
@@ -820,8 +1482,11 @@
           "CBSA Code": 11640,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Camuy Municipio"
           },
@@ -836,8 +1501,11 @@
           "CBSA Code": 11640,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Hatillo Municipio"
           },
@@ -852,8 +1520,11 @@
           "CBSA Code": 11640,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Quebradillas Municipio"
           },
@@ -865,11 +1536,35 @@
           }
        }
     ],
+    "Arkadelphia, AR": [
+       {
+          "CBSA Code": 11660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Clark County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 19,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Asheville, NC": [
        {
           "CBSA Code": 11700,
           "Metropolitan Division Code": null,
           "CSA Code": 120,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Asheville-Marion-Brevard, NC",
           "County": {
@@ -886,6 +1581,9 @@
           "CBSA Code": 11700,
           "Metropolitan Division Code": null,
           "CSA Code": 120,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Asheville-Marion-Brevard, NC",
           "County": {
@@ -902,6 +1600,9 @@
           "CBSA Code": 11700,
           "Metropolitan Division Code": null,
           "CSA Code": 120,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Asheville-Marion-Brevard, NC",
           "County": {
@@ -918,6 +1619,9 @@
           "CBSA Code": 11700,
           "Metropolitan Division Code": null,
           "CSA Code": 120,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Asheville-Marion-Brevard, NC",
           "County": {
@@ -931,11 +1635,161 @@
           }
        }
     ],
+    "Ashland, OH": [
+       {
+          "CBSA Code": 11740,
+          "Metropolitan Division Code": null,
+          "CSA Code": 360,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Mansfield-Ashland-Bucyrus, OH",
+          "County": {
+             "County Equivalent": "Ashland County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Ashtabula, OH": [
+       {
+          "CBSA Code": 11780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Cleveland-Akron-Canton, OH",
+          "County": {
+             "County Equivalent": "Ashtabula County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Astoria, OR": [
+       {
+          "CBSA Code": 11820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Clatsop County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Atchison, KS": [
+       {
+          "CBSA Code": 11860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
+          "County": {
+             "County Equivalent": "Atchison County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Athens, OH": [
+       {
+          "CBSA Code": 11900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Athens County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 9,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Athens, TN": [
+       {
+          "CBSA Code": 11940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
+          "County": {
+             "County Equivalent": "McMinn County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 107,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Athens, TX": [
+       {
+          "CBSA Code": 11980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dallas-Fort Worth, TX-OK",
+          "County": {
+             "County Equivalent": "Henderson County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 213,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Athens-Clarke County, GA": [
        {
           "CBSA Code": 12020,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -952,6 +1806,9 @@
           "CBSA Code": 12020,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -968,6 +1825,9 @@
           "CBSA Code": 12020,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -984,6 +1844,9 @@
           "CBSA Code": 12020,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1002,6 +1865,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1018,6 +1884,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1034,6 +1903,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1050,6 +1922,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1066,6 +1941,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1082,6 +1960,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1098,6 +1979,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1114,6 +1998,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1130,6 +2017,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1146,6 +2036,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1162,6 +2055,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1178,6 +2074,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1194,6 +2093,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1210,6 +2112,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1226,6 +2131,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1242,6 +2150,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1258,6 +2169,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1274,6 +2188,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1290,6 +2207,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1306,6 +2226,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1322,6 +2245,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1338,6 +2264,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1354,6 +2283,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1370,6 +2302,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1386,6 +2321,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1402,6 +2340,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1418,6 +2359,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1434,6 +2378,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1450,6 +2397,9 @@
           "CBSA Code": 12060,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -1468,6 +2418,9 @@
           "CBSA Code": 12100,
           "Metropolitan Division Code": null,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -1481,11 +2434,77 @@
           }
        }
     ],
+    "Atmore, AL": [
+       {
+          "CBSA Code": 12120,
+          "Metropolitan Division Code": null,
+          "CSA Code": 426,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Pensacola-Ferry Pass, FL-AL",
+          "County": {
+             "County Equivalent": "Escambia County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 53,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Auburn, IN": [
+       {
+          "CBSA Code": 12140,
+          "Metropolitan Division Code": null,
+          "CSA Code": 258,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Fort Wayne-Huntington-Auburn, IN",
+          "County": {
+             "County Equivalent": "DeKalb County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 33,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Auburn, NY": [
+       {
+          "CBSA Code": 12180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 532,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Syracuse-Auburn, NY",
+          "County": {
+             "County Equivalent": "Cayuga County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Auburn-Opelika, AL": [
        {
           "CBSA Code": 12220,
           "Metropolitan Division Code": null,
           "CSA Code": 194,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Auburn-Opelika, GA-AL",
           "County": {
@@ -1504,6 +2523,9 @@
           "CBSA Code": 12260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1520,6 +2542,9 @@
           "CBSA Code": 12260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1536,6 +2561,9 @@
           "CBSA Code": 12260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1552,6 +2580,9 @@
           "CBSA Code": 12260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1568,6 +2599,9 @@
           "CBSA Code": 12260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1584,6 +2618,9 @@
           "CBSA Code": 12260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1600,6 +2637,9 @@
           "CBSA Code": 12260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1613,11 +2653,56 @@
           }
        }
     ],
+    "Augusta-Waterville, ME": [
+       {
+          "CBSA Code": 12300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Kennebec County"
+          },
+          "State Name": "Maine",
+          "FIPS State Code": 23,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Austin, MN": [
+       {
+          "CBSA Code": 12380,
+          "Metropolitan Division Code": null,
+          "CSA Code": 462,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Rochester-Austin, MN",
+          "County": {
+             "County Equivalent": "Mower County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 99,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Austin-Round Rock-Georgetown, TX": [
        {
           "CBSA Code": 12420,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1634,6 +2719,9 @@
           "CBSA Code": 12420,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1650,6 +2738,9 @@
           "CBSA Code": 12420,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1666,6 +2757,9 @@
           "CBSA Code": 12420,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1682,6 +2776,9 @@
           "CBSA Code": 12420,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1695,11 +2792,35 @@
           }
        }
     ],
+    "Bainbridge, GA": [
+       {
+          "CBSA Code": 12460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Decatur County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 87,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Bakersfield, CA": [
        {
           "CBSA Code": 12540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1718,6 +2839,9 @@
           "CBSA Code": 12580,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -1734,6 +2858,9 @@
           "CBSA Code": 12580,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -1750,6 +2877,9 @@
           "CBSA Code": 12580,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -1766,6 +2896,9 @@
           "CBSA Code": 12580,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -1782,6 +2915,9 @@
           "CBSA Code": 12580,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -1798,6 +2934,9 @@
           "CBSA Code": 12580,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -1814,6 +2953,9 @@
           "CBSA Code": 12580,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -1832,6 +2974,9 @@
           "CBSA Code": 12620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1845,11 +2990,56 @@
           }
        }
     ],
+    "Baraboo, WI": [
+       {
+          "CBSA Code": 12660,
+          "Metropolitan Division Code": null,
+          "CSA Code": 357,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Madison-Janesville-Beloit, WI",
+          "County": {
+             "County Equivalent": "Sauk County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 111,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Bardstown, KY": [
+       {
+          "CBSA Code": 12680,
+          "Metropolitan Division Code": null,
+          "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
+          "County": {
+             "County Equivalent": "Nelson County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 179,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Barnstable Town, MA": [
        {
           "CBSA Code": 12700,
           "Metropolitan Division Code": null,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -1863,11 +3053,117 @@
           }
        }
     ],
+    "Barre, VT": [
+       {
+          "CBSA Code": 12740,
+          "Metropolitan Division Code": null,
+          "CSA Code": 162,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Burlington-South Burlington-Barre, VT",
+          "County": {
+             "County Equivalent": "Washington County"
+          },
+          "State Name": "Vermont",
+          "FIPS State Code": 50,
+          "FIPS County Code": 23,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Bartlesville, OK": [
+       {
+          "CBSA Code": 12780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 538,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Tulsa-Muskogee-Bartlesville, OK",
+          "County": {
+             "County Equivalent": "Washington County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 147,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Batavia, NY": [
+       {
+          "CBSA Code": 12860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 464,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Rochester-Batavia-Seneca Falls, NY",
+          "County": {
+             "County Equivalent": "Genesee County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 37,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Batesville, AR": [
+       {
+          "CBSA Code": 12900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Independence County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 63,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 12900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Sharp County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 135,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Baton Rouge, LA": [
        {
           "CBSA Code": 12940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1884,6 +3180,9 @@
           "CBSA Code": 12940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1900,6 +3199,9 @@
           "CBSA Code": 12940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1916,6 +3218,9 @@
           "CBSA Code": 12940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1932,6 +3237,9 @@
           "CBSA Code": 12940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1948,6 +3256,9 @@
           "CBSA Code": 12940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1964,6 +3275,9 @@
           "CBSA Code": 12940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1980,6 +3294,9 @@
           "CBSA Code": 12940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -1996,6 +3313,9 @@
           "CBSA Code": 12940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2012,6 +3332,9 @@
           "CBSA Code": 12940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2030,6 +3353,9 @@
           "CBSA Code": 12980,
           "Metropolitan Division Code": null,
           "CSA Code": 310,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kalamazoo-Battle Creek-Portage, MI",
           "County": {
@@ -2048,6 +3374,9 @@
           "CBSA Code": 13020,
           "Metropolitan Division Code": null,
           "CSA Code": 474,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Saginaw-Midland-Bay City, MI",
           "County": {
@@ -2061,11 +3390,56 @@
           }
        }
     ],
+    "Bay City, TX": [
+       {
+          "CBSA Code": 13060,
+          "Metropolitan Division Code": null,
+          "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Houston-The Woodlands, TX",
+          "County": {
+             "County Equivalent": "Matagorda County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 321,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Beatrice, NE": [
+       {
+          "CBSA Code": 13100,
+          "Metropolitan Division Code": null,
+          "CSA Code": 339,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lincoln-Beatrice, NE",
+          "County": {
+             "County Equivalent": "Gage County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 67,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Beaumont-Port Arthur, TX": [
        {
           "CBSA Code": 13140,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2082,6 +3456,9 @@
           "CBSA Code": 13140,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2098,6 +3475,9 @@
           "CBSA Code": 13140,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2111,11 +3491,35 @@
           }
        }
     ],
+    "Beaver Dam, WI": [
+       {
+          "CBSA Code": 13180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 376,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Milwaukee-Racine-Waukesha, WI",
+          "County": {
+             "County Equivalent": "Dodge County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Beckley, WV": [
        {
           "CBSA Code": 13220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2132,6 +3536,9 @@
           "CBSA Code": 13220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2145,11 +3552,77 @@
           }
        }
     ],
+    "Bedford, IN": [
+       {
+          "CBSA Code": 13260,
+          "Metropolitan Division Code": null,
+          "CSA Code": 144,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Bloomington-Bedford, IN",
+          "County": {
+             "County Equivalent": "Lawrence County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 93,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Beeville, TX": [
+       {
+          "CBSA Code": 13300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Bee County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 25,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Bellefontaine, OH": [
+       {
+          "CBSA Code": 13340,
+          "Metropolitan Division Code": null,
+          "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbus-Marion-Zanesville, OH",
+          "County": {
+             "County Equivalent": "Logan County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 91,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Bellingham, WA": [
        {
           "CBSA Code": 13380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2163,11 +3636,35 @@
           }
        }
     ],
+    "Bemidji, MN": [
+       {
+          "CBSA Code": 13420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Beltrami County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Bend, OR": [
        {
           "CBSA Code": 13460,
           "Metropolitan Division Code": null,
           "CSA Code": 140,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Bend-Prineville, OR",
           "County": {
@@ -2181,11 +3678,159 @@
           }
        }
     ],
+    "Bennettsville, SC": [
+       {
+          "CBSA Code": 13500,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Marlboro County"
+          },
+          "State Name": "South Carolina",
+          "FIPS State Code": 45,
+          "FIPS County Code": 69,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Bennington, VT": [
+       {
+          "CBSA Code": 13540,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Bennington County"
+          },
+          "State Name": "Vermont",
+          "FIPS State Code": 50,
+          "FIPS County Code": 3,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Berlin, NH": [
+       {
+          "CBSA Code": 13620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Coos County"
+          },
+          "State Name": "New Hampshire",
+          "FIPS State Code": 33,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Big Rapids, MI": [
+       {
+          "CBSA Code": 13660,
+          "Metropolitan Division Code": null,
+          "CSA Code": 266,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Grand Rapids-Kentwood-Muskegon, MI",
+          "County": {
+             "County Equivalent": "Mecosta County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 107,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Big Spring, TX": [
+       {
+          "CBSA Code": 13700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Howard County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 227,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Big Stone Gap, VA": [
+       {
+          "CBSA Code": 13720,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Wise County"
+          },
+          "State Name": "Virginia",
+          "FIPS State Code": 51,
+          "FIPS County Code": 195,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 13720,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Norton city"
+          },
+          "State Name": "Virginia",
+          "FIPS State Code": 51,
+          "FIPS County Code": 720,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Billings, MT": [
        {
           "CBSA Code": 13740,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2202,6 +3847,9 @@
           "CBSA Code": 13740,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2218,6 +3866,9 @@
           "CBSA Code": 13740,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2236,6 +3887,9 @@
           "CBSA Code": 13780,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2252,6 +3906,9 @@
           "CBSA Code": 13780,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2270,6 +3927,9 @@
           "CBSA Code": 13820,
           "Metropolitan Division Code": null,
           "CSA Code": 142,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Birmingham-Hoover-Talladega, AL",
           "County": {
@@ -2286,6 +3946,9 @@
           "CBSA Code": 13820,
           "Metropolitan Division Code": null,
           "CSA Code": 142,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Birmingham-Hoover-Talladega, AL",
           "County": {
@@ -2302,6 +3965,9 @@
           "CBSA Code": 13820,
           "Metropolitan Division Code": null,
           "CSA Code": 142,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Birmingham-Hoover-Talladega, AL",
           "County": {
@@ -2318,6 +3984,9 @@
           "CBSA Code": 13820,
           "Metropolitan Division Code": null,
           "CSA Code": 142,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Birmingham-Hoover-Talladega, AL",
           "County": {
@@ -2334,6 +4003,9 @@
           "CBSA Code": 13820,
           "Metropolitan Division Code": null,
           "CSA Code": 142,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Birmingham-Hoover-Talladega, AL",
           "County": {
@@ -2350,6 +4022,9 @@
           "CBSA Code": 13820,
           "Metropolitan Division Code": null,
           "CSA Code": 142,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Birmingham-Hoover-Talladega, AL",
           "County": {
@@ -2368,6 +4043,9 @@
           "CBSA Code": 13900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2384,6 +4062,9 @@
           "CBSA Code": 13900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2400,6 +4081,9 @@
           "CBSA Code": 13900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2413,11 +4097,35 @@
           }
        }
     ],
+    "Blackfoot, ID": [
+       {
+          "CBSA Code": 13940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 292,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Idaho Falls-Rexburg-Blackfoot, ID",
+          "County": {
+             "County Equivalent": "Bingham County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Blacksburg-Christiansburg, VA": [
        {
           "CBSA Code": 13980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2434,6 +4142,9 @@
           "CBSA Code": 13980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2450,6 +4161,9 @@
           "CBSA Code": 13980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2466,6 +4180,9 @@
           "CBSA Code": 13980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2484,6 +4201,9 @@
           "CBSA Code": 14010,
           "Metropolitan Division Code": null,
           "CSA Code": 145,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Bloomington-Pontiac, IL",
           "County": {
@@ -2502,6 +4222,9 @@
           "CBSA Code": 14020,
           "Metropolitan Division Code": null,
           "CSA Code": 144,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Bloomington-Bedford, IN",
           "County": {
@@ -2518,6 +4241,9 @@
           "CBSA Code": 14020,
           "Metropolitan Division Code": null,
           "CSA Code": 144,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Bloomington-Bedford, IN",
           "County": {
@@ -2536,6 +4262,9 @@
           "CBSA Code": 14100,
           "Metropolitan Division Code": null,
           "CSA Code": 146,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Bloomsburg-Berwick-Sunbury, PA",
           "County": {
@@ -2552,6 +4281,9 @@
           "CBSA Code": 14100,
           "Metropolitan Division Code": null,
           "CSA Code": 146,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Bloomsburg-Berwick-Sunbury, PA",
           "County": {
@@ -2565,11 +4297,115 @@
           }
        }
     ],
+    "Bluefield, WV-VA": [
+       {
+          "CBSA Code": 14140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Bland County"
+          },
+          "State Name": "Virginia",
+          "FIPS State Code": 51,
+          "FIPS County Code": 21,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 14140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Tazewell County"
+          },
+          "State Name": "Virginia",
+          "FIPS State Code": 51,
+          "FIPS County Code": 185,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 14140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Mercer County"
+          },
+          "State Name": "West Virginia",
+          "FIPS State Code": 54,
+          "FIPS County Code": 55,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Blytheville, AR": [
+       {
+          "CBSA Code": 14180,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Mississippi County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 93,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Bogalusa, LA": [
+       {
+          "CBSA Code": 14220,
+          "Metropolitan Division Code": null,
+          "CSA Code": 406,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "New Orleans-Metairie-Hammond, LA-MS",
+          "County": {
+             "County Equivalent": "Washington Parish"
+          },
+          "State Name": "Louisiana",
+          "FIPS State Code": 22,
+          "FIPS County Code": 117,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Boise City, ID": [
        {
           "CBSA Code": 14260,
           "Metropolitan Division Code": null,
           "CSA Code": 147,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boise City-Mountain Home-Ontario, ID-OR",
           "County": {
@@ -2586,6 +4422,9 @@
           "CBSA Code": 14260,
           "Metropolitan Division Code": null,
           "CSA Code": 147,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boise City-Mountain Home-Ontario, ID-OR",
           "County": {
@@ -2602,6 +4441,9 @@
           "CBSA Code": 14260,
           "Metropolitan Division Code": null,
           "CSA Code": 147,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boise City-Mountain Home-Ontario, ID-OR",
           "County": {
@@ -2618,6 +4460,9 @@
           "CBSA Code": 14260,
           "Metropolitan Division Code": null,
           "CSA Code": 147,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boise City-Mountain Home-Ontario, ID-OR",
           "County": {
@@ -2634,6 +4479,9 @@
           "CBSA Code": 14260,
           "Metropolitan Division Code": null,
           "CSA Code": 147,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boise City-Mountain Home-Ontario, ID-OR",
           "County": {
@@ -2647,11 +4495,77 @@
           }
        }
     ],
+    "Bonham, TX": [
+       {
+          "CBSA Code": 14300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dallas-Fort Worth, TX-OK",
+          "County": {
+             "County Equivalent": "Fannin County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 147,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Boone, NC": [
+       {
+          "CBSA Code": 14380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Watauga County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 189,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Borger, TX": [
+       {
+          "CBSA Code": 14420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 108,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Amarillo-Pampa-Borger, TX",
+          "County": {
+             "County Equivalent": "Hutchinson County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 233,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Boston-Cambridge-Newton, MA-NH": [
        {
           "CBSA Code": 14460,
           "Metropolitan Division Code": 14454,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Boston, MA",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -2668,6 +4582,9 @@
           "CBSA Code": 14460,
           "Metropolitan Division Code": 14454,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Boston, MA",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -2684,6 +4601,9 @@
           "CBSA Code": 14460,
           "Metropolitan Division Code": 14454,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Boston, MA",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -2700,6 +4620,9 @@
           "CBSA Code": 14460,
           "Metropolitan Division Code": 15764,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Cambridge-Newton-Framingham, MA",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -2716,6 +4639,9 @@
           "CBSA Code": 14460,
           "Metropolitan Division Code": 15764,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Cambridge-Newton-Framingham, MA",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -2732,6 +4658,9 @@
           "CBSA Code": 14460,
           "Metropolitan Division Code": 40484,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Rockingham County-Strafford County, NH",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -2748,6 +4677,9 @@
           "CBSA Code": 14460,
           "Metropolitan Division Code": 40484,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Rockingham County-Strafford County, NH",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -2766,6 +4698,9 @@
           "CBSA Code": 14500,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -2784,6 +4719,9 @@
           "CBSA Code": 14540,
           "Metropolitan Division Code": null,
           "CSA Code": 150,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Bowling Green-Glasgow, KY",
           "County": {
@@ -2800,6 +4738,9 @@
           "CBSA Code": 14540,
           "Metropolitan Division Code": null,
           "CSA Code": 150,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Bowling Green-Glasgow, KY",
           "County": {
@@ -2816,6 +4757,9 @@
           "CBSA Code": 14540,
           "Metropolitan Division Code": null,
           "CSA Code": 150,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Bowling Green-Glasgow, KY",
           "County": {
@@ -2832,6 +4776,9 @@
           "CBSA Code": 14540,
           "Metropolitan Division Code": null,
           "CSA Code": 150,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Bowling Green-Glasgow, KY",
           "County": {
@@ -2845,11 +4792,138 @@
           }
        }
     ],
+    "Bozeman, MT": [
+       {
+          "CBSA Code": 14580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Gallatin County"
+          },
+          "State Name": "Montana",
+          "FIPS State Code": 30,
+          "FIPS County Code": 31,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Bradford, PA": [
+       {
+          "CBSA Code": 14620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "McKean County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 83,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Brainerd, MN": [
+       {
+          "CBSA Code": 14660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Cass County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 21,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 14660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Crow Wing County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 35,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Branson, MO": [
+       {
+          "CBSA Code": 14700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Taney County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 213,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Breckenridge, CO": [
+       {
+          "CBSA Code": 14720,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Summit County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 117,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Bremerton-Silverdale-Port Orchard, WA": [
        {
           "CBSA Code": 14740,
           "Metropolitan Division Code": null,
           "CSA Code": 500,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Seattle-Tacoma, WA",
           "County": {
@@ -2863,11 +4937,56 @@
           }
        }
     ],
+    "Brenham, TX": [
+       {
+          "CBSA Code": 14780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Houston-The Woodlands, TX",
+          "County": {
+             "County Equivalent": "Washington County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 477,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Brevard, NC": [
+       {
+          "CBSA Code": 14820,
+          "Metropolitan Division Code": null,
+          "CSA Code": 120,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Asheville-Marion-Brevard, NC",
+          "County": {
+             "County Equivalent": "Transylvania County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 175,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Bridgeport-Stamford-Norwalk, CT": [
        {
           "CBSA Code": 14860,
           "Metropolitan Division Code": null,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -2881,11 +5000,98 @@
           }
        }
     ],
+    "Brookhaven, MS": [
+       {
+          "CBSA Code": 15020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 298,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Jackson-Vicksburg-Brookhaven, MS",
+          "County": {
+             "County Equivalent": "Lincoln County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 85,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Brookings, OR": [
+       {
+          "CBSA Code": 15060,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Curry County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 15,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Brookings, SD": [
+       {
+          "CBSA Code": 15100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Brookings County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Brownsville, TN": [
+       {
+          "CBSA Code": 15140,
+          "Metropolitan Division Code": null,
+          "CSA Code": 297,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Jackson-Brownsville, TN",
+          "County": {
+             "County Equivalent": "Haywood County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 75,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Brownsville-Harlingen, TX": [
        {
           "CBSA Code": 15180,
           "Metropolitan Division Code": null,
           "CSA Code": 154,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Brownsville-Harlingen-Raymondville, TX",
           "County": {
@@ -2899,11 +5105,35 @@
           }
        }
     ],
+    "Brownwood, TX": [
+       {
+          "CBSA Code": 15220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Brown County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 49,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Brunswick, GA": [
        {
           "CBSA Code": 15260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2920,6 +5150,9 @@
           "CBSA Code": 15260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2936,6 +5169,9 @@
           "CBSA Code": 15260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -2949,11 +5185,35 @@
           }
        }
     ],
+    "Bucyrus-Galion, OH": [
+       {
+          "CBSA Code": 15340,
+          "Metropolitan Division Code": null,
+          "CSA Code": 360,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Mansfield-Ashland-Bucyrus, OH",
+          "County": {
+             "County Equivalent": "Crawford County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 33,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Buffalo-Cheektowaga, NY": [
        {
           "CBSA Code": 15380,
           "Metropolitan Division Code": null,
           "CSA Code": 160,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Buffalo-Cheektowaga-Olean, NY",
           "County": {
@@ -2970,6 +5230,9 @@
           "CBSA Code": 15380,
           "Metropolitan Division Code": null,
           "CSA Code": 160,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Buffalo-Cheektowaga-Olean, NY",
           "County": {
@@ -2983,11 +5246,94 @@
           }
        }
     ],
+    "Burley, ID": [
+       {
+          "CBSA Code": 15420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Cassia County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 31,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 15420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Minidoka County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 67,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Burlington, IA-IL": [
+       {
+          "CBSA Code": 15460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 161,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Burlington-Fort Madison-Keokuk, IA-IL-MO",
+          "County": {
+             "County Equivalent": "Henderson County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 71,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 15460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 161,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Burlington-Fort Madison-Keokuk, IA-IL-MO",
+          "County": {
+             "County Equivalent": "Des Moines County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 57,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Burlington, NC": [
        {
           "CBSA Code": 15500,
           "Metropolitan Division Code": null,
           "CSA Code": 268,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greensboro--Winston-Salem--High Point, NC",
           "County": {
@@ -3006,6 +5352,9 @@
           "CBSA Code": 15540,
           "Metropolitan Division Code": null,
           "CSA Code": 162,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Burlington-South Burlington-Barre, VT",
           "County": {
@@ -3022,6 +5371,9 @@
           "CBSA Code": 15540,
           "Metropolitan Division Code": null,
           "CSA Code": 162,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Burlington-South Burlington-Barre, VT",
           "County": {
@@ -3038,6 +5390,9 @@
           "CBSA Code": 15540,
           "Metropolitan Division Code": null,
           "CSA Code": 162,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Burlington-South Burlington-Barre, VT",
           "County": {
@@ -3051,11 +5406,96 @@
           }
        }
     ],
+    "Butte-Silver Bow, MT": [
+       {
+          "CBSA Code": 15580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Silver Bow County"
+          },
+          "State Name": "Montana",
+          "FIPS State Code": 30,
+          "FIPS County Code": 93,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Cadillac, MI": [
+       {
+          "CBSA Code": 15620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Missaukee County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 113,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 15620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Wexford County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 165,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Calhoun, GA": [
+       {
+          "CBSA Code": 15660,
+          "Metropolitan Division Code": null,
+          "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
+          "County": {
+             "County Equivalent": "Gordon County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 129,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "California-Lexington Park, MD": [
        {
           "CBSA Code": 15680,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -3069,11 +5509,157 @@
           }
        }
     ],
+    "Cambridge, MD": [
+       {
+          "CBSA Code": 15700,
+          "Metropolitan Division Code": null,
+          "CSA Code": 480,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Salisbury-Cambridge, MD-DE",
+          "County": {
+             "County Equivalent": "Dorchester County"
+          },
+          "State Name": "Maryland",
+          "FIPS State Code": 24,
+          "FIPS County Code": 19,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Cambridge, OH": [
+       {
+          "CBSA Code": 15740,
+          "Metropolitan Division Code": null,
+          "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbus-Marion-Zanesville, OH",
+          "County": {
+             "County Equivalent": "Guernsey County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 59,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Camden, AR": [
+       {
+          "CBSA Code": 15780,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Calhoun County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 15780,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Ouachita County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 103,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Campbellsville, KY": [
+       {
+          "CBSA Code": 15820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Green County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 87,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 15820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Taylor County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 217,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Ca�on City, CO": [
+       {
+          "CBSA Code": 15860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 444,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Pueblo-Ca�on City, CO",
+          "County": {
+             "County Equivalent": "Fremont County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 43,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Canton-Massillon, OH": [
        {
           "CBSA Code": 15940,
           "Metropolitan Division Code": null,
           "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cleveland-Akron-Canton, OH",
           "County": {
@@ -3090,6 +5676,9 @@
           "CBSA Code": 15940,
           "Metropolitan Division Code": null,
           "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cleveland-Akron-Canton, OH",
           "County": {
@@ -3108,6 +5697,9 @@
           "CBSA Code": 15980,
           "Metropolitan Division Code": null,
           "CSA Code": 163,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cape Coral-Fort Myers-Naples, FL",
           "County": {
@@ -3126,6 +5718,9 @@
           "CBSA Code": 16020,
           "Metropolitan Division Code": null,
           "CSA Code": 164,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cape Girardeau-Sikeston, MO-IL",
           "County": {
@@ -3142,6 +5737,9 @@
           "CBSA Code": 16020,
           "Metropolitan Division Code": null,
           "CSA Code": 164,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cape Girardeau-Sikeston, MO-IL",
           "County": {
@@ -3158,6 +5756,9 @@
           "CBSA Code": 16020,
           "Metropolitan Division Code": null,
           "CSA Code": 164,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cape Girardeau-Sikeston, MO-IL",
           "County": {
@@ -3176,6 +5777,9 @@
           "CBSA Code": 16060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3192,6 +5796,9 @@
           "CBSA Code": 16060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3208,6 +5815,9 @@
           "CBSA Code": 16060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3221,11 +5831,56 @@
           }
        }
     ],
+    "Carlsbad-Artesia, NM": [
+       {
+          "CBSA Code": 16100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Eddy County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 15,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Carroll, IA": [
+       {
+          "CBSA Code": 16140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Carroll County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Carson City, NV": [
        {
           "CBSA Code": 16180,
           "Metropolitan Division Code": null,
           "CSA Code": 456,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Reno-Carson City-Fernley, NV",
           "County": {
@@ -3244,6 +5899,9 @@
           "CBSA Code": 16220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3257,11 +5915,35 @@
           }
        }
     ],
+    "Cedar City, UT": [
+       {
+          "CBSA Code": 16260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Iron County"
+          },
+          "State Name": "Utah",
+          "FIPS State Code": 49,
+          "FIPS County Code": 21,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Cedar Rapids, IA": [
        {
           "CBSA Code": 16300,
           "Metropolitan Division Code": null,
           "CSA Code": 168,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cedar Rapids-Iowa City, IA",
           "County": {
@@ -3278,6 +5960,9 @@
           "CBSA Code": 16300,
           "Metropolitan Division Code": null,
           "CSA Code": 168,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cedar Rapids-Iowa City, IA",
           "County": {
@@ -3294,6 +5979,9 @@
           "CBSA Code": 16300,
           "Metropolitan Division Code": null,
           "CSA Code": 168,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cedar Rapids-Iowa City, IA",
           "County": {
@@ -3307,11 +5995,119 @@
           }
        }
     ],
+    "Cedartown, GA": [
+       {
+          "CBSA Code": 16340,
+          "Metropolitan Division Code": null,
+          "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
+          "County": {
+             "County Equivalent": "Polk County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 233,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Celina, OH": [
+       {
+          "CBSA Code": 16380,
+          "Metropolitan Division Code": null,
+          "CSA Code": 338,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lima-Van Wert-Celina, OH",
+          "County": {
+             "County Equivalent": "Mercer County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 107,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Central City, KY": [
+       {
+          "CBSA Code": 16420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Muhlenberg County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 177,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Centralia, IL": [
+       {
+          "CBSA Code": 16460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
+          "County": {
+             "County Equivalent": "Marion County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 121,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Centralia, WA": [
+       {
+          "CBSA Code": 16500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 500,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Seattle-Tacoma, WA",
+          "County": {
+             "County Equivalent": "Lewis County"
+          },
+          "State Name": "Washington",
+          "FIPS State Code": 53,
+          "FIPS County Code": 41,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Chambersburg-Waynesboro, PA": [
        {
           "CBSA Code": 16540,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -3330,6 +6126,9 @@
           "CBSA Code": 16580,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3346,6 +6145,9 @@
           "CBSA Code": 16580,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3364,6 +6166,9 @@
           "CBSA Code": 16620,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -3380,6 +6185,9 @@
           "CBSA Code": 16620,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -3396,6 +6204,9 @@
           "CBSA Code": 16620,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -3412,6 +6223,9 @@
           "CBSA Code": 16620,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -3428,6 +6242,9 @@
           "CBSA Code": 16620,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -3441,11 +6258,54 @@
           }
        }
     ],
+    "Charleston-Mattoon, IL": [
+       {
+          "CBSA Code": 16660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Coles County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 29,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 16660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Cumberland County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 35,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Charleston-North Charleston, SC": [
        {
           "CBSA Code": 16700,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3462,6 +6322,9 @@
           "CBSA Code": 16700,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3478,6 +6341,9 @@
           "CBSA Code": 16700,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3496,6 +6362,9 @@
           "CBSA Code": 16740,
           "Metropolitan Division Code": null,
           "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charlotte-Concord, NC-SC",
           "County": {
@@ -3512,6 +6381,9 @@
           "CBSA Code": 16740,
           "Metropolitan Division Code": null,
           "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charlotte-Concord, NC-SC",
           "County": {
@@ -3528,6 +6400,9 @@
           "CBSA Code": 16740,
           "Metropolitan Division Code": null,
           "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charlotte-Concord, NC-SC",
           "County": {
@@ -3544,6 +6419,9 @@
           "CBSA Code": 16740,
           "Metropolitan Division Code": null,
           "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charlotte-Concord, NC-SC",
           "County": {
@@ -3560,6 +6438,9 @@
           "CBSA Code": 16740,
           "Metropolitan Division Code": null,
           "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charlotte-Concord, NC-SC",
           "County": {
@@ -3576,6 +6457,9 @@
           "CBSA Code": 16740,
           "Metropolitan Division Code": null,
           "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charlotte-Concord, NC-SC",
           "County": {
@@ -3592,6 +6476,9 @@
           "CBSA Code": 16740,
           "Metropolitan Division Code": null,
           "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charlotte-Concord, NC-SC",
           "County": {
@@ -3608,6 +6495,9 @@
           "CBSA Code": 16740,
           "Metropolitan Division Code": null,
           "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charlotte-Concord, NC-SC",
           "County": {
@@ -3624,6 +6514,9 @@
           "CBSA Code": 16740,
           "Metropolitan Division Code": null,
           "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charlotte-Concord, NC-SC",
           "County": {
@@ -3640,6 +6533,9 @@
           "CBSA Code": 16740,
           "Metropolitan Division Code": null,
           "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charlotte-Concord, NC-SC",
           "County": {
@@ -3656,6 +6552,9 @@
           "CBSA Code": 16740,
           "Metropolitan Division Code": null,
           "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charlotte-Concord, NC-SC",
           "County": {
@@ -3674,6 +6573,9 @@
           "CBSA Code": 16820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3690,6 +6592,9 @@
           "CBSA Code": 16820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3706,6 +6611,9 @@
           "CBSA Code": 16820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3722,6 +6630,9 @@
           "CBSA Code": 16820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3738,6 +6649,9 @@
           "CBSA Code": 16820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3756,6 +6670,9 @@
           "CBSA Code": 16860,
           "Metropolitan Division Code": null,
           "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
           "County": {
@@ -3772,6 +6689,9 @@
           "CBSA Code": 16860,
           "Metropolitan Division Code": null,
           "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
           "County": {
@@ -3788,6 +6708,9 @@
           "CBSA Code": 16860,
           "Metropolitan Division Code": null,
           "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
           "County": {
@@ -3804,6 +6727,9 @@
           "CBSA Code": 16860,
           "Metropolitan Division Code": null,
           "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
           "County": {
@@ -3820,6 +6746,9 @@
           "CBSA Code": 16860,
           "Metropolitan Division Code": null,
           "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
           "County": {
@@ -3836,6 +6765,9 @@
           "CBSA Code": 16860,
           "Metropolitan Division Code": null,
           "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
           "County": {
@@ -3854,6 +6786,9 @@
           "CBSA Code": 16940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -3872,6 +6807,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 16984,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Chicago-Naperville-Evanston, IL",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -3888,6 +6826,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 16984,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Chicago-Naperville-Evanston, IL",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -3904,6 +6845,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 16984,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Chicago-Naperville-Evanston, IL",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -3920,6 +6864,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 16984,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Chicago-Naperville-Evanston, IL",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -3936,6 +6883,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 16984,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Chicago-Naperville-Evanston, IL",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -3952,6 +6902,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 20994,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Elgin, IL",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -3968,6 +6921,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 20994,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Elgin, IL",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -3984,6 +6940,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 20994,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Elgin, IL",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -4000,6 +6959,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 23844,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Gary, IN",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -4016,6 +6978,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 23844,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Gary, IN",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -4032,6 +6997,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 23844,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Gary, IN",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -4048,6 +7016,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 23844,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Gary, IN",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -4064,6 +7035,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 29404,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Lake County-Kenosha County, IL-WI",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -4080,6 +7054,9 @@
           "CBSA Code": 16980,
           "Metropolitan Division Code": 29404,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Lake County-Kenosha County, IL-WI",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -4098,6 +7075,9 @@
           "CBSA Code": 17020,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -4111,11 +7091,35 @@
           }
        }
     ],
+    "Chillicothe, OH": [
+       {
+          "CBSA Code": 17060,
+          "Metropolitan Division Code": null,
+          "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbus-Marion-Zanesville, OH",
+          "County": {
+             "County Equivalent": "Ross County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 141,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Cincinnati, OH-KY-IN": [
        {
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4132,6 +7136,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4148,6 +7155,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4164,6 +7174,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4180,6 +7193,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4196,6 +7212,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4212,6 +7231,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4228,6 +7250,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4244,6 +7269,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4260,6 +7288,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4276,6 +7307,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4292,6 +7326,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4308,6 +7345,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4324,6 +7364,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4340,6 +7383,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4356,6 +7402,9 @@
           "CBSA Code": 17140,
           "Metropolitan Division Code": null,
           "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
           "County": {
@@ -4369,11 +7418,94 @@
           }
        }
     ],
+    "Clarksburg, WV": [
+       {
+          "CBSA Code": 17220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Doddridge County"
+          },
+          "State Name": "West Virginia",
+          "FIPS State Code": 54,
+          "FIPS County Code": 17,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 17220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Harrison County"
+          },
+          "State Name": "West Virginia",
+          "FIPS State Code": 54,
+          "FIPS County Code": 33,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 17220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Taylor County"
+          },
+          "State Name": "West Virginia",
+          "FIPS State Code": 54,
+          "FIPS County Code": 91,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Clarksdale, MS": [
+       {
+          "CBSA Code": 17260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Coahoma County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Clarksville, TN-KY": [
        {
           "CBSA Code": 17300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -4390,6 +7522,9 @@
           "CBSA Code": 17300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -4406,6 +7541,9 @@
           "CBSA Code": 17300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -4422,6 +7560,9 @@
           "CBSA Code": 17300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -4435,11 +7576,56 @@
           }
        }
     ],
+    "Clearlake, CA": [
+       {
+          "CBSA Code": 17340,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lake County"
+          },
+          "State Name": "California",
+          "FIPS State Code": 6,
+          "FIPS County Code": 33,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Cleveland, MS": [
+       {
+          "CBSA Code": 17380,
+          "Metropolitan Division Code": null,
+          "CSA Code": 185,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Cleveland-Indianola, MS",
+          "County": {
+             "County Equivalent": "Bolivar County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Cleveland, TN": [
        {
           "CBSA Code": 17420,
           "Metropolitan Division Code": null,
           "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
           "County": {
@@ -4456,6 +7642,9 @@
           "CBSA Code": 17420,
           "Metropolitan Division Code": null,
           "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
           "County": {
@@ -4474,6 +7663,9 @@
           "CBSA Code": 17460,
           "Metropolitan Division Code": null,
           "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cleveland-Akron-Canton, OH",
           "County": {
@@ -4490,6 +7682,9 @@
           "CBSA Code": 17460,
           "Metropolitan Division Code": null,
           "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cleveland-Akron-Canton, OH",
           "County": {
@@ -4506,6 +7701,9 @@
           "CBSA Code": 17460,
           "Metropolitan Division Code": null,
           "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cleveland-Akron-Canton, OH",
           "County": {
@@ -4522,6 +7720,9 @@
           "CBSA Code": 17460,
           "Metropolitan Division Code": null,
           "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cleveland-Akron-Canton, OH",
           "County": {
@@ -4538,6 +7739,9 @@
           "CBSA Code": 17460,
           "Metropolitan Division Code": null,
           "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cleveland-Akron-Canton, OH",
           "County": {
@@ -4551,11 +7755,119 @@
           }
        }
     ],
+    "Clewiston, FL": [
+       {
+          "CBSA Code": 17500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 163,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Cape Coral-Fort Myers-Naples, FL",
+          "County": {
+             "County Equivalent": "Hendry County"
+          },
+          "State Name": "Florida",
+          "FIPS State Code": 12,
+          "FIPS County Code": 51,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Clinton, IA": [
+       {
+          "CBSA Code": 17540,
+          "Metropolitan Division Code": null,
+          "CSA Code": 209,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Davenport-Moline, IA-IL",
+          "County": {
+             "County Equivalent": "Clinton County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Clovis, NM": [
+       {
+          "CBSA Code": 17580,
+          "Metropolitan Division Code": null,
+          "CSA Code": 188,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Clovis-Portales, NM",
+          "County": {
+             "County Equivalent": "Curry County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 9,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Coamo, PR": [
+       {
+          "CBSA Code": 17620,
+          "Metropolitan Division Code": null,
+          "CSA Code": 434,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Ponce-Yauco-Coamo, PR",
+          "County": {
+             "County Equivalent": "Coamo Municipio"
+          },
+          "State Name": "Puerto Rico",
+          "FIPS State Code": 72,
+          "FIPS County Code": 43,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Coco, PR": [
+       {
+          "CBSA Code": 17640,
+          "Metropolitan Division Code": null,
+          "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "San Juan-Bayam�n, PR",
+          "County": {
+             "County Equivalent": "Salinas Municipio"
+          },
+          "State Name": "Puerto Rico",
+          "FIPS State Code": 72,
+          "FIPS County Code": 123,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Coeur d'Alene, ID": [
        {
           "CBSA Code": 17660,
           "Metropolitan Division Code": null,
           "CSA Code": 518,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Spokane-Spokane Valley-Coeur d'Alene, WA-ID",
           "County": {
@@ -4569,11 +7881,56 @@
           }
        }
     ],
+    "Coffeyville, KS": [
+       {
+          "CBSA Code": 17700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Montgomery County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 125,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Coldwater, MI": [
+       {
+          "CBSA Code": 17740,
+          "Metropolitan Division Code": null,
+          "CSA Code": 310,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Kalamazoo-Battle Creek-Portage, MI",
+          "County": {
+             "County Equivalent": "Branch County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 23,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "College Station-Bryan, TX": [
        {
           "CBSA Code": 17780,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -4590,6 +7947,9 @@
           "CBSA Code": 17780,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -4606,6 +7966,9 @@
           "CBSA Code": 17780,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -4624,6 +7987,9 @@
           "CBSA Code": 17820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -4640,6 +8006,9 @@
           "CBSA Code": 17820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -4658,6 +8027,9 @@
           "CBSA Code": 17860,
           "Metropolitan Division Code": null,
           "CSA Code": 190,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbia-Moberly-Mexico, MO",
           "County": {
@@ -4674,6 +8046,9 @@
           "CBSA Code": 17860,
           "Metropolitan Division Code": null,
           "CSA Code": 190,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbia-Moberly-Mexico, MO",
           "County": {
@@ -4690,6 +8065,9 @@
           "CBSA Code": 17860,
           "Metropolitan Division Code": null,
           "CSA Code": 190,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbia-Moberly-Mexico, MO",
           "County": {
@@ -4708,6 +8086,9 @@
           "CBSA Code": 17900,
           "Metropolitan Division Code": null,
           "CSA Code": 192,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbia-Orangeburg-Newberry, SC",
           "County": {
@@ -4724,6 +8105,9 @@
           "CBSA Code": 17900,
           "Metropolitan Division Code": null,
           "CSA Code": 192,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbia-Orangeburg-Newberry, SC",
           "County": {
@@ -4740,6 +8124,9 @@
           "CBSA Code": 17900,
           "Metropolitan Division Code": null,
           "CSA Code": 192,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbia-Orangeburg-Newberry, SC",
           "County": {
@@ -4756,6 +8143,9 @@
           "CBSA Code": 17900,
           "Metropolitan Division Code": null,
           "CSA Code": 192,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbia-Orangeburg-Newberry, SC",
           "County": {
@@ -4772,6 +8162,9 @@
           "CBSA Code": 17900,
           "Metropolitan Division Code": null,
           "CSA Code": 192,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbia-Orangeburg-Newberry, SC",
           "County": {
@@ -4788,6 +8181,9 @@
           "CBSA Code": 17900,
           "Metropolitan Division Code": null,
           "CSA Code": 192,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbia-Orangeburg-Newberry, SC",
           "County": {
@@ -4806,6 +8202,9 @@
           "CBSA Code": 17980,
           "Metropolitan Division Code": null,
           "CSA Code": 194,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Auburn-Opelika, GA-AL",
           "County": {
@@ -4822,6 +8221,9 @@
           "CBSA Code": 17980,
           "Metropolitan Division Code": null,
           "CSA Code": 194,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Auburn-Opelika, GA-AL",
           "County": {
@@ -4838,6 +8240,9 @@
           "CBSA Code": 17980,
           "Metropolitan Division Code": null,
           "CSA Code": 194,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Auburn-Opelika, GA-AL",
           "County": {
@@ -4854,6 +8259,9 @@
           "CBSA Code": 17980,
           "Metropolitan Division Code": null,
           "CSA Code": 194,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Auburn-Opelika, GA-AL",
           "County": {
@@ -4870,6 +8278,9 @@
           "CBSA Code": 17980,
           "Metropolitan Division Code": null,
           "CSA Code": 194,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Auburn-Opelika, GA-AL",
           "County": {
@@ -4886,6 +8297,9 @@
           "CBSA Code": 17980,
           "Metropolitan Division Code": null,
           "CSA Code": 194,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Auburn-Opelika, GA-AL",
           "County": {
@@ -4902,6 +8316,9 @@
           "CBSA Code": 17980,
           "Metropolitan Division Code": null,
           "CSA Code": 194,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Auburn-Opelika, GA-AL",
           "County": {
@@ -4920,6 +8337,9 @@
           "CBSA Code": 18020,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -4933,11 +8353,56 @@
           }
        }
     ],
+    "Columbus, MS": [
+       {
+          "CBSA Code": 18060,
+          "Metropolitan Division Code": null,
+          "CSA Code": 200,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbus-West Point, MS",
+          "County": {
+             "County Equivalent": "Lowndes County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 87,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Columbus, NE": [
+       {
+          "CBSA Code": 18100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Platte County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 141,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Columbus, OH": [
        {
           "CBSA Code": 18140,
           "Metropolitan Division Code": null,
           "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Marion-Zanesville, OH",
           "County": {
@@ -4954,6 +8419,9 @@
           "CBSA Code": 18140,
           "Metropolitan Division Code": null,
           "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Marion-Zanesville, OH",
           "County": {
@@ -4970,6 +8438,9 @@
           "CBSA Code": 18140,
           "Metropolitan Division Code": null,
           "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Marion-Zanesville, OH",
           "County": {
@@ -4986,6 +8457,9 @@
           "CBSA Code": 18140,
           "Metropolitan Division Code": null,
           "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Marion-Zanesville, OH",
           "County": {
@@ -5002,6 +8476,9 @@
           "CBSA Code": 18140,
           "Metropolitan Division Code": null,
           "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Marion-Zanesville, OH",
           "County": {
@@ -5018,6 +8495,9 @@
           "CBSA Code": 18140,
           "Metropolitan Division Code": null,
           "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Marion-Zanesville, OH",
           "County": {
@@ -5034,6 +8514,9 @@
           "CBSA Code": 18140,
           "Metropolitan Division Code": null,
           "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Marion-Zanesville, OH",
           "County": {
@@ -5050,6 +8533,9 @@
           "CBSA Code": 18140,
           "Metropolitan Division Code": null,
           "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Marion-Zanesville, OH",
           "County": {
@@ -5066,6 +8552,9 @@
           "CBSA Code": 18140,
           "Metropolitan Division Code": null,
           "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Marion-Zanesville, OH",
           "County": {
@@ -5082,6 +8571,9 @@
           "CBSA Code": 18140,
           "Metropolitan Division Code": null,
           "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Columbus-Marion-Zanesville, OH",
           "County": {
@@ -5095,11 +8587,220 @@
           }
        }
     ],
+    "Concord, NH": [
+       {
+          "CBSA Code": 18180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
+          "County": {
+             "County Equivalent": "Merrimack County"
+          },
+          "State Name": "New Hampshire",
+          "FIPS State Code": 33,
+          "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Connersville, IN": [
+       {
+          "CBSA Code": 18220,
+          "Metropolitan Division Code": null,
+          "CSA Code": 458,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Richmond-Connersville, IN",
+          "County": {
+             "County Equivalent": "Fayette County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 41,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Cookeville, TN": [
+       {
+          "CBSA Code": 18260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Jackson County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 87,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 18260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Overton County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 133,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 18260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Putnam County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 141,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Coos Bay, OR": [
+       {
+          "CBSA Code": 18300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Coos County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Cordele, GA": [
+       {
+          "CBSA Code": 18380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Crisp County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 81,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Corinth, MS": [
+       {
+          "CBSA Code": 18420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 539,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Tupelo-Corinth, MS",
+          "County": {
+             "County Equivalent": "Alcorn County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 3,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Cornelia, GA": [
+       {
+          "CBSA Code": 18460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
+          "County": {
+             "County Equivalent": "Habersham County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 137,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Corning, NY": [
+       {
+          "CBSA Code": 18500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 236,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Elmira-Corning, NY",
+          "County": {
+             "County Equivalent": "Steuben County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 101,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Corpus Christi, TX": [
        {
           "CBSA Code": 18580,
           "Metropolitan Division Code": null,
           "CSA Code": 204,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Corpus Christi-Kingsville-Alice, TX",
           "County": {
@@ -5116,6 +8817,9 @@
           "CBSA Code": 18580,
           "Metropolitan Division Code": null,
           "CSA Code": 204,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Corpus Christi-Kingsville-Alice, TX",
           "County": {
@@ -5129,11 +8833,56 @@
           }
        }
     ],
+    "Corsicana, TX": [
+       {
+          "CBSA Code": 18620,
+          "Metropolitan Division Code": null,
+          "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dallas-Fort Worth, TX-OK",
+          "County": {
+             "County Equivalent": "Navarro County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 349,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Cortland, NY": [
+       {
+          "CBSA Code": 18660,
+          "Metropolitan Division Code": null,
+          "CSA Code": 296,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Ithaca-Cortland, NY",
+          "County": {
+             "County Equivalent": "Cortland County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 23,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Corvallis, OR": [
        {
           "CBSA Code": 18700,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -5147,11 +8896,98 @@
           }
        }
     ],
+    "Coshocton, OH": [
+       {
+          "CBSA Code": 18740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Coshocton County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 31,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Craig, CO": [
+       {
+          "CBSA Code": 18780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 525,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Steamboat Springs-Craig, CO",
+          "County": {
+             "County Equivalent": "Moffat County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 81,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Crawfordsville, IN": [
+       {
+          "CBSA Code": 18820,
+          "Metropolitan Division Code": null,
+          "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Indianapolis-Carmel-Muncie, IN",
+          "County": {
+             "County Equivalent": "Montgomery County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 107,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Crescent City, CA": [
+       {
+          "CBSA Code": 18860,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Del Norte County"
+          },
+          "State Name": "California",
+          "FIPS State Code": 6,
+          "FIPS County Code": 15,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Crestview-Fort Walton Beach-Destin, FL": [
        {
           "CBSA Code": 18880,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -5168,6 +9004,9 @@
           "CBSA Code": 18880,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -5181,11 +9020,96 @@
           }
        }
     ],
+    "Crossville, TN": [
+       {
+          "CBSA Code": 18900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Cumberland County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 35,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Cullman, AL": [
+       {
+          "CBSA Code": 18980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 142,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Birmingham-Hoover-Talladega, AL",
+          "County": {
+             "County Equivalent": "Cullman County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 43,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Cullowhee, NC": [
+       {
+          "CBSA Code": 19000,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Jackson County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 99,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 19000,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Swain County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 173,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Cumberland, MD-WV": [
        {
           "CBSA Code": 19060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -5202,6 +9126,9 @@
           "CBSA Code": 19060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -5220,6 +9147,9 @@
           "CBSA Code": 19100,
           "Metropolitan Division Code": 19124,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Dallas-Plano-Irving, TX",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -5236,6 +9166,9 @@
           "CBSA Code": 19100,
           "Metropolitan Division Code": 19124,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Dallas-Plano-Irving, TX",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -5252,6 +9185,9 @@
           "CBSA Code": 19100,
           "Metropolitan Division Code": 19124,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Dallas-Plano-Irving, TX",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -5268,6 +9204,9 @@
           "CBSA Code": 19100,
           "Metropolitan Division Code": 19124,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Dallas-Plano-Irving, TX",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -5284,6 +9223,9 @@
           "CBSA Code": 19100,
           "Metropolitan Division Code": 19124,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Dallas-Plano-Irving, TX",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -5300,6 +9242,9 @@
           "CBSA Code": 19100,
           "Metropolitan Division Code": 19124,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Dallas-Plano-Irving, TX",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -5316,6 +9261,9 @@
           "CBSA Code": 19100,
           "Metropolitan Division Code": 19124,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Dallas-Plano-Irving, TX",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -5332,6 +9280,9 @@
           "CBSA Code": 19100,
           "Metropolitan Division Code": 23104,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Fort Worth-Arlington-Grapevine, TX",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -5348,6 +9299,9 @@
           "CBSA Code": 19100,
           "Metropolitan Division Code": 23104,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Fort Worth-Arlington-Grapevine, TX",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -5364,6 +9318,9 @@
           "CBSA Code": 19100,
           "Metropolitan Division Code": 23104,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Fort Worth-Arlington-Grapevine, TX",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -5380,6 +9337,9 @@
           "CBSA Code": 19100,
           "Metropolitan Division Code": 23104,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Fort Worth-Arlington-Grapevine, TX",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -5398,6 +9358,9 @@
           "CBSA Code": 19140,
           "Metropolitan Division Code": null,
           "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
           "County": {
@@ -5414,6 +9377,9 @@
           "CBSA Code": 19140,
           "Metropolitan Division Code": null,
           "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
           "County": {
@@ -5432,6 +9398,9 @@
           "CBSA Code": 19180,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -5445,11 +9414,94 @@
           }
        }
     ],
+    "Danville, KY": [
+       {
+          "CBSA Code": 19220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Boyle County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 21,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 19220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lincoln County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 137,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Danville, VA": [
+       {
+          "CBSA Code": 19260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pittsylvania County"
+          },
+          "State Name": "Virginia",
+          "FIPS State Code": 51,
+          "FIPS County Code": 143,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 19260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Danville city"
+          },
+          "State Name": "Virginia",
+          "FIPS State Code": 51,
+          "FIPS County Code": 590,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Daphne-Fairhope-Foley, AL": [
        {
           "CBSA Code": 19300,
           "Metropolitan Division Code": null,
           "CSA Code": 380,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Mobile-Daphne-Fairhope, AL",
           "County": {
@@ -5468,6 +9520,9 @@
           "CBSA Code": 19340,
           "Metropolitan Division Code": null,
           "CSA Code": 209,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Davenport-Moline, IA-IL",
           "County": {
@@ -5484,6 +9539,9 @@
           "CBSA Code": 19340,
           "Metropolitan Division Code": null,
           "CSA Code": 209,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Davenport-Moline, IA-IL",
           "County": {
@@ -5500,6 +9558,9 @@
           "CBSA Code": 19340,
           "Metropolitan Division Code": null,
           "CSA Code": 209,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Davenport-Moline, IA-IL",
           "County": {
@@ -5516,6 +9577,9 @@
           "CBSA Code": 19340,
           "Metropolitan Division Code": null,
           "CSA Code": 209,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Davenport-Moline, IA-IL",
           "County": {
@@ -5529,11 +9593,35 @@
           }
        }
     ],
+    "Dayton, TN": [
+       {
+          "CBSA Code": 19420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
+          "County": {
+             "County Equivalent": "Rhea County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 143,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Dayton-Kettering, OH": [
        {
           "CBSA Code": 19430,
           "Metropolitan Division Code": null,
           "CSA Code": 212,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Dayton-Springfield-Kettering, OH",
           "County": {
@@ -5550,6 +9638,9 @@
           "CBSA Code": 19430,
           "Metropolitan Division Code": null,
           "CSA Code": 212,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Dayton-Springfield-Kettering, OH",
           "County": {
@@ -5566,6 +9657,9 @@
           "CBSA Code": 19430,
           "Metropolitan Division Code": null,
           "CSA Code": 212,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Dayton-Springfield-Kettering, OH",
           "County": {
@@ -5584,6 +9678,9 @@
           "CBSA Code": 19460,
           "Metropolitan Division Code": null,
           "CSA Code": 290,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Huntsville-Decatur, AL",
           "County": {
@@ -5600,6 +9697,9 @@
           "CBSA Code": 19460,
           "Metropolitan Division Code": null,
           "CSA Code": 290,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Huntsville-Decatur, AL",
           "County": {
@@ -5618,6 +9718,9 @@
           "CBSA Code": 19500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -5631,11 +9734,77 @@
           }
        }
     ],
+    "Decatur, IN": [
+       {
+          "CBSA Code": 19540,
+          "Metropolitan Division Code": null,
+          "CSA Code": 258,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Fort Wayne-Huntington-Auburn, IN",
+          "County": {
+             "County Equivalent": "Adams County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 1,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Defiance, OH": [
+       {
+          "CBSA Code": 19580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Defiance County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 39,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Del Rio, TX": [
+       {
+          "CBSA Code": 19620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Val Verde County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 465,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Deltona-Daytona Beach-Ormond Beach, FL": [
        {
           "CBSA Code": 19660,
           "Metropolitan Division Code": null,
           "CSA Code": 422,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Orlando-Lakeland-Deltona, FL",
           "County": {
@@ -5652,6 +9821,9 @@
           "CBSA Code": 19660,
           "Metropolitan Division Code": null,
           "CSA Code": 422,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Orlando-Lakeland-Deltona, FL",
           "County": {
@@ -5665,11 +9837,35 @@
           }
        }
     ],
+    "Deming, NM": [
+       {
+          "CBSA Code": 19700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Luna County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 29,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Denver-Aurora-Lakewood, CO": [
        {
           "CBSA Code": 19740,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -5686,6 +9882,9 @@
           "CBSA Code": 19740,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -5702,6 +9901,9 @@
           "CBSA Code": 19740,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -5718,6 +9920,9 @@
           "CBSA Code": 19740,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -5734,6 +9939,9 @@
           "CBSA Code": 19740,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -5750,6 +9958,9 @@
           "CBSA Code": 19740,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -5766,6 +9977,9 @@
           "CBSA Code": 19740,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -5782,6 +9996,9 @@
           "CBSA Code": 19740,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -5798,6 +10015,9 @@
           "CBSA Code": 19740,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -5814,6 +10034,9 @@
           "CBSA Code": 19740,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -5827,11 +10050,35 @@
           }
        }
     ],
+    "DeRidder, LA": [
+       {
+          "CBSA Code": 19760,
+          "Metropolitan Division Code": null,
+          "CSA Code": 217,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "DeRidder-Fort Polk South, LA",
+          "County": {
+             "County Equivalent": "Beauregard Parish"
+          },
+          "State Name": "Louisiana",
+          "FIPS State Code": 22,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Des Moines-West Des Moines, IA": [
        {
           "CBSA Code": 19780,
           "Metropolitan Division Code": null,
           "CSA Code": 218,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Des Moines-Ames-West Des Moines, IA",
           "County": {
@@ -5848,6 +10095,9 @@
           "CBSA Code": 19780,
           "Metropolitan Division Code": null,
           "CSA Code": 218,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Des Moines-Ames-West Des Moines, IA",
           "County": {
@@ -5864,6 +10114,9 @@
           "CBSA Code": 19780,
           "Metropolitan Division Code": null,
           "CSA Code": 218,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Des Moines-Ames-West Des Moines, IA",
           "County": {
@@ -5880,6 +10133,9 @@
           "CBSA Code": 19780,
           "Metropolitan Division Code": null,
           "CSA Code": 218,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Des Moines-Ames-West Des Moines, IA",
           "County": {
@@ -5896,6 +10152,9 @@
           "CBSA Code": 19780,
           "Metropolitan Division Code": null,
           "CSA Code": 218,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Des Moines-Ames-West Des Moines, IA",
           "County": {
@@ -5912,6 +10171,9 @@
           "CBSA Code": 19780,
           "Metropolitan Division Code": null,
           "CSA Code": 218,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Des Moines-Ames-West Des Moines, IA",
           "County": {
@@ -5930,6 +10192,9 @@
           "CBSA Code": 19820,
           "Metropolitan Division Code": 19804,
           "CSA Code": 220,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Detroit-Dearborn-Livonia, MI",
           "CSA Title": "Detroit-Warren-Ann Arbor, MI",
           "County": {
@@ -5946,6 +10211,9 @@
           "CBSA Code": 19820,
           "Metropolitan Division Code": 47664,
           "CSA Code": 220,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Warren-Troy-Farmington Hills, MI",
           "CSA Title": "Detroit-Warren-Ann Arbor, MI",
           "County": {
@@ -5962,6 +10230,9 @@
           "CBSA Code": 19820,
           "Metropolitan Division Code": 47664,
           "CSA Code": 220,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Warren-Troy-Farmington Hills, MI",
           "CSA Title": "Detroit-Warren-Ann Arbor, MI",
           "County": {
@@ -5978,6 +10249,9 @@
           "CBSA Code": 19820,
           "Metropolitan Division Code": 47664,
           "CSA Code": 220,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Warren-Troy-Farmington Hills, MI",
           "CSA Title": "Detroit-Warren-Ann Arbor, MI",
           "County": {
@@ -5994,6 +10268,9 @@
           "CBSA Code": 19820,
           "Metropolitan Division Code": 47664,
           "CSA Code": 220,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Warren-Troy-Farmington Hills, MI",
           "CSA Title": "Detroit-Warren-Ann Arbor, MI",
           "County": {
@@ -6010,6 +10287,9 @@
           "CBSA Code": 19820,
           "Metropolitan Division Code": 47664,
           "CSA Code": 220,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Warren-Troy-Farmington Hills, MI",
           "CSA Title": "Detroit-Warren-Ann Arbor, MI",
           "County": {
@@ -6023,11 +10303,96 @@
           }
        }
     ],
+    "Dickinson, ND": [
+       {
+          "CBSA Code": 19860,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Billings County"
+          },
+          "State Name": "North Dakota",
+          "FIPS State Code": 38,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 19860,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Stark County"
+          },
+          "State Name": "North Dakota",
+          "FIPS State Code": 38,
+          "FIPS County Code": 89,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Dixon, IL": [
+       {
+          "CBSA Code": 19940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 221,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dixon-Sterling, IL",
+          "County": {
+             "County Equivalent": "Lee County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 103,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Dodge City, KS": [
+       {
+          "CBSA Code": 19980,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Ford County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 57,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Dothan, AL": [
        {
           "CBSA Code": 20020,
           "Metropolitan Division Code": null,
           "CSA Code": 222,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Dothan-Ozark, AL",
           "County": {
@@ -6044,6 +10409,9 @@
           "CBSA Code": 20020,
           "Metropolitan Division Code": null,
           "CSA Code": 222,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Dothan-Ozark, AL",
           "County": {
@@ -6060,6 +10428,9 @@
           "CBSA Code": 20020,
           "Metropolitan Division Code": null,
           "CSA Code": 222,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Dothan-Ozark, AL",
           "County": {
@@ -6073,11 +10444,54 @@
           }
        }
     ],
+    "Douglas, GA": [
+       {
+          "CBSA Code": 20060,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Atkinson County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 3,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 20060,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Coffee County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 69,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Dover, DE": [
        {
           "CBSA Code": 20100,
           "Metropolitan Division Code": null,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -6091,11 +10505,94 @@
           }
        }
     ],
+    "Dublin, GA": [
+       {
+          "CBSA Code": 20140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Johnson County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 167,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 20140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Laurens County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 175,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 20140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Treutlen County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 283,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "DuBois, PA": [
+       {
+          "CBSA Code": 20180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 524,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "State College-DuBois, PA",
+          "County": {
+             "County Equivalent": "Clearfield County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 33,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Dubuque, IA": [
        {
           "CBSA Code": 20220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6114,6 +10611,9 @@
           "CBSA Code": 20260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6130,6 +10630,9 @@
           "CBSA Code": 20260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6146,6 +10649,9 @@
           "CBSA Code": 20260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6162,6 +10668,9 @@
           "CBSA Code": 20260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6175,11 +10684,98 @@
           }
        }
     ],
+    "Dumas, TX": [
+       {
+          "CBSA Code": 20300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Moore County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 341,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Duncan, OK": [
+       {
+          "CBSA Code": 20340,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Stephens County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 137,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Durango, CO": [
+       {
+          "CBSA Code": 20420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "La Plata County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 67,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Durant, OK": [
+       {
+          "CBSA Code": 20460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dallas-Fort Worth, TX-OK",
+          "County": {
+             "County Equivalent": "Bryan County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Durham-Chapel Hill, NC": [
        {
           "CBSA Code": 20500,
           "Metropolitan Division Code": null,
           "CSA Code": 450,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Raleigh-Durham-Cary, NC",
           "County": {
@@ -6196,6 +10792,9 @@
           "CBSA Code": 20500,
           "Metropolitan Division Code": null,
           "CSA Code": 450,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Raleigh-Durham-Cary, NC",
           "County": {
@@ -6212,6 +10811,9 @@
           "CBSA Code": 20500,
           "Metropolitan Division Code": null,
           "CSA Code": 450,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Raleigh-Durham-Cary, NC",
           "County": {
@@ -6228,6 +10830,9 @@
           "CBSA Code": 20500,
           "Metropolitan Division Code": null,
           "CSA Code": 450,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Raleigh-Durham-Cary, NC",
           "County": {
@@ -6244,6 +10849,9 @@
           "CBSA Code": 20500,
           "Metropolitan Division Code": null,
           "CSA Code": 450,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Raleigh-Durham-Cary, NC",
           "County": {
@@ -6257,11 +10865,77 @@
           }
        }
     ],
+    "Dyersburg, TN": [
+       {
+          "CBSA Code": 20540,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Dyer County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Eagle Pass, TX": [
+       {
+          "CBSA Code": 20580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Maverick County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 323,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Easton, MD": [
+       {
+          "CBSA Code": 20660,
+          "Metropolitan Division Code": null,
+          "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
+          "County": {
+             "County Equivalent": "Talbot County"
+          },
+          "State Name": "Maryland",
+          "FIPS State Code": 24,
+          "FIPS County Code": 41,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "East Stroudsburg, PA": [
        {
           "CBSA Code": 20700,
           "Metropolitan Division Code": null,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -6280,6 +10954,9 @@
           "CBSA Code": 20740,
           "Metropolitan Division Code": null,
           "CSA Code": 232,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Eau Claire-Menomonie, WI",
           "County": {
@@ -6296,6 +10973,9 @@
           "CBSA Code": 20740,
           "Metropolitan Division Code": null,
           "CSA Code": 232,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Eau Claire-Menomonie, WI",
           "County": {
@@ -6309,11 +10989,77 @@
           }
        }
     ],
+    "Edwards, CO": [
+       {
+          "CBSA Code": 20780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 233,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Edwards-Glenwood Springs, CO",
+          "County": {
+             "County Equivalent": "Eagle County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 37,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Effingham, IL": [
+       {
+          "CBSA Code": 20820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Effingham County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 49,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "El Campo, TX": [
+       {
+          "CBSA Code": 20900,
+          "Metropolitan Division Code": null,
+          "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Houston-The Woodlands, TX",
+          "County": {
+             "County Equivalent": "Wharton County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 481,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "El Centro, CA": [
        {
           "CBSA Code": 20940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6327,11 +11073,75 @@
           }
        }
     ],
+    "El Dorado, AR": [
+       {
+          "CBSA Code": 20980,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Union County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 139,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Elizabeth City, NC": [
+       {
+          "CBSA Code": 21020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Virginia Beach-Norfolk, VA-NC",
+          "County": {
+             "County Equivalent": "Pasquotank County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 139,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 21020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Virginia Beach-Norfolk, VA-NC",
+          "County": {
+             "County Equivalent": "Perquimans County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 143,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Elizabethtown-Fort Knox, KY": [
        {
           "CBSA Code": 21060,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -6348,6 +11158,9 @@
           "CBSA Code": 21060,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -6364,6 +11177,9 @@
           "CBSA Code": 21060,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -6377,11 +11193,35 @@
           }
        }
     ],
+    "Elk City, OK": [
+       {
+          "CBSA Code": 21120,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Beckham County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 9,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Elkhart-Goshen, IN": [
        {
           "CBSA Code": 21140,
           "Metropolitan Division Code": null,
           "CSA Code": 515,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "South Bend-Elkhart-Mishawaka, IN-MI",
           "County": {
@@ -6395,11 +11235,96 @@
           }
        }
     ],
+    "Elkins, WV": [
+       {
+          "CBSA Code": 21180,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Randolph County"
+          },
+          "State Name": "West Virginia",
+          "FIPS State Code": 54,
+          "FIPS County Code": 83,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Elko, NV": [
+       {
+          "CBSA Code": 21220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Elko County"
+          },
+          "State Name": "Nevada",
+          "FIPS State Code": 32,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 21220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Eureka County"
+          },
+          "State Name": "Nevada",
+          "FIPS State Code": 32,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Ellensburg, WA": [
+       {
+          "CBSA Code": 21260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Kittitas County"
+          },
+          "State Name": "Washington",
+          "FIPS State Code": 53,
+          "FIPS County Code": 37,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Elmira, NY": [
        {
           "CBSA Code": 21300,
           "Metropolitan Division Code": null,
           "CSA Code": 236,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Elmira-Corning, NY",
           "County": {
@@ -6418,6 +11343,9 @@
           "CBSA Code": 21340,
           "Metropolitan Division Code": null,
           "CSA Code": 238,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "El Paso-Las Cruces, TX-NM",
           "County": {
@@ -6434,6 +11362,9 @@
           "CBSA Code": 21340,
           "Metropolitan Division Code": null,
           "CSA Code": 238,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "El Paso-Las Cruces, TX-NM",
           "County": {
@@ -6447,11 +11378,54 @@
           }
        }
     ],
+    "Emporia, KS": [
+       {
+          "CBSA Code": 21380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Chase County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 17,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 21380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lyon County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 111,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Enid, OK": [
        {
           "CBSA Code": 21420,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6465,11 +11439,35 @@
           }
        }
     ],
+    "Enterprise, AL": [
+       {
+          "CBSA Code": 21460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Coffee County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 31,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Erie, PA": [
        {
           "CBSA Code": 21500,
           "Metropolitan Division Code": null,
           "CSA Code": 240,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Erie-Meadville, PA",
           "County": {
@@ -6483,11 +11481,96 @@
           }
        }
     ],
+    "Escanaba, MI": [
+       {
+          "CBSA Code": 21540,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Delta County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 41,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Espa�ola, NM": [
+       {
+          "CBSA Code": 21580,
+          "Metropolitan Division Code": null,
+          "CSA Code": 106,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Albuquerque-Santa Fe-Las Vegas, NM",
+          "County": {
+             "County Equivalent": "Rio Arriba County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 39,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Eufaula, AL-GA": [
+       {
+          "CBSA Code": 21640,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Barbour County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 21640,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Quitman County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 239,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Eugene-Springfield, OR": [
        {
           "CBSA Code": 21660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6501,11 +11584,56 @@
           }
        }
     ],
+    "Eureka-Arcata, CA": [
+       {
+          "CBSA Code": 21700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Humboldt County"
+          },
+          "State Name": "California",
+          "FIPS State Code": 6,
+          "FIPS County Code": 23,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Evanston, WY": [
+       {
+          "CBSA Code": 21740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Uinta County"
+          },
+          "State Name": "Wyoming",
+          "FIPS State Code": 56,
+          "FIPS County Code": 41,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Evansville, IN-KY": [
        {
           "CBSA Code": 21780,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6522,6 +11650,9 @@
           "CBSA Code": 21780,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6538,6 +11669,9 @@
           "CBSA Code": 21780,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6554,6 +11688,9 @@
           "CBSA Code": 21780,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6572,6 +11709,9 @@
           "CBSA Code": 21820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6585,11 +11725,98 @@
           }
        }
     ],
+    "Fairfield, IA": [
+       {
+          "CBSA Code": 21840,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Jefferson County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 101,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fairmont, MN": [
+       {
+          "CBSA Code": 21860,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Martin County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 91,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fairmont, WV": [
+       {
+          "CBSA Code": 21900,
+          "Metropolitan Division Code": null,
+          "CSA Code": 390,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Morgantown-Fairmont, WV",
+          "County": {
+             "County Equivalent": "Marion County"
+          },
+          "State Name": "West Virginia",
+          "FIPS State Code": 54,
+          "FIPS County Code": 49,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fallon, NV": [
+       {
+          "CBSA Code": 21980,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Churchill County"
+          },
+          "State Name": "Nevada",
+          "FIPS State Code": 32,
+          "FIPS County Code": 1,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Fargo, ND-MN": [
        {
           "CBSA Code": 22020,
           "Metropolitan Division Code": null,
           "CSA Code": 244,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Fargo-Wahpeton, ND-MN",
           "County": {
@@ -6606,6 +11833,9 @@
           "CBSA Code": 22020,
           "Metropolitan Division Code": null,
           "CSA Code": 244,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Fargo-Wahpeton, ND-MN",
           "County": {
@@ -6619,11 +11849,56 @@
           }
        }
     ],
+    "Faribault-Northfield, MN": [
+       {
+          "CBSA Code": 22060,
+          "Metropolitan Division Code": null,
+          "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Minneapolis-St. Paul, MN-WI",
+          "County": {
+             "County Equivalent": "Rice County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 131,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Farmington, MO": [
+       {
+          "CBSA Code": 22100,
+          "Metropolitan Division Code": null,
+          "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
+          "County": {
+             "County Equivalent": "St. Francois County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 187,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Farmington, NM": [
        {
           "CBSA Code": 22140,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6642,6 +11917,9 @@
           "CBSA Code": 22180,
           "Metropolitan Division Code": null,
           "CSA Code": 246,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Fayetteville-Sanford-Lumberton, NC",
           "County": {
@@ -6658,6 +11936,9 @@
           "CBSA Code": 22180,
           "Metropolitan Division Code": null,
           "CSA Code": 246,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Fayetteville-Sanford-Lumberton, NC",
           "County": {
@@ -6674,6 +11955,9 @@
           "CBSA Code": 22180,
           "Metropolitan Division Code": null,
           "CSA Code": 246,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Fayetteville-Sanford-Lumberton, NC",
           "County": {
@@ -6692,6 +11976,9 @@
           "CBSA Code": 22220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6708,6 +11995,9 @@
           "CBSA Code": 22220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6724,6 +12014,9 @@
           "CBSA Code": 22220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6737,11 +12030,98 @@
           }
        }
     ],
+    "Fergus Falls, MN": [
+       {
+          "CBSA Code": 22260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Otter Tail County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 111,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fernley, NV": [
+       {
+          "CBSA Code": 22280,
+          "Metropolitan Division Code": null,
+          "CSA Code": 456,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Reno-Carson City-Fernley, NV",
+          "County": {
+             "County Equivalent": "Lyon County"
+          },
+          "State Name": "Nevada",
+          "FIPS State Code": 32,
+          "FIPS County Code": 19,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Findlay, OH": [
+       {
+          "CBSA Code": 22300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 534,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Toledo-Findlay-Tiffin, OH",
+          "County": {
+             "County Equivalent": "Hancock County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 63,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fitzgerald, GA": [
+       {
+          "CBSA Code": 22340,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Ben Hill County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 17,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Flagstaff, AZ": [
        {
           "CBSA Code": 22380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6760,6 +12140,9 @@
           "CBSA Code": 22420,
           "Metropolitan Division Code": null,
           "CSA Code": 220,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Detroit-Warren-Ann Arbor, MI",
           "County": {
@@ -6778,6 +12161,9 @@
           "CBSA Code": 22500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6794,6 +12180,9 @@
           "CBSA Code": 22500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6812,6 +12201,9 @@
           "CBSA Code": 22520,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6828,6 +12220,9 @@
           "CBSA Code": 22520,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6846,6 +12241,9 @@
           "CBSA Code": 22540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6859,11 +12257,56 @@
           }
        }
     ],
+    "Forest City, NC": [
+       {
+          "CBSA Code": 22580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Rutherford County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 161,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Forrest City, AR": [
+       {
+          "CBSA Code": 22620,
+          "Metropolitan Division Code": null,
+          "CSA Code": 368,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Memphis-Forrest City, TN-MS-AR",
+          "County": {
+             "County Equivalent": "St. Francis County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 123,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Fort Collins, CO": [
        {
           "CBSA Code": 22660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6877,11 +12320,178 @@
           }
        }
     ],
+    "Fort Dodge, IA": [
+       {
+          "CBSA Code": 22700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Webster County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 187,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fort Leonard Wood, MO": [
+       {
+          "CBSA Code": 22780,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pulaski County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 169,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fort Madison-Keokuk, IA-IL-MO": [
+       {
+          "CBSA Code": 22800,
+          "Metropolitan Division Code": null,
+          "CSA Code": 161,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Burlington-Fort Madison-Keokuk, IA-IL-MO",
+          "County": {
+             "County Equivalent": "Hancock County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 67,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 22800,
+          "Metropolitan Division Code": null,
+          "CSA Code": 161,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Burlington-Fort Madison-Keokuk, IA-IL-MO",
+          "County": {
+             "County Equivalent": "Lee County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 111,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 22800,
+          "Metropolitan Division Code": null,
+          "CSA Code": 161,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Burlington-Fort Madison-Keokuk, IA-IL-MO",
+          "County": {
+             "County Equivalent": "Clark County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Fort Morgan, CO": [
+       {
+          "CBSA Code": 22820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Morgan County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 87,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fort Payne, AL": [
+       {
+          "CBSA Code": 22840,
+          "Metropolitan Division Code": null,
+          "CSA Code": 497,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Scottsboro-Fort Payne, AL",
+          "County": {
+             "County Equivalent": "DeKalb County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 49,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fort Polk South, LA": [
+       {
+          "CBSA Code": 22860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 217,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "DeRidder-Fort Polk South, LA",
+          "County": {
+             "County Equivalent": "Vernon Parish"
+          },
+          "State Name": "Louisiana",
+          "FIPS State Code": 22,
+          "FIPS County Code": 115,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Fort Smith, AR-OK": [
        {
           "CBSA Code": 22900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6898,6 +12508,9 @@
           "CBSA Code": 22900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6914,6 +12527,9 @@
           "CBSA Code": 22900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6930,6 +12546,9 @@
           "CBSA Code": 22900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -6948,6 +12567,9 @@
           "CBSA Code": 23060,
           "Metropolitan Division Code": null,
           "CSA Code": 258,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Fort Wayne-Huntington-Auburn, IN",
           "County": {
@@ -6964,6 +12586,9 @@
           "CBSA Code": 23060,
           "Metropolitan Division Code": null,
           "CSA Code": 258,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Fort Wayne-Huntington-Auburn, IN",
           "County": {
@@ -6977,11 +12602,159 @@
           }
        }
     ],
+    "Frankfort, IN": [
+       {
+          "CBSA Code": 23140,
+          "Metropolitan Division Code": null,
+          "CSA Code": 320,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lafayette-West Lafayette-Frankfort, IN",
+          "County": {
+             "County Equivalent": "Clinton County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 23,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Frankfort, KY": [
+       {
+          "CBSA Code": 23180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
+          "County": {
+             "County Equivalent": "Anderson County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 23180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
+          "County": {
+             "County Equivalent": "Franklin County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 73,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fredericksburg, TX": [
+       {
+          "CBSA Code": 23240,
+          "Metropolitan Division Code": null,
+          "CSA Code": 314,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Kerrville-Fredericksburg, TX",
+          "County": {
+             "County Equivalent": "Gillespie County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 171,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Freeport, IL": [
+       {
+          "CBSA Code": 23300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 466,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Rockford-Freeport-Rochelle, IL",
+          "County": {
+             "County Equivalent": "Stephenson County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 177,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fremont, NE": [
+       {
+          "CBSA Code": 23340,
+          "Metropolitan Division Code": null,
+          "CSA Code": 420,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Omaha-Council Bluffs-Fremont, NE-IA",
+          "County": {
+             "County Equivalent": "Dodge County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 53,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Fremont, OH": [
+       {
+          "CBSA Code": 23380,
+          "Metropolitan Division Code": null,
+          "CSA Code": 534,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Toledo-Findlay-Tiffin, OH",
+          "County": {
+             "County Equivalent": "Sandusky County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 143,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Fresno, CA": [
        {
           "CBSA Code": 23420,
           "Metropolitan Division Code": null,
           "CSA Code": 260,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Fresno-Madera-Hanford, CA",
           "County": {
@@ -7000,6 +12773,9 @@
           "CBSA Code": 23460,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7013,11 +12789,35 @@
           }
        }
     ],
+    "Gaffney, SC": [
+       {
+          "CBSA Code": 23500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 273,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Greenville-Spartanburg-Anderson, SC",
+          "County": {
+             "County Equivalent": "Cherokee County"
+          },
+          "State Name": "South Carolina",
+          "FIPS State Code": 45,
+          "FIPS County Code": 21,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Gainesville, FL": [
        {
           "CBSA Code": 23540,
           "Metropolitan Division Code": null,
           "CSA Code": 264,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Gainesville-Lake City, FL",
           "County": {
@@ -7034,6 +12834,9 @@
           "CBSA Code": 23540,
           "Metropolitan Division Code": null,
           "CSA Code": 264,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Gainesville-Lake City, FL",
           "County": {
@@ -7050,6 +12853,9 @@
           "CBSA Code": 23540,
           "Metropolitan Division Code": null,
           "CSA Code": 264,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Gainesville-Lake City, FL",
           "County": {
@@ -7068,6 +12874,9 @@
           "CBSA Code": 23580,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -7081,11 +12890,159 @@
           }
        }
     ],
+    "Gainesville, TX": [
+       {
+          "CBSA Code": 23620,
+          "Metropolitan Division Code": null,
+          "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dallas-Fort Worth, TX-OK",
+          "County": {
+             "County Equivalent": "Cooke County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 97,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Galesburg, IL": [
+       {
+          "CBSA Code": 23660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Knox County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 95,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Gallup, NM": [
+       {
+          "CBSA Code": 23700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "McKinley County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 31,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Garden City, KS": [
+       {
+          "CBSA Code": 23780,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Finney County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 55,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 23780,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Kearny County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 93,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Gardnerville Ranchos, NV": [
+       {
+          "CBSA Code": 23820,
+          "Metropolitan Division Code": null,
+          "CSA Code": 456,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Reno-Carson City-Fernley, NV",
+          "County": {
+             "County Equivalent": "Douglas County"
+          },
+          "State Name": "Nevada",
+          "FIPS State Code": 32,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Georgetown, SC": [
+       {
+          "CBSA Code": 23860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 396,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Myrtle Beach-Conway, SC-NC",
+          "County": {
+             "County Equivalent": "Georgetown County"
+          },
+          "State Name": "South Carolina",
+          "FIPS State Code": 45,
+          "FIPS County Code": 43,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Gettysburg, PA": [
        {
           "CBSA Code": 23900,
           "Metropolitan Division Code": null,
           "CSA Code": 276,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Harrisburg-York-Lebanon, PA",
           "County": {
@@ -7099,11 +13056,113 @@
           }
        }
     ],
+    "Gillette, WY": [
+       {
+          "CBSA Code": 23940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Campbell County"
+          },
+          "State Name": "Wyoming",
+          "FIPS State Code": 56,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 23940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Crook County"
+          },
+          "State Name": "Wyoming",
+          "FIPS State Code": 56,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 23940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Weston County"
+          },
+          "State Name": "Wyoming",
+          "FIPS State Code": 56,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Glasgow, KY": [
+       {
+          "CBSA Code": 23980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 150,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Bowling Green-Glasgow, KY",
+          "County": {
+             "County Equivalent": "Barren County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 9,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 23980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 150,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Bowling Green-Glasgow, KY",
+          "County": {
+             "County Equivalent": "Metcalfe County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 169,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Glens Falls, NY": [
        {
           "CBSA Code": 24020,
           "Metropolitan Division Code": null,
           "CSA Code": 104,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albany-Schenectady, NY",
           "County": {
@@ -7120,6 +13179,9 @@
           "CBSA Code": 24020,
           "Metropolitan Division Code": null,
           "CSA Code": 104,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albany-Schenectady, NY",
           "County": {
@@ -7133,11 +13195,75 @@
           }
        }
     ],
+    "Glenwood Springs, CO": [
+       {
+          "CBSA Code": 24060,
+          "Metropolitan Division Code": null,
+          "CSA Code": 233,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Edwards-Glenwood Springs, CO",
+          "County": {
+             "County Equivalent": "Garfield County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 24060,
+          "Metropolitan Division Code": null,
+          "CSA Code": 233,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Edwards-Glenwood Springs, CO",
+          "County": {
+             "County Equivalent": "Pitkin County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 97,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Gloversville, NY": [
+       {
+          "CBSA Code": 24100,
+          "Metropolitan Division Code": null,
+          "CSA Code": 104,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Albany-Schenectady, NY",
+          "County": {
+             "County Equivalent": "Fulton County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 35,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Goldsboro, NC": [
        {
           "CBSA Code": 24140,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7151,11 +13277,35 @@
           }
        }
     ],
+    "Granbury, TX": [
+       {
+          "CBSA Code": 24180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dallas-Fort Worth, TX-OK",
+          "County": {
+             "County Equivalent": "Hood County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 221,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Grand Forks, ND-MN": [
        {
           "CBSA Code": 24220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7172,6 +13322,9 @@
           "CBSA Code": 24220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7190,6 +13343,9 @@
           "CBSA Code": 24260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7206,6 +13362,9 @@
           "CBSA Code": 24260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7222,6 +13381,9 @@
           "CBSA Code": 24260,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7240,6 +13402,9 @@
           "CBSA Code": 24300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7253,11 +13418,35 @@
           }
        }
     ],
+    "Grand Rapids, MN": [
+       {
+          "CBSA Code": 24330,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Itasca County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 61,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Grand Rapids-Kentwood, MI": [
        {
           "CBSA Code": 24340,
           "Metropolitan Division Code": null,
           "CSA Code": 266,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Grand Rapids-Kentwood-Muskegon, MI",
           "County": {
@@ -7274,6 +13463,9 @@
           "CBSA Code": 24340,
           "Metropolitan Division Code": null,
           "CSA Code": 266,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Grand Rapids-Kentwood-Muskegon, MI",
           "County": {
@@ -7290,6 +13482,9 @@
           "CBSA Code": 24340,
           "Metropolitan Division Code": null,
           "CSA Code": 266,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Grand Rapids-Kentwood-Muskegon, MI",
           "County": {
@@ -7306,6 +13501,9 @@
           "CBSA Code": 24340,
           "Metropolitan Division Code": null,
           "CSA Code": 266,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Grand Rapids-Kentwood-Muskegon, MI",
           "County": {
@@ -7319,11 +13517,35 @@
           }
        }
     ],
+    "Grants, NM": [
+       {
+          "CBSA Code": 24380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Cibola County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 6,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Grants Pass, OR": [
        {
           "CBSA Code": 24420,
           "Metropolitan Division Code": null,
           "CSA Code": 366,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Medford-Grants Pass, OR",
           "County": {
@@ -7337,11 +13559,35 @@
           }
        }
     ],
+    "Great Bend, KS": [
+       {
+          "CBSA Code": 24460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Barton County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 9,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Great Falls, MT": [
        {
           "CBSA Code": 24500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7360,6 +13606,9 @@
           "CBSA Code": 24540,
           "Metropolitan Division Code": null,
           "CSA Code": 216,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Denver-Aurora, CO",
           "County": {
@@ -7378,6 +13627,9 @@
           "CBSA Code": 24580,
           "Metropolitan Division Code": null,
           "CSA Code": 267,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Green Bay-Shawano, WI",
           "County": {
@@ -7394,6 +13646,9 @@
           "CBSA Code": 24580,
           "Metropolitan Division Code": null,
           "CSA Code": 267,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Green Bay-Shawano, WI",
           "County": {
@@ -7410,6 +13665,9 @@
           "CBSA Code": 24580,
           "Metropolitan Division Code": null,
           "CSA Code": 267,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Green Bay-Shawano, WI",
           "County": {
@@ -7423,11 +13681,35 @@
           }
        }
     ],
+    "Greeneville, TN": [
+       {
+          "CBSA Code": 24620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Greene County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 59,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Greensboro-High Point, NC": [
        {
           "CBSA Code": 24660,
           "Metropolitan Division Code": null,
           "CSA Code": 268,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greensboro--Winston-Salem--High Point, NC",
           "County": {
@@ -7444,6 +13726,9 @@
           "CBSA Code": 24660,
           "Metropolitan Division Code": null,
           "CSA Code": 268,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greensboro--Winston-Salem--High Point, NC",
           "County": {
@@ -7460,6 +13745,9 @@
           "CBSA Code": 24660,
           "Metropolitan Division Code": null,
           "CSA Code": 268,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greensboro--Winston-Salem--High Point, NC",
           "County": {
@@ -7473,11 +13761,56 @@
           }
        }
     ],
+    "Greensburg, IN": [
+       {
+          "CBSA Code": 24700,
+          "Metropolitan Division Code": null,
+          "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Indianapolis-Carmel-Muncie, IN",
+          "County": {
+             "County Equivalent": "Decatur County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 31,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Greenville, MS": [
+       {
+          "CBSA Code": 24740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Washington County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 151,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Greenville, NC": [
        {
           "CBSA Code": 24780,
           "Metropolitan Division Code": null,
           "CSA Code": 272,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greenville-Kinston-Washington, NC",
           "County": {
@@ -7491,11 +13824,35 @@
           }
        }
     ],
+    "Greenville, OH": [
+       {
+          "CBSA Code": 24820,
+          "Metropolitan Division Code": null,
+          "CSA Code": 212,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dayton-Springfield-Kettering, OH",
+          "County": {
+             "County Equivalent": "Darke County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 37,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Greenville-Anderson, SC": [
        {
           "CBSA Code": 24860,
           "Metropolitan Division Code": null,
           "CSA Code": 273,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greenville-Spartanburg-Anderson, SC",
           "County": {
@@ -7512,6 +13869,9 @@
           "CBSA Code": 24860,
           "Metropolitan Division Code": null,
           "CSA Code": 273,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greenville-Spartanburg-Anderson, SC",
           "County": {
@@ -7528,6 +13888,9 @@
           "CBSA Code": 24860,
           "Metropolitan Division Code": null,
           "CSA Code": 273,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greenville-Spartanburg-Anderson, SC",
           "County": {
@@ -7544,6 +13907,9 @@
           "CBSA Code": 24860,
           "Metropolitan Division Code": null,
           "CSA Code": 273,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greenville-Spartanburg-Anderson, SC",
           "County": {
@@ -7557,13 +13923,98 @@
           }
        }
     ],
+    "Greenwood, MS": [
+       {
+          "CBSA Code": 24900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Carroll County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 15,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 24900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Leflore County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 83,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Greenwood, SC": [
+       {
+          "CBSA Code": 24940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 273,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Greenville-Spartanburg-Anderson, SC",
+          "County": {
+             "County Equivalent": "Greenwood County"
+          },
+          "State Name": "South Carolina",
+          "FIPS State Code": 45,
+          "FIPS County Code": 47,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Grenada, MS": [
+       {
+          "CBSA Code": 24980,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Grenada County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 43,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Guayama, PR": [
        {
           "CBSA Code": 25020,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Arroyo Municipio"
           },
@@ -7578,8 +14029,11 @@
           "CBSA Code": 25020,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Guayama Municipio"
           },
@@ -7594,8 +14048,11 @@
           "CBSA Code": 25020,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Patillas Municipio"
           },
@@ -7612,6 +14069,9 @@
           "CBSA Code": 25060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7628,6 +14088,9 @@
           "CBSA Code": 25060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7644,6 +14107,9 @@
           "CBSA Code": 25060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7660,6 +14126,9 @@
           "CBSA Code": 25060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7673,11 +14142,35 @@
           }
        }
     ],
+    "Guymon, OK": [
+       {
+          "CBSA Code": 25100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Texas County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 139,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Hagerstown-Martinsburg, MD-WV": [
        {
           "CBSA Code": 25180,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -7694,6 +14187,9 @@
           "CBSA Code": 25180,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -7710,6 +14206,9 @@
           "CBSA Code": 25180,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -7723,11 +14222,54 @@
           }
        }
     ],
+    "Hailey, ID": [
+       {
+          "CBSA Code": 25200,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Blaine County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 25200,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Camas County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 25,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Hammond, LA": [
        {
           "CBSA Code": 25220,
           "Metropolitan Division Code": null,
           "CSA Code": 406,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Orleans-Metairie-Hammond, LA-MS",
           "County": {
@@ -7746,6 +14288,9 @@
           "CBSA Code": 25260,
           "Metropolitan Division Code": null,
           "CSA Code": 260,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Fresno-Madera-Hanford, CA",
           "County": {
@@ -7759,11 +14304,54 @@
           }
        }
     ],
+    "Hannibal, MO": [
+       {
+          "CBSA Code": 25300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 448,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Quincy-Hannibal, IL-MO",
+          "County": {
+             "County Equivalent": "Marion County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 127,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 25300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 448,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Quincy-Hannibal, IL-MO",
+          "County": {
+             "County Equivalent": "Ralls County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 173,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Harrisburg-Carlisle, PA": [
        {
           "CBSA Code": 25420,
           "Metropolitan Division Code": null,
           "CSA Code": 276,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Harrisburg-York-Lebanon, PA",
           "County": {
@@ -7780,6 +14368,9 @@
           "CBSA Code": 25420,
           "Metropolitan Division Code": null,
           "CSA Code": 276,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Harrisburg-York-Lebanon, PA",
           "County": {
@@ -7796,6 +14387,9 @@
           "CBSA Code": 25420,
           "Metropolitan Division Code": null,
           "CSA Code": 276,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Harrisburg-York-Lebanon, PA",
           "County": {
@@ -7809,11 +14403,54 @@
           }
        }
     ],
+    "Harrison, AR": [
+       {
+          "CBSA Code": 25460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Boone County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 9,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 25460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Newton County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 101,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Harrisonburg, VA": [
        {
           "CBSA Code": 25500,
           "Metropolitan Division Code": null,
           "CSA Code": 277,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Harrisonburg-Staunton, VA",
           "County": {
@@ -7830,6 +14467,9 @@
           "CBSA Code": 25500,
           "Metropolitan Division Code": null,
           "CSA Code": 277,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Harrisonburg-Staunton, VA",
           "County": {
@@ -7848,6 +14488,9 @@
           "CBSA Code": 25540,
           "Metropolitan Division Code": null,
           "CSA Code": 278,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Hartford-East Hartford, CT",
           "County": {
@@ -7864,6 +14507,9 @@
           "CBSA Code": 25540,
           "Metropolitan Division Code": null,
           "CSA Code": 278,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Hartford-East Hartford, CT",
           "County": {
@@ -7880,6 +14526,9 @@
           "CBSA Code": 25540,
           "Metropolitan Division Code": null,
           "CSA Code": 278,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Hartford-East Hartford, CT",
           "County": {
@@ -7893,11 +14542,35 @@
           }
        }
     ],
+    "Hastings, NE": [
+       {
+          "CBSA Code": 25580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Adams County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 1,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Hattiesburg, MS": [
        {
           "CBSA Code": 25620,
           "Metropolitan Division Code": null,
           "CSA Code": 279,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Hattiesburg-Laurel, MS",
           "County": {
@@ -7914,6 +14587,9 @@
           "CBSA Code": 25620,
           "Metropolitan Division Code": null,
           "CSA Code": 279,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Hattiesburg-Laurel, MS",
           "County": {
@@ -7930,6 +14606,9 @@
           "CBSA Code": 25620,
           "Metropolitan Division Code": null,
           "CSA Code": 279,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Hattiesburg-Laurel, MS",
           "County": {
@@ -7946,6 +14625,9 @@
           "CBSA Code": 25620,
           "Metropolitan Division Code": null,
           "CSA Code": 279,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Hattiesburg-Laurel, MS",
           "County": {
@@ -7959,11 +14641,218 @@
           }
        }
     ],
+    "Hays, KS": [
+       {
+          "CBSA Code": 25700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Ellis County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 51,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Heber, UT": [
+       {
+          "CBSA Code": 25720,
+          "Metropolitan Division Code": null,
+          "CSA Code": 482,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Salt Lake City-Provo-Orem, UT",
+          "County": {
+             "County Equivalent": "Summit County"
+          },
+          "State Name": "Utah",
+          "FIPS State Code": 49,
+          "FIPS County Code": 43,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 25720,
+          "Metropolitan Division Code": null,
+          "CSA Code": 482,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Salt Lake City-Provo-Orem, UT",
+          "County": {
+             "County Equivalent": "Wasatch County"
+          },
+          "State Name": "Utah",
+          "FIPS State Code": 49,
+          "FIPS County Code": 51,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Helena, MT": [
+       {
+          "CBSA Code": 25740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Jefferson County"
+          },
+          "State Name": "Montana",
+          "FIPS State Code": 30,
+          "FIPS County Code": 43,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 25740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lewis and Clark County"
+          },
+          "State Name": "Montana",
+          "FIPS State Code": 30,
+          "FIPS County Code": 49,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Helena-West Helena, AR": [
+       {
+          "CBSA Code": 25760,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Phillips County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 107,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Henderson, NC": [
+       {
+          "CBSA Code": 25780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 450,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Raleigh-Durham-Cary, NC",
+          "County": {
+             "County Equivalent": "Vance County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 181,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Hereford, TX": [
+       {
+          "CBSA Code": 25820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Deaf Smith County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 117,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Hermiston-Pendleton, OR": [
+       {
+          "CBSA Code": 25840,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Morrow County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 49,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 25840,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Umatilla County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 59,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Hickory-Lenoir-Morganton, NC": [
        {
           "CBSA Code": 25860,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7980,6 +14869,9 @@
           "CBSA Code": 25860,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -7996,6 +14888,9 @@
           "CBSA Code": 25860,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -8012,6 +14907,9 @@
           "CBSA Code": 25860,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -8025,11 +14923,56 @@
           }
        }
     ],
+    "Hillsdale, MI": [
+       {
+          "CBSA Code": 25880,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Hillsdale County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 59,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Hilo, HI": [
+       {
+          "CBSA Code": 25900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Hawaii County"
+          },
+          "State Name": "Hawaii",
+          "FIPS State Code": 15,
+          "FIPS County Code": 1,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Hilton Head Island-Bluffton, SC": [
        {
           "CBSA Code": 25940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -8046,6 +14989,9 @@
           "CBSA Code": 25940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -8064,6 +15010,9 @@
           "CBSA Code": 25980,
           "Metropolitan Division Code": null,
           "CSA Code": 496,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Savannah-Hinesville-Statesboro, GA",
           "County": {
@@ -8080,6 +15029,9 @@
           "CBSA Code": 25980,
           "Metropolitan Division Code": null,
           "CSA Code": 496,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Savannah-Hinesville-Statesboro, GA",
           "County": {
@@ -8093,11 +15045,56 @@
           }
        }
     ],
+    "Hobbs, NM": [
+       {
+          "CBSA Code": 26020,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lea County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 25,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Holland, MI": [
+       {
+          "CBSA Code": 26090,
+          "Metropolitan Division Code": null,
+          "CSA Code": 266,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Grand Rapids-Kentwood-Muskegon, MI",
+          "County": {
+             "County Equivalent": "Allegan County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Homosassa Springs, FL": [
        {
           "CBSA Code": 26140,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -8111,11 +15108,75 @@
           }
        }
     ],
+    "Hood River, OR": [
+       {
+          "CBSA Code": 26220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Hood River County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Hope, AR": [
+       {
+          "CBSA Code": 26260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Hempstead County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 57,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 26260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Nevada County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 99,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Hot Springs, AR": [
        {
           "CBSA Code": 26300,
           "Metropolitan Division Code": null,
           "CSA Code": 284,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Hot Springs-Malvern, AR",
           "County": {
@@ -8129,11 +15190,54 @@
           }
        }
     ],
+    "Houghton, MI": [
+       {
+          "CBSA Code": 26340,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Houghton County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 61,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 26340,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Keweenaw County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 83,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Houma-Thibodaux, LA": [
        {
           "CBSA Code": 26380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -8150,6 +15254,9 @@
           "CBSA Code": 26380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -8168,6 +15275,9 @@
           "CBSA Code": 26420,
           "Metropolitan Division Code": null,
           "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Houston-The Woodlands, TX",
           "County": {
@@ -8184,6 +15294,9 @@
           "CBSA Code": 26420,
           "Metropolitan Division Code": null,
           "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Houston-The Woodlands, TX",
           "County": {
@@ -8200,6 +15313,9 @@
           "CBSA Code": 26420,
           "Metropolitan Division Code": null,
           "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Houston-The Woodlands, TX",
           "County": {
@@ -8216,6 +15332,9 @@
           "CBSA Code": 26420,
           "Metropolitan Division Code": null,
           "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Houston-The Woodlands, TX",
           "County": {
@@ -8232,6 +15351,9 @@
           "CBSA Code": 26420,
           "Metropolitan Division Code": null,
           "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Houston-The Woodlands, TX",
           "County": {
@@ -8248,6 +15370,9 @@
           "CBSA Code": 26420,
           "Metropolitan Division Code": null,
           "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Houston-The Woodlands, TX",
           "County": {
@@ -8264,6 +15389,9 @@
           "CBSA Code": 26420,
           "Metropolitan Division Code": null,
           "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Houston-The Woodlands, TX",
           "County": {
@@ -8280,6 +15408,9 @@
           "CBSA Code": 26420,
           "Metropolitan Division Code": null,
           "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Houston-The Woodlands, TX",
           "County": {
@@ -8296,6 +15427,9 @@
           "CBSA Code": 26420,
           "Metropolitan Division Code": null,
           "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Houston-The Woodlands, TX",
           "County": {
@@ -8309,11 +15443,77 @@
           }
        }
     ],
+    "Hudson, NY": [
+       {
+          "CBSA Code": 26460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 104,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Albany-Schenectady, NY",
+          "County": {
+             "County Equivalent": "Columbia County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 21,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Huntingdon, PA": [
+       {
+          "CBSA Code": 26500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 107,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Altoona-Huntingdon, PA",
+          "County": {
+             "County Equivalent": "Huntingdon County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 61,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Huntington, IN": [
+       {
+          "CBSA Code": 26540,
+          "Metropolitan Division Code": null,
+          "CSA Code": 258,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Fort Wayne-Huntington-Auburn, IN",
+          "County": {
+             "County Equivalent": "Huntington County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 69,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Huntington-Ashland, WV-KY-OH": [
        {
           "CBSA Code": 26580,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -8330,6 +15530,9 @@
           "CBSA Code": 26580,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -8346,6 +15549,9 @@
           "CBSA Code": 26580,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -8362,6 +15568,9 @@
           "CBSA Code": 26580,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -8378,6 +15587,9 @@
           "CBSA Code": 26580,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -8394,6 +15606,9 @@
           "CBSA Code": 26580,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -8410,6 +15625,9 @@
           "CBSA Code": 26580,
           "Metropolitan Division Code": null,
           "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
           "County": {
@@ -8428,6 +15646,9 @@
           "CBSA Code": 26620,
           "Metropolitan Division Code": null,
           "CSA Code": 290,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Huntsville-Decatur, AL",
           "County": {
@@ -8444,6 +15665,9 @@
           "CBSA Code": 26620,
           "Metropolitan Division Code": null,
           "CSA Code": 290,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Huntsville-Decatur, AL",
           "County": {
@@ -8457,11 +15681,117 @@
           }
        }
     ],
+    "Huntsville, TX": [
+       {
+          "CBSA Code": 26660,
+          "Metropolitan Division Code": null,
+          "CSA Code": 288,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Houston-The Woodlands, TX",
+          "County": {
+             "County Equivalent": "Walker County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 471,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Huron, SD": [
+       {
+          "CBSA Code": 26700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Beadle County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 26700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Jerauld County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 73,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Hutchinson, KS": [
+       {
+          "CBSA Code": 26740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Reno County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 155,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Hutchinson, MN": [
+       {
+          "CBSA Code": 26780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Minneapolis-St. Paul, MN-WI",
+          "County": {
+             "County Equivalent": "McLeod County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 85,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Idaho Falls, ID": [
        {
           "CBSA Code": 26820,
           "Metropolitan Division Code": null,
           "CSA Code": 292,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Idaho Falls-Rexburg-Blackfoot, ID",
           "County": {
@@ -8478,6 +15808,9 @@
           "CBSA Code": 26820,
           "Metropolitan Division Code": null,
           "CSA Code": 292,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Idaho Falls-Rexburg-Blackfoot, ID",
           "County": {
@@ -8494,6 +15827,9 @@
           "CBSA Code": 26820,
           "Metropolitan Division Code": null,
           "CSA Code": 292,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Idaho Falls-Rexburg-Blackfoot, ID",
           "County": {
@@ -8507,11 +15843,35 @@
           }
        }
     ],
+    "Indiana, PA": [
+       {
+          "CBSA Code": 26860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
+          "County": {
+             "County Equivalent": "Indiana County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 63,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Indianapolis-Carmel-Anderson, IN": [
        {
           "CBSA Code": 26900,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -8528,6 +15888,9 @@
           "CBSA Code": 26900,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -8544,6 +15907,9 @@
           "CBSA Code": 26900,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -8560,6 +15926,9 @@
           "CBSA Code": 26900,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -8576,6 +15945,9 @@
           "CBSA Code": 26900,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -8592,6 +15964,9 @@
           "CBSA Code": 26900,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -8608,6 +15983,9 @@
           "CBSA Code": 26900,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -8624,6 +16002,9 @@
           "CBSA Code": 26900,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -8640,6 +16021,9 @@
           "CBSA Code": 26900,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -8656,6 +16040,9 @@
           "CBSA Code": 26900,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -8672,6 +16059,9 @@
           "CBSA Code": 26900,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -8685,11 +16075,35 @@
           }
        }
     ],
+    "Indianola, MS": [
+       {
+          "CBSA Code": 26940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 185,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Cleveland-Indianola, MS",
+          "County": {
+             "County Equivalent": "Sunflower County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 133,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Iowa City, IA": [
        {
           "CBSA Code": 26980,
           "Metropolitan Division Code": null,
           "CSA Code": 168,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cedar Rapids-Iowa City, IA",
           "County": {
@@ -8706,6 +16120,9 @@
           "CBSA Code": 26980,
           "Metropolitan Division Code": null,
           "CSA Code": 168,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cedar Rapids-Iowa City, IA",
           "County": {
@@ -8719,11 +16136,54 @@
           }
        }
     ],
+    "Iron Mountain, MI-WI": [
+       {
+          "CBSA Code": 27020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 361,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Marinette-Iron Mountain, WI-MI",
+          "County": {
+             "County Equivalent": "Dickinson County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 43,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 27020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 361,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Marinette-Iron Mountain, WI-MI",
+          "County": {
+             "County Equivalent": "Florence County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 37,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Ithaca, NY": [
        {
           "CBSA Code": 27060,
           "Metropolitan Division Code": null,
           "CSA Code": 296,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Ithaca-Cortland, NY",
           "County": {
@@ -8742,6 +16202,9 @@
           "CBSA Code": 27100,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -8760,6 +16223,9 @@
           "CBSA Code": 27140,
           "Metropolitan Division Code": null,
           "CSA Code": 298,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jackson-Vicksburg-Brookhaven, MS",
           "County": {
@@ -8776,6 +16242,9 @@
           "CBSA Code": 27140,
           "Metropolitan Division Code": null,
           "CSA Code": 298,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jackson-Vicksburg-Brookhaven, MS",
           "County": {
@@ -8792,6 +16261,9 @@
           "CBSA Code": 27140,
           "Metropolitan Division Code": null,
           "CSA Code": 298,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jackson-Vicksburg-Brookhaven, MS",
           "County": {
@@ -8808,6 +16280,9 @@
           "CBSA Code": 27140,
           "Metropolitan Division Code": null,
           "CSA Code": 298,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jackson-Vicksburg-Brookhaven, MS",
           "County": {
@@ -8824,6 +16299,9 @@
           "CBSA Code": 27140,
           "Metropolitan Division Code": null,
           "CSA Code": 298,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jackson-Vicksburg-Brookhaven, MS",
           "County": {
@@ -8840,6 +16318,9 @@
           "CBSA Code": 27140,
           "Metropolitan Division Code": null,
           "CSA Code": 298,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jackson-Vicksburg-Brookhaven, MS",
           "County": {
@@ -8856,6 +16337,9 @@
           "CBSA Code": 27140,
           "Metropolitan Division Code": null,
           "CSA Code": 298,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jackson-Vicksburg-Brookhaven, MS",
           "County": {
@@ -8869,11 +16353,35 @@
           }
        }
     ],
+    "Jackson, OH": [
+       {
+          "CBSA Code": 27160,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Jackson County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 79,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Jackson, TN": [
        {
           "CBSA Code": 27180,
           "Metropolitan Division Code": null,
           "CSA Code": 297,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jackson-Brownsville, TN",
           "County": {
@@ -8890,6 +16398,9 @@
           "CBSA Code": 27180,
           "Metropolitan Division Code": null,
           "CSA Code": 297,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jackson-Brownsville, TN",
           "County": {
@@ -8906,6 +16417,9 @@
           "CBSA Code": 27180,
           "Metropolitan Division Code": null,
           "CSA Code": 297,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jackson-Brownsville, TN",
           "County": {
@@ -8922,6 +16436,9 @@
           "CBSA Code": 27180,
           "Metropolitan Division Code": null,
           "CSA Code": 297,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jackson-Brownsville, TN",
           "County": {
@@ -8935,11 +16452,54 @@
           }
        }
     ],
+    "Jackson, WY-ID": [
+       {
+          "CBSA Code": 27220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Teton County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 81,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 27220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Teton County"
+          },
+          "State Name": "Wyoming",
+          "FIPS State Code": 56,
+          "FIPS County Code": 39,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Jacksonville, FL": [
        {
           "CBSA Code": 27260,
           "Metropolitan Division Code": null,
           "CSA Code": 300,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jacksonville-St. Marys-Palatka, FL-GA",
           "County": {
@@ -8956,6 +16516,9 @@
           "CBSA Code": 27260,
           "Metropolitan Division Code": null,
           "CSA Code": 300,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jacksonville-St. Marys-Palatka, FL-GA",
           "County": {
@@ -8972,6 +16535,9 @@
           "CBSA Code": 27260,
           "Metropolitan Division Code": null,
           "CSA Code": 300,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jacksonville-St. Marys-Palatka, FL-GA",
           "County": {
@@ -8988,6 +16554,9 @@
           "CBSA Code": 27260,
           "Metropolitan Division Code": null,
           "CSA Code": 300,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jacksonville-St. Marys-Palatka, FL-GA",
           "County": {
@@ -9004,6 +16573,9 @@
           "CBSA Code": 27260,
           "Metropolitan Division Code": null,
           "CSA Code": 300,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jacksonville-St. Marys-Palatka, FL-GA",
           "County": {
@@ -9017,11 +16589,54 @@
           }
        }
     ],
+    "Jacksonville, IL": [
+       {
+          "CBSA Code": 27300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 522,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Springfield-Jacksonville-Lincoln, IL",
+          "County": {
+             "County Equivalent": "Morgan County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 137,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 27300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 522,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Springfield-Jacksonville-Lincoln, IL",
+          "County": {
+             "County Equivalent": "Scott County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 171,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Jacksonville, NC": [
        {
           "CBSA Code": 27340,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -9035,11 +16650,77 @@
           }
        }
     ],
+    "Jacksonville, TX": [
+       {
+          "CBSA Code": 27380,
+          "Metropolitan Division Code": null,
+          "CSA Code": 540,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Tyler-Jacksonville, TX",
+          "County": {
+             "County Equivalent": "Cherokee County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 73,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Jamestown, ND": [
+       {
+          "CBSA Code": 27420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Stutsman County"
+          },
+          "State Name": "North Dakota",
+          "FIPS State Code": 38,
+          "FIPS County Code": 93,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Jamestown-Dunkirk-Fredonia, NY": [
+       {
+          "CBSA Code": 27460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Chautauqua County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Janesville-Beloit, WI": [
        {
           "CBSA Code": 27500,
           "Metropolitan Division Code": null,
           "CSA Code": 357,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Madison-Janesville-Beloit, WI",
           "County": {
@@ -9053,11 +16734,117 @@
           }
        }
     ],
+    "Jasper, AL": [
+       {
+          "CBSA Code": 27530,
+          "Metropolitan Division Code": null,
+          "CSA Code": 142,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Birmingham-Hoover-Talladega, AL",
+          "County": {
+             "County Equivalent": "Walker County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 127,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Jasper, IN": [
+       {
+          "CBSA Code": 27540,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Dubois County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 37,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 27540,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pike County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 125,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Jayuya, PR": [
+       {
+          "CBSA Code": 27580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Jayuya Municipio"
+          },
+          "State Name": "Puerto Rico",
+          "FIPS State Code": 72,
+          "FIPS County Code": 73,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Jefferson, GA": [
+       {
+          "CBSA Code": 27600,
+          "Metropolitan Division Code": null,
+          "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
+          "County": {
+             "County Equivalent": "Jackson County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 157,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Jefferson City, MO": [
        {
           "CBSA Code": 27620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -9074,6 +16861,9 @@
           "CBSA Code": 27620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -9090,6 +16880,9 @@
           "CBSA Code": 27620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -9106,6 +16899,9 @@
           "CBSA Code": 27620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -9119,11 +16915,56 @@
           }
        }
     ],
+    "Jennings, LA": [
+       {
+          "CBSA Code": 27660,
+          "Metropolitan Division Code": null,
+          "CSA Code": 324,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lake Charles-Jennings, LA",
+          "County": {
+             "County Equivalent": "Jefferson Davis Parish"
+          },
+          "State Name": "Louisiana",
+          "FIPS State Code": 22,
+          "FIPS County Code": 53,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Jesup, GA": [
+       {
+          "CBSA Code": 27700,
+          "Metropolitan Division Code": null,
+          "CSA Code": 496,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Savannah-Hinesville-Statesboro, GA",
+          "County": {
+             "County Equivalent": "Wayne County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 305,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Johnson City, TN": [
        {
           "CBSA Code": 27740,
           "Metropolitan Division Code": null,
           "CSA Code": 304,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Johnson City-Kingsport-Bristol, TN-VA",
           "County": {
@@ -9140,6 +16981,9 @@
           "CBSA Code": 27740,
           "Metropolitan Division Code": null,
           "CSA Code": 304,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Johnson City-Kingsport-Bristol, TN-VA",
           "County": {
@@ -9156,6 +17000,9 @@
           "CBSA Code": 27740,
           "Metropolitan Division Code": null,
           "CSA Code": 304,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Johnson City-Kingsport-Bristol, TN-VA",
           "County": {
@@ -9174,6 +17021,9 @@
           "CBSA Code": 27780,
           "Metropolitan Division Code": null,
           "CSA Code": 306,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Johnstown-Somerset, PA",
           "County": {
@@ -9192,6 +17042,9 @@
           "CBSA Code": 27860,
           "Metropolitan Division Code": null,
           "CSA Code": 308,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jonesboro-Paragould, AR",
           "County": {
@@ -9208,6 +17061,9 @@
           "CBSA Code": 27860,
           "Metropolitan Division Code": null,
           "CSA Code": 308,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Jonesboro-Paragould, AR",
           "County": {
@@ -9226,6 +17082,9 @@
           "CBSA Code": 27900,
           "Metropolitan Division Code": null,
           "CSA Code": 309,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Joplin-Miami, MO-OK",
           "County": {
@@ -9242,6 +17101,9 @@
           "CBSA Code": 27900,
           "Metropolitan Division Code": null,
           "CSA Code": 309,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Joplin-Miami, MO-OK",
           "County": {
@@ -9255,11 +17117,35 @@
           }
        }
     ],
+    "Juneau, AK": [
+       {
+          "CBSA Code": 27940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Juneau City and Borough"
+          },
+          "State Name": "Alaska",
+          "FIPS State Code": 2,
+          "FIPS County Code": 110,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Kahului-Wailuku-Lahaina, HI": [
        {
           "CBSA Code": 27980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -9278,6 +17164,9 @@
           "CBSA Code": 28020,
           "Metropolitan Division Code": null,
           "CSA Code": 310,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kalamazoo-Battle Creek-Portage, MI",
           "County": {
@@ -9291,11 +17180,35 @@
           }
        }
     ],
+    "Kalispell, MT": [
+       {
+          "CBSA Code": 28060,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Flathead County"
+          },
+          "State Name": "Montana",
+          "FIPS State Code": 30,
+          "FIPS County Code": 29,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Kankakee, IL": [
        {
           "CBSA Code": 28100,
           "Metropolitan Division Code": null,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -9314,6 +17227,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9330,6 +17246,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9346,6 +17265,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9362,6 +17284,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9378,6 +17303,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9394,6 +17322,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9410,6 +17341,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9426,6 +17360,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9442,6 +17379,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9458,6 +17398,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9474,6 +17417,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9490,6 +17436,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9506,6 +17455,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9522,6 +17474,9 @@
           "CBSA Code": 28140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -9535,11 +17490,138 @@
           }
        }
     ],
+    "Kapaa, HI": [
+       {
+          "CBSA Code": 28180,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Kauai County"
+          },
+          "State Name": "Hawaii",
+          "FIPS State Code": 15,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Kearney, NE": [
+       {
+          "CBSA Code": 28260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Buffalo County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 19,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 28260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Kearney County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 99,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Keene, NH": [
+       {
+          "CBSA Code": 28300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Cheshire County"
+          },
+          "State Name": "New Hampshire",
+          "FIPS State Code": 33,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Kendallville, IN": [
+       {
+          "CBSA Code": 28340,
+          "Metropolitan Division Code": null,
+          "CSA Code": 258,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Fort Wayne-Huntington-Auburn, IN",
+          "County": {
+             "County Equivalent": "Noble County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 113,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Kennett, MO": [
+       {
+          "CBSA Code": 28380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Dunklin County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 69,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Kennewick-Richland, WA": [
        {
           "CBSA Code": 28420,
           "Metropolitan Division Code": null,
           "CSA Code": 313,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kennewick-Richland-Walla Walla, WA",
           "County": {
@@ -9556,6 +17638,9 @@
           "CBSA Code": 28420,
           "Metropolitan Division Code": null,
           "CSA Code": 313,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kennewick-Richland-Walla Walla, WA",
           "County": {
@@ -9569,11 +17654,98 @@
           }
        }
     ],
+    "Kerrville, TX": [
+       {
+          "CBSA Code": 28500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 314,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Kerrville-Fredericksburg, TX",
+          "County": {
+             "County Equivalent": "Kerr County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 265,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Ketchikan, AK": [
+       {
+          "CBSA Code": 28540,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Ketchikan Gateway Borough"
+          },
+          "State Name": "Alaska",
+          "FIPS State Code": 2,
+          "FIPS County Code": 130,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Key West, FL": [
+       {
+          "CBSA Code": 28580,
+          "Metropolitan Division Code": null,
+          "CSA Code": 370,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Miami-Port St. Lucie-Fort Lauderdale, FL",
+          "County": {
+             "County Equivalent": "Monroe County"
+          },
+          "State Name": "Florida",
+          "FIPS State Code": 12,
+          "FIPS County Code": 87,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Kill Devil Hills, NC": [
+       {
+          "CBSA Code": 28620,
+          "Metropolitan Division Code": null,
+          "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Virginia Beach-Norfolk, VA-NC",
+          "County": {
+             "County Equivalent": "Dare County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 55,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Killeen-Temple, TX": [
        {
           "CBSA Code": 28660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -9590,6 +17762,9 @@
           "CBSA Code": 28660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -9606,6 +17781,9 @@
           "CBSA Code": 28660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -9624,6 +17802,9 @@
           "CBSA Code": 28700,
           "Metropolitan Division Code": null,
           "CSA Code": 304,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Johnson City-Kingsport-Bristol, TN-VA",
           "County": {
@@ -9640,6 +17821,9 @@
           "CBSA Code": 28700,
           "Metropolitan Division Code": null,
           "CSA Code": 304,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Johnson City-Kingsport-Bristol, TN-VA",
           "County": {
@@ -9656,6 +17840,9 @@
           "CBSA Code": 28700,
           "Metropolitan Division Code": null,
           "CSA Code": 304,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Johnson City-Kingsport-Bristol, TN-VA",
           "County": {
@@ -9672,6 +17859,9 @@
           "CBSA Code": 28700,
           "Metropolitan Division Code": null,
           "CSA Code": 304,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Johnson City-Kingsport-Bristol, TN-VA",
           "County": {
@@ -9688,6 +17878,9 @@
           "CBSA Code": 28700,
           "Metropolitan Division Code": null,
           "CSA Code": 304,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Johnson City-Kingsport-Bristol, TN-VA",
           "County": {
@@ -9706,6 +17899,9 @@
           "CBSA Code": 28740,
           "Metropolitan Division Code": null,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -9719,11 +17915,136 @@
           }
        }
     ],
+    "Kingsville, TX": [
+       {
+          "CBSA Code": 28780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 204,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Corpus Christi-Kingsville-Alice, TX",
+          "County": {
+             "County Equivalent": "Kenedy County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 261,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 28780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 204,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Corpus Christi-Kingsville-Alice, TX",
+          "County": {
+             "County Equivalent": "Kleberg County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 273,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Kinston, NC": [
+       {
+          "CBSA Code": 28820,
+          "Metropolitan Division Code": null,
+          "CSA Code": 272,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Greenville-Kinston-Washington, NC",
+          "County": {
+             "County Equivalent": "Lenoir County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 107,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Kirksville, MO": [
+       {
+          "CBSA Code": 28860,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Adair County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 1,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 28860,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Schuyler County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 197,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Klamath Falls, OR": [
+       {
+          "CBSA Code": 28900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Klamath County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 35,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Knoxville, TN": [
        {
           "CBSA Code": 28940,
           "Metropolitan Division Code": null,
           "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Knoxville-Morristown-Sevierville, TN",
           "County": {
@@ -9740,6 +18061,9 @@
           "CBSA Code": 28940,
           "Metropolitan Division Code": null,
           "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Knoxville-Morristown-Sevierville, TN",
           "County": {
@@ -9756,6 +18080,9 @@
           "CBSA Code": 28940,
           "Metropolitan Division Code": null,
           "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Knoxville-Morristown-Sevierville, TN",
           "County": {
@@ -9772,6 +18099,9 @@
           "CBSA Code": 28940,
           "Metropolitan Division Code": null,
           "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Knoxville-Morristown-Sevierville, TN",
           "County": {
@@ -9788,6 +18118,9 @@
           "CBSA Code": 28940,
           "Metropolitan Division Code": null,
           "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Knoxville-Morristown-Sevierville, TN",
           "County": {
@@ -9804,6 +18137,9 @@
           "CBSA Code": 28940,
           "Metropolitan Division Code": null,
           "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Knoxville-Morristown-Sevierville, TN",
           "County": {
@@ -9820,6 +18156,9 @@
           "CBSA Code": 28940,
           "Metropolitan Division Code": null,
           "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Knoxville-Morristown-Sevierville, TN",
           "County": {
@@ -9836,6 +18175,9 @@
           "CBSA Code": 28940,
           "Metropolitan Division Code": null,
           "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Knoxville-Morristown-Sevierville, TN",
           "County": {
@@ -9854,6 +18196,9 @@
           "CBSA Code": 29020,
           "Metropolitan Division Code": null,
           "CSA Code": 316,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kokomo-Peru, IN",
           "County": {
@@ -9867,11 +18212,35 @@
           }
        }
     ],
+    "Laconia, NH": [
+       {
+          "CBSA Code": 29060,
+          "Metropolitan Division Code": null,
+          "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
+          "County": {
+             "County Equivalent": "Belknap County"
+          },
+          "State Name": "New Hampshire",
+          "FIPS State Code": 33,
+          "FIPS County Code": 1,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "La Crosse-Onalaska, WI-MN": [
        {
           "CBSA Code": 29100,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -9888,6 +18257,9 @@
           "CBSA Code": 29100,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -9906,6 +18278,9 @@
           "CBSA Code": 29180,
           "Metropolitan Division Code": null,
           "CSA Code": 318,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lafayette-Opelousas-Morgan City, LA",
           "County": {
@@ -9922,6 +18297,9 @@
           "CBSA Code": 29180,
           "Metropolitan Division Code": null,
           "CSA Code": 318,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lafayette-Opelousas-Morgan City, LA",
           "County": {
@@ -9938,6 +18316,9 @@
           "CBSA Code": 29180,
           "Metropolitan Division Code": null,
           "CSA Code": 318,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lafayette-Opelousas-Morgan City, LA",
           "County": {
@@ -9954,6 +18335,9 @@
           "CBSA Code": 29180,
           "Metropolitan Division Code": null,
           "CSA Code": 318,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lafayette-Opelousas-Morgan City, LA",
           "County": {
@@ -9970,6 +18354,9 @@
           "CBSA Code": 29180,
           "Metropolitan Division Code": null,
           "CSA Code": 318,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lafayette-Opelousas-Morgan City, LA",
           "County": {
@@ -9988,6 +18375,9 @@
           "CBSA Code": 29200,
           "Metropolitan Division Code": null,
           "CSA Code": 320,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lafayette-West Lafayette-Frankfort, IN",
           "County": {
@@ -10004,6 +18394,9 @@
           "CBSA Code": 29200,
           "Metropolitan Division Code": null,
           "CSA Code": 320,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lafayette-West Lafayette-Frankfort, IN",
           "County": {
@@ -10020,6 +18413,9 @@
           "CBSA Code": 29200,
           "Metropolitan Division Code": null,
           "CSA Code": 320,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lafayette-West Lafayette-Frankfort, IN",
           "County": {
@@ -10036,6 +18432,9 @@
           "CBSA Code": 29200,
           "Metropolitan Division Code": null,
           "CSA Code": 320,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lafayette-West Lafayette-Frankfort, IN",
           "County": {
@@ -10049,11 +18448,75 @@
           }
        }
     ],
+    "La Grande, OR": [
+       {
+          "CBSA Code": 29260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Union County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 61,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "LaGrange, GA-AL": [
+       {
+          "CBSA Code": 29300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
+          "County": {
+             "County Equivalent": "Chambers County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 17,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 29300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
+          "County": {
+             "County Equivalent": "Troup County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 285,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Lake Charles, LA": [
        {
           "CBSA Code": 29340,
           "Metropolitan Division Code": null,
           "CSA Code": 324,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lake Charles-Jennings, LA",
           "County": {
@@ -10070,6 +18533,9 @@
           "CBSA Code": 29340,
           "Metropolitan Division Code": null,
           "CSA Code": 324,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lake Charles-Jennings, LA",
           "County": {
@@ -10083,11 +18549,35 @@
           }
        }
     ],
+    "Lake City, FL": [
+       {
+          "CBSA Code": 29380,
+          "Metropolitan Division Code": null,
+          "CSA Code": 264,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Gainesville-Lake City, FL",
+          "County": {
+             "County Equivalent": "Columbia County"
+          },
+          "State Name": "Florida",
+          "FIPS State Code": 12,
+          "FIPS County Code": 23,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Lake Havasu City-Kingman, AZ": [
        {
           "CBSA Code": 29420,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10106,6 +18596,9 @@
           "CBSA Code": 29460,
           "Metropolitan Division Code": null,
           "CSA Code": 422,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Orlando-Lakeland-Deltona, FL",
           "County": {
@@ -10119,11 +18612,35 @@
           }
        }
     ],
+    "Lamesa, TX": [
+       {
+          "CBSA Code": 29500,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Dawson County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 115,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Lancaster, PA": [
        {
           "CBSA Code": 29540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10142,6 +18659,9 @@
           "CBSA Code": 29620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10158,6 +18678,9 @@
           "CBSA Code": 29620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10174,6 +18697,9 @@
           "CBSA Code": 29620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10190,6 +18716,9 @@
           "CBSA Code": 29620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10203,11 +18732,35 @@
           }
        }
     ],
+    "Laramie, WY": [
+       {
+          "CBSA Code": 29660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Albany County"
+          },
+          "State Name": "Wyoming",
+          "FIPS State Code": 56,
+          "FIPS County Code": 1,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Laredo, TX": [
        {
           "CBSA Code": 29700,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10226,14 +18779,57 @@
           "CBSA Code": 29740,
           "Metropolitan Division Code": null,
           "CSA Code": 238,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "El Paso-Las Cruces, TX-NM",
           "County": {
-             "County Equivalent": "Doña Ana County"
+             "County Equivalent": "Do�a Ana County"
           },
           "State Name": "New Mexico",
           "FIPS State Code": 35,
           "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Las Vegas, NM": [
+       {
+          "CBSA Code": 29780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 106,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Albuquerque-Santa Fe-Las Vegas, NM",
+          "County": {
+             "County Equivalent": "Mora County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 33,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 29780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 106,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Albuquerque-Santa Fe-Las Vegas, NM",
+          "County": {
+             "County Equivalent": "San Miguel County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 47,
           "Central": {
              "Outlying County": "Central"
           }
@@ -10244,6 +18840,9 @@
           "CBSA Code": 29820,
           "Metropolitan Division Code": null,
           "CSA Code": 332,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Las Vegas-Henderson, NV",
           "County": {
@@ -10257,11 +18856,75 @@
           }
        }
     ],
+    "Laurel, MS": [
+       {
+          "CBSA Code": 29860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 279,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Hattiesburg-Laurel, MS",
+          "County": {
+             "County Equivalent": "Jasper County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 61,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 29860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 279,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Hattiesburg-Laurel, MS",
+          "County": {
+             "County Equivalent": "Jones County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 67,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Laurinburg, NC": [
+       {
+          "CBSA Code": 29900,
+          "Metropolitan Division Code": null,
+          "CSA Code": 246,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Fayetteville-Sanford-Lumberton, NC",
+          "County": {
+             "County Equivalent": "Scotland County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 165,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Lawrence, KS": [
        {
           "CBSA Code": 29940,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -10275,11 +18938,35 @@
           }
        }
     ],
+    "Lawrenceburg, TN": [
+       {
+          "CBSA Code": 29980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
+          "County": {
+             "County Equivalent": "Lawrence County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 99,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Lawton, OK": [
        {
           "CBSA Code": 30020,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10296,6 +18983,9 @@
           "CBSA Code": 30020,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10309,11 +18999,113 @@
           }
        }
     ],
+    "Lebanon, MO": [
+       {
+          "CBSA Code": 30060,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Laclede County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 105,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Lebanon, NH-VT": [
+       {
+          "CBSA Code": 30100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Grafton County"
+          },
+          "State Name": "New Hampshire",
+          "FIPS State Code": 33,
+          "FIPS County Code": 9,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 30100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Sullivan County"
+          },
+          "State Name": "New Hampshire",
+          "FIPS State Code": 33,
+          "FIPS County Code": 19,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 30100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Orange County"
+          },
+          "State Name": "Vermont",
+          "FIPS State Code": 50,
+          "FIPS County Code": 17,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 30100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Windsor County"
+          },
+          "State Name": "Vermont",
+          "FIPS State Code": 50,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Lebanon, PA": [
        {
           "CBSA Code": 30140,
           "Metropolitan Division Code": null,
           "CSA Code": 276,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Harrisburg-York-Lebanon, PA",
           "County": {
@@ -10327,11 +19119,77 @@
           }
        }
     ],
+    "Levelland, TX": [
+       {
+          "CBSA Code": 30220,
+          "Metropolitan Division Code": null,
+          "CSA Code": 352,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lubbock-Plainview-Levelland, TX",
+          "County": {
+             "County Equivalent": "Hockley County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 219,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Lewisburg, PA": [
+       {
+          "CBSA Code": 30260,
+          "Metropolitan Division Code": null,
+          "CSA Code": 146,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Bloomsburg-Berwick-Sunbury, PA",
+          "County": {
+             "County Equivalent": "Union County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 119,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Lewisburg, TN": [
+       {
+          "CBSA Code": 30280,
+          "Metropolitan Division Code": null,
+          "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
+          "County": {
+             "County Equivalent": "Marshall County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 117,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Lewiston, ID-WA": [
        {
           "CBSA Code": 30300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10348,6 +19206,9 @@
           "CBSA Code": 30300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10366,6 +19227,9 @@
           "CBSA Code": 30340,
           "Metropolitan Division Code": null,
           "CSA Code": 438,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Lewiston-South Portland, ME",
           "County": {
@@ -10379,11 +19243,75 @@
           }
        }
     ],
+    "Lewistown, PA": [
+       {
+          "CBSA Code": 30380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Mifflin County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 87,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Lexington, NE": [
+       {
+          "CBSA Code": 30420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Dawson County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 47,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 30420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Gosper County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 73,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Lexington-Fayette, KY": [
        {
           "CBSA Code": 30460,
           "Metropolitan Division Code": null,
           "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
           "County": {
@@ -10400,6 +19328,9 @@
           "CBSA Code": 30460,
           "Metropolitan Division Code": null,
           "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
           "County": {
@@ -10416,6 +19347,9 @@
           "CBSA Code": 30460,
           "Metropolitan Division Code": null,
           "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
           "County": {
@@ -10432,6 +19366,9 @@
           "CBSA Code": 30460,
           "Metropolitan Division Code": null,
           "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
           "County": {
@@ -10448,6 +19385,9 @@
           "CBSA Code": 30460,
           "Metropolitan Division Code": null,
           "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
           "County": {
@@ -10464,6 +19404,9 @@
           "CBSA Code": 30460,
           "Metropolitan Division Code": null,
           "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
           "County": {
@@ -10477,11 +19420,35 @@
           }
        }
     ],
+    "Liberal, KS": [
+       {
+          "CBSA Code": 30580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Seward County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 175,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Lima, OH": [
        {
           "CBSA Code": 30620,
           "Metropolitan Division Code": null,
           "CSA Code": 338,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lima-Van Wert-Celina, OH",
           "County": {
@@ -10495,11 +19462,35 @@
           }
        }
     ],
+    "Lincoln, IL": [
+       {
+          "CBSA Code": 30660,
+          "Metropolitan Division Code": null,
+          "CSA Code": 522,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Springfield-Jacksonville-Lincoln, IL",
+          "County": {
+             "County Equivalent": "Logan County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 107,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Lincoln, NE": [
        {
           "CBSA Code": 30700,
           "Metropolitan Division Code": null,
           "CSA Code": 339,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lincoln-Beatrice, NE",
           "County": {
@@ -10516,6 +19507,9 @@
           "CBSA Code": 30700,
           "Metropolitan Division Code": null,
           "CSA Code": 339,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lincoln-Beatrice, NE",
           "County": {
@@ -10534,6 +19528,9 @@
           "CBSA Code": 30780,
           "Metropolitan Division Code": null,
           "CSA Code": 340,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Little Rock-North Little Rock, AR",
           "County": {
@@ -10550,6 +19547,9 @@
           "CBSA Code": 30780,
           "Metropolitan Division Code": null,
           "CSA Code": 340,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Little Rock-North Little Rock, AR",
           "County": {
@@ -10566,6 +19566,9 @@
           "CBSA Code": 30780,
           "Metropolitan Division Code": null,
           "CSA Code": 340,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Little Rock-North Little Rock, AR",
           "County": {
@@ -10582,6 +19585,9 @@
           "CBSA Code": 30780,
           "Metropolitan Division Code": null,
           "CSA Code": 340,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Little Rock-North Little Rock, AR",
           "County": {
@@ -10598,6 +19604,9 @@
           "CBSA Code": 30780,
           "Metropolitan Division Code": null,
           "CSA Code": 340,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Little Rock-North Little Rock, AR",
           "County": {
@@ -10614,6 +19623,9 @@
           "CBSA Code": 30780,
           "Metropolitan Division Code": null,
           "CSA Code": 340,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Little Rock-North Little Rock, AR",
           "County": {
@@ -10627,11 +19639,35 @@
           }
        }
     ],
+    "Lock Haven, PA": [
+       {
+          "CBSA Code": 30820,
+          "Metropolitan Division Code": null,
+          "CSA Code": 558,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Williamsport-Lock Haven, PA",
+          "County": {
+             "County Equivalent": "Clinton County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 35,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Logan, UT-ID": [
        {
           "CBSA Code": 30860,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10648,6 +19684,9 @@
           "CBSA Code": 30860,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10661,11 +19700,113 @@
           }
        }
     ],
+    "Logansport, IN": [
+       {
+          "CBSA Code": 30900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Cass County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 17,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "London, KY": [
+       {
+          "CBSA Code": 30940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Clay County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 51,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 30940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Knox County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 121,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 30940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Laurel County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 125,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 30940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Whitley County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 235,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Longview, TX": [
        {
           "CBSA Code": 30980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10682,6 +19823,9 @@
           "CBSA Code": 30980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10698,6 +19842,9 @@
           "CBSA Code": 30980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10714,6 +19861,9 @@
           "CBSA Code": 30980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -10732,6 +19882,9 @@
           "CBSA Code": 31020,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -10745,11 +19898,35 @@
           }
        }
     ],
+    "Los Alamos, NM": [
+       {
+          "CBSA Code": 31060,
+          "Metropolitan Division Code": null,
+          "CSA Code": 106,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Albuquerque-Santa Fe-Las Vegas, NM",
+          "County": {
+             "County Equivalent": "Los Alamos County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 28,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Los Angeles-Long Beach-Anaheim, CA": [
        {
           "CBSA Code": 31080,
           "Metropolitan Division Code": 11244,
           "CSA Code": 348,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Anaheim-Santa Ana-Irvine, CA",
           "CSA Title": "Los Angeles-Long Beach, CA",
           "County": {
@@ -10766,6 +19943,9 @@
           "CBSA Code": 31080,
           "Metropolitan Division Code": 31084,
           "CSA Code": 348,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Los Angeles-Long Beach-Glendale, CA",
           "CSA Title": "Los Angeles-Long Beach, CA",
           "County": {
@@ -10784,6 +19964,9 @@
           "CBSA Code": 31140,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -10800,6 +19983,9 @@
           "CBSA Code": 31140,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -10816,6 +20002,9 @@
           "CBSA Code": 31140,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -10832,6 +20021,9 @@
           "CBSA Code": 31140,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -10848,6 +20040,9 @@
           "CBSA Code": 31140,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -10864,6 +20059,9 @@
           "CBSA Code": 31140,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -10880,6 +20078,9 @@
           "CBSA Code": 31140,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -10896,6 +20097,9 @@
           "CBSA Code": 31140,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -10912,6 +20116,9 @@
           "CBSA Code": 31140,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -10928,6 +20135,9 @@
           "CBSA Code": 31140,
           "Metropolitan Division Code": null,
           "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
           "County": {
@@ -10946,6 +20156,9 @@
           "CBSA Code": 31180,
           "Metropolitan Division Code": null,
           "CSA Code": 352,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lubbock-Plainview-Levelland, TX",
           "County": {
@@ -10962,6 +20175,9 @@
           "CBSA Code": 31180,
           "Metropolitan Division Code": null,
           "CSA Code": 352,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lubbock-Plainview-Levelland, TX",
           "County": {
@@ -10978,6 +20194,9 @@
           "CBSA Code": 31180,
           "Metropolitan Division Code": null,
           "CSA Code": 352,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Lubbock-Plainview-Levelland, TX",
           "County": {
@@ -10991,11 +20210,77 @@
           }
        }
     ],
+    "Ludington, MI": [
+       {
+          "CBSA Code": 31220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Mason County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 105,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Lufkin, TX": [
+       {
+          "CBSA Code": 31260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Angelina County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Lumberton, NC": [
+       {
+          "CBSA Code": 31300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 246,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Fayetteville-Sanford-Lumberton, NC",
+          "County": {
+             "County Equivalent": "Robeson County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 155,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Lynchburg, VA": [
        {
           "CBSA Code": 31340,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -11012,6 +20297,9 @@
           "CBSA Code": 31340,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -11028,6 +20316,9 @@
           "CBSA Code": 31340,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -11044,6 +20335,9 @@
           "CBSA Code": 31340,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -11060,6 +20354,9 @@
           "CBSA Code": 31340,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -11073,11 +20370,35 @@
           }
        }
     ],
+    "Macomb, IL": [
+       {
+          "CBSA Code": 31380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "McDonough County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 109,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Macon-Bibb County, GA": [
        {
           "CBSA Code": 31420,
           "Metropolitan Division Code": null,
           "CSA Code": 356,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Macon-Bibb County--Warner Robins, GA",
           "County": {
@@ -11094,6 +20415,9 @@
           "CBSA Code": 31420,
           "Metropolitan Division Code": null,
           "CSA Code": 356,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Macon-Bibb County--Warner Robins, GA",
           "County": {
@@ -11110,6 +20434,9 @@
           "CBSA Code": 31420,
           "Metropolitan Division Code": null,
           "CSA Code": 356,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Macon-Bibb County--Warner Robins, GA",
           "County": {
@@ -11126,6 +20453,9 @@
           "CBSA Code": 31420,
           "Metropolitan Division Code": null,
           "CSA Code": 356,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Macon-Bibb County--Warner Robins, GA",
           "County": {
@@ -11142,6 +20472,9 @@
           "CBSA Code": 31420,
           "Metropolitan Division Code": null,
           "CSA Code": 356,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Macon-Bibb County--Warner Robins, GA",
           "County": {
@@ -11160,6 +20493,9 @@
           "CBSA Code": 31460,
           "Metropolitan Division Code": null,
           "CSA Code": 260,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Fresno-Madera-Hanford, CA",
           "County": {
@@ -11173,11 +20509,35 @@
           }
        }
     ],
+    "Madison, IN": [
+       {
+          "CBSA Code": 31500,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Jefferson County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 77,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Madison, WI": [
        {
           "CBSA Code": 31540,
           "Metropolitan Division Code": null,
           "CSA Code": 357,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Madison-Janesville-Beloit, WI",
           "County": {
@@ -11194,6 +20554,9 @@
           "CBSA Code": 31540,
           "Metropolitan Division Code": null,
           "CSA Code": 357,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Madison-Janesville-Beloit, WI",
           "County": {
@@ -11210,6 +20573,9 @@
           "CBSA Code": 31540,
           "Metropolitan Division Code": null,
           "CSA Code": 357,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Madison-Janesville-Beloit, WI",
           "County": {
@@ -11226,6 +20592,9 @@
           "CBSA Code": 31540,
           "Metropolitan Division Code": null,
           "CSA Code": 357,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Madison-Janesville-Beloit, WI",
           "County": {
@@ -11239,11 +20608,98 @@
           }
        }
     ],
+    "Madisonville, KY": [
+       {
+          "CBSA Code": 31580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Hopkins County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 107,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Magnolia, AR": [
+       {
+          "CBSA Code": 31620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Columbia County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Malone, NY": [
+       {
+          "CBSA Code": 31660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Franklin County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 33,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Malvern, AR": [
+       {
+          "CBSA Code": 31680,
+          "Metropolitan Division Code": null,
+          "CSA Code": 284,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Hot Springs-Malvern, AR",
+          "County": {
+             "County Equivalent": "Hot Spring County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 59,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Manchester-Nashua, NH": [
        {
           "CBSA Code": 31700,
           "Metropolitan Division Code": null,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -11262,6 +20718,9 @@
           "CBSA Code": 31740,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -11278,6 +20737,9 @@
           "CBSA Code": 31740,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -11294,6 +20756,9 @@
           "CBSA Code": 31740,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -11307,11 +20772,35 @@
           }
        }
     ],
+    "Manitowoc, WI": [
+       {
+          "CBSA Code": 31820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Manitowoc County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 71,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Mankato, MN": [
        {
           "CBSA Code": 31860,
           "Metropolitan Division Code": null,
           "CSA Code": 359,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Mankato-New Ulm, MN",
           "County": {
@@ -11328,6 +20817,9 @@
           "CBSA Code": 31860,
           "Metropolitan Division Code": null,
           "CSA Code": 359,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Mankato-New Ulm, MN",
           "County": {
@@ -11346,6 +20838,9 @@
           "CBSA Code": 31900,
           "Metropolitan Division Code": null,
           "CSA Code": 360,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Mansfield-Ashland-Bucyrus, OH",
           "County": {
@@ -11359,13 +20854,346 @@
           }
        }
     ],
-    "Mayagüez, PR": [
+    "Marietta, OH": [
+       {
+          "CBSA Code": 31930,
+          "Metropolitan Division Code": null,
+          "CSA Code": 425,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Parkersburg-Marietta-Vienna, WV-OH",
+          "County": {
+             "County Equivalent": "Washington County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 167,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Marinette, WI-MI": [
+       {
+          "CBSA Code": 31940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 361,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Marinette-Iron Mountain, WI-MI",
+          "County": {
+             "County Equivalent": "Menominee County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 109,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 31940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 361,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Marinette-Iron Mountain, WI-MI",
+          "County": {
+             "County Equivalent": "Marinette County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 75,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Marion, IN": [
+       {
+          "CBSA Code": 31980,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Grant County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 53,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Marion, NC": [
+       {
+          "CBSA Code": 32000,
+          "Metropolitan Division Code": null,
+          "CSA Code": 120,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Asheville-Marion-Brevard, NC",
+          "County": {
+             "County Equivalent": "McDowell County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 111,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Marion, OH": [
+       {
+          "CBSA Code": 32020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbus-Marion-Zanesville, OH",
+          "County": {
+             "County Equivalent": "Marion County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 101,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Marquette, MI": [
+       {
+          "CBSA Code": 32100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Marquette County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 103,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Marshall, MN": [
+       {
+          "CBSA Code": 32140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lyon County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 83,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Marshall, MO": [
+       {
+          "CBSA Code": 32180,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Saline County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 195,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Marshalltown, IA": [
+       {
+          "CBSA Code": 32260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Marshall County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 127,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Martin, TN": [
+       {
+          "CBSA Code": 32280,
+          "Metropolitan Division Code": null,
+          "CSA Code": 362,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Martin-Union City, TN",
+          "County": {
+             "County Equivalent": "Weakley County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 183,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Martinsville, VA": [
+       {
+          "CBSA Code": 32300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Henry County"
+          },
+          "State Name": "Virginia",
+          "FIPS State Code": 51,
+          "FIPS County Code": 89,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 32300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Martinsville city"
+          },
+          "State Name": "Virginia",
+          "FIPS State Code": 51,
+          "FIPS County Code": 690,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Maryville, MO": [
+       {
+          "CBSA Code": 32340,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Nodaway County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 147,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mason City, IA": [
+       {
+          "CBSA Code": 32380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Cerro Gordo County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 33,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 32380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Worth County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 195,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Mayag�ez, PR": [
        {
           "CBSA Code": 32420,
           "Metropolitan Division Code": null,
           "CSA Code": 364,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "Mayagüez-San Germán, PR",
+          "CSA Title": "Mayag�ez-San Germ�n, PR",
           "County": {
              "County Equivalent": "Hormigueros Municipio"
           },
@@ -11380,10 +21208,13 @@
           "CBSA Code": 32420,
           "Metropolitan Division Code": null,
           "CSA Code": 364,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "Mayagüez-San Germán, PR",
+          "CSA Title": "Mayag�ez-San Germ�n, PR",
           "County": {
-             "County Equivalent": "Las Marías Municipio"
+             "County Equivalent": "Las Mar�as Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -11396,14 +21227,80 @@
           "CBSA Code": 32420,
           "Metropolitan Division Code": null,
           "CSA Code": 364,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "Mayagüez-San Germán, PR",
+          "CSA Title": "Mayag�ez-San Germ�n, PR",
           "County": {
-             "County Equivalent": "Mayagüez Municipio"
+             "County Equivalent": "Mayag�ez Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
           "FIPS County Code": 97,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mayfield, KY": [
+       {
+          "CBSA Code": 32460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 424,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Paducah-Mayfield, KY-IL",
+          "County": {
+             "County Equivalent": "Graves County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 83,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Maysville, KY": [
+       {
+          "CBSA Code": 32500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
+          "County": {
+             "County Equivalent": "Mason County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 161,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "McAlester, OK": [
+       {
+          "CBSA Code": 32540,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pittsburg County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 121,
           "Central": {
              "Outlying County": "Central"
           }
@@ -11414,6 +21311,9 @@
           "CBSA Code": 32580,
           "Metropolitan Division Code": null,
           "CSA Code": 365,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "McAllen-Edinburg, TX",
           "County": {
@@ -11427,11 +21327,98 @@
           }
        }
     ],
+    "McComb, MS": [
+       {
+          "CBSA Code": 32620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pike County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 113,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "McMinnville, TN": [
+       {
+          "CBSA Code": 32660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Warren County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 177,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "McPherson, KS": [
+       {
+          "CBSA Code": 32700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "McPherson County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 113,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Meadville, PA": [
+       {
+          "CBSA Code": 32740,
+          "Metropolitan Division Code": null,
+          "CSA Code": 240,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Erie-Meadville, PA",
+          "County": {
+             "County Equivalent": "Crawford County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 39,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Medford, OR": [
        {
           "CBSA Code": 32780,
           "Metropolitan Division Code": null,
           "CSA Code": 366,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Medford-Grants Pass, OR",
           "County": {
@@ -11450,6 +21437,9 @@
           "CBSA Code": 32820,
           "Metropolitan Division Code": null,
           "CSA Code": 368,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Memphis-Forrest City, TN-MS-AR",
           "County": {
@@ -11466,6 +21456,9 @@
           "CBSA Code": 32820,
           "Metropolitan Division Code": null,
           "CSA Code": 368,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Memphis-Forrest City, TN-MS-AR",
           "County": {
@@ -11482,6 +21475,9 @@
           "CBSA Code": 32820,
           "Metropolitan Division Code": null,
           "CSA Code": 368,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Memphis-Forrest City, TN-MS-AR",
           "County": {
@@ -11498,6 +21494,9 @@
           "CBSA Code": 32820,
           "Metropolitan Division Code": null,
           "CSA Code": 368,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Memphis-Forrest City, TN-MS-AR",
           "County": {
@@ -11514,6 +21513,9 @@
           "CBSA Code": 32820,
           "Metropolitan Division Code": null,
           "CSA Code": 368,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Memphis-Forrest City, TN-MS-AR",
           "County": {
@@ -11530,6 +21532,9 @@
           "CBSA Code": 32820,
           "Metropolitan Division Code": null,
           "CSA Code": 368,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Memphis-Forrest City, TN-MS-AR",
           "County": {
@@ -11546,6 +21551,9 @@
           "CBSA Code": 32820,
           "Metropolitan Division Code": null,
           "CSA Code": 368,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Memphis-Forrest City, TN-MS-AR",
           "County": {
@@ -11562,6 +21570,9 @@
           "CBSA Code": 32820,
           "Metropolitan Division Code": null,
           "CSA Code": 368,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Memphis-Forrest City, TN-MS-AR",
           "County": {
@@ -11575,11 +21586,35 @@
           }
        }
     ],
+    "Menomonie, WI": [
+       {
+          "CBSA Code": 32860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 232,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Eau Claire-Menomonie, WI",
+          "County": {
+             "County Equivalent": "Dunn County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 33,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Merced, CA": [
        {
           "CBSA Code": 32900,
           "Metropolitan Division Code": null,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -11593,11 +21628,115 @@
           }
        }
     ],
+    "Meridian, MS": [
+       {
+          "CBSA Code": 32940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Clarke County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 23,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 32940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Kemper County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 69,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 32940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lauderdale County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 75,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mexico, MO": [
+       {
+          "CBSA Code": 33020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 190,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbia-Moberly-Mexico, MO",
+          "County": {
+             "County Equivalent": "Audrain County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Miami, OK": [
+       {
+          "CBSA Code": 33060,
+          "Metropolitan Division Code": null,
+          "CSA Code": 309,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Joplin-Miami, MO-OK",
+          "County": {
+             "County Equivalent": "Ottawa County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 115,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Miami-Fort Lauderdale-Pompano Beach, FL": [
        {
           "CBSA Code": 33100,
           "Metropolitan Division Code": 22744,
           "CSA Code": 370,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Fort Lauderdale-Pompano Beach-Sunrise, FL",
           "CSA Title": "Miami-Port St. Lucie-Fort Lauderdale, FL",
           "County": {
@@ -11614,6 +21753,9 @@
           "CBSA Code": 33100,
           "Metropolitan Division Code": 33124,
           "CSA Code": 370,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Miami-Miami Beach-Kendall, FL",
           "CSA Title": "Miami-Port St. Lucie-Fort Lauderdale, FL",
           "County": {
@@ -11630,6 +21772,9 @@
           "CBSA Code": 33100,
           "Metropolitan Division Code": 48424,
           "CSA Code": 370,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "West Palm Beach-Boca Raton-Boynton Beach, FL",
           "CSA Title": "Miami-Port St. Lucie-Fort Lauderdale, FL",
           "County": {
@@ -11648,6 +21793,9 @@
           "CBSA Code": 33140,
           "Metropolitan Division Code": null,
           "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Chicago-Naperville, IL-IN-WI",
           "County": {
@@ -11661,11 +21809,35 @@
           }
        }
     ],
+    "Middlesborough, KY": [
+       {
+          "CBSA Code": 33180,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Bell County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Midland, MI": [
        {
           "CBSA Code": 33220,
           "Metropolitan Division Code": null,
           "CSA Code": 474,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Saginaw-Midland-Bay City, MI",
           "County": {
@@ -11684,6 +21856,9 @@
           "CBSA Code": 33260,
           "Metropolitan Division Code": null,
           "CSA Code": 372,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Midland-Odessa, TX",
           "County": {
@@ -11700,6 +21875,9 @@
           "CBSA Code": 33260,
           "Metropolitan Division Code": null,
           "CSA Code": 372,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Midland-Odessa, TX",
           "County": {
@@ -11713,11 +21891,54 @@
           }
        }
     ],
+    "Milledgeville, GA": [
+       {
+          "CBSA Code": 33300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Baldwin County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 9,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 33300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Hancock County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 141,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Milwaukee-Waukesha, WI": [
        {
           "CBSA Code": 33340,
           "Metropolitan Division Code": null,
           "CSA Code": 376,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Milwaukee-Racine-Waukesha, WI",
           "County": {
@@ -11734,6 +21955,9 @@
           "CBSA Code": 33340,
           "Metropolitan Division Code": null,
           "CSA Code": 376,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Milwaukee-Racine-Waukesha, WI",
           "County": {
@@ -11750,6 +21974,9 @@
           "CBSA Code": 33340,
           "Metropolitan Division Code": null,
           "CSA Code": 376,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Milwaukee-Racine-Waukesha, WI",
           "County": {
@@ -11766,6 +21993,9 @@
           "CBSA Code": 33340,
           "Metropolitan Division Code": null,
           "CSA Code": 376,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Milwaukee-Racine-Waukesha, WI",
           "County": {
@@ -11779,11 +22009,56 @@
           }
        }
     ],
+    "Minden, LA": [
+       {
+          "CBSA Code": 33380,
+          "Metropolitan Division Code": null,
+          "CSA Code": 508,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Shreveport-Bossier City-Minden, LA",
+          "County": {
+             "County Equivalent": "Webster Parish"
+          },
+          "State Name": "Louisiana",
+          "FIPS State Code": 22,
+          "FIPS County Code": 119,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mineral Wells, TX": [
+       {
+          "CBSA Code": 33420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dallas-Fort Worth, TX-OK",
+          "County": {
+             "County Equivalent": "Palo Pinto County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 363,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Minneapolis-St. Paul-Bloomington, MN-WI": [
        {
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11800,6 +22075,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11816,6 +22094,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11832,6 +22113,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11848,6 +22132,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11864,6 +22151,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11880,6 +22170,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11896,6 +22189,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11912,6 +22208,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11928,6 +22227,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11944,6 +22246,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11960,6 +22265,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11976,6 +22284,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -11992,6 +22303,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -12008,6 +22322,9 @@
           "CBSA Code": 33460,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -12021,11 +22338,73 @@
           }
        }
     ],
+    "Minot, ND": [
+       {
+          "CBSA Code": 33500,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "McHenry County"
+          },
+          "State Name": "North Dakota",
+          "FIPS State Code": 38,
+          "FIPS County Code": 49,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 33500,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Renville County"
+          },
+          "State Name": "North Dakota",
+          "FIPS State Code": 38,
+          "FIPS County Code": 75,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 33500,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Ward County"
+          },
+          "State Name": "North Dakota",
+          "FIPS State Code": 38,
+          "FIPS County Code": 101,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Missoula, MT": [
        {
           "CBSA Code": 33540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -12039,11 +22418,75 @@
           }
        }
     ],
+    "Mitchell, SD": [
+       {
+          "CBSA Code": 33580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Davison County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 35,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 33580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Hanson County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 61,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Moberly, MO": [
+       {
+          "CBSA Code": 33620,
+          "Metropolitan Division Code": null,
+          "CSA Code": 190,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbia-Moberly-Mexico, MO",
+          "County": {
+             "County Equivalent": "Randolph County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 175,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Mobile, AL": [
        {
           "CBSA Code": 33660,
           "Metropolitan Division Code": null,
           "CSA Code": 380,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Mobile-Daphne-Fairhope, AL",
           "County": {
@@ -12060,6 +22503,9 @@
           "CBSA Code": 33660,
           "Metropolitan Division Code": null,
           "CSA Code": 380,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Mobile-Daphne-Fairhope, AL",
           "County": {
@@ -12078,6 +22524,9 @@
           "CBSA Code": 33700,
           "Metropolitan Division Code": null,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -12096,6 +22545,9 @@
           "CBSA Code": 33740,
           "Metropolitan Division Code": null,
           "CSA Code": 384,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Monroe-Ruston, LA",
           "County": {
@@ -12112,6 +22564,9 @@
           "CBSA Code": 33740,
           "Metropolitan Division Code": null,
           "CSA Code": 384,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Monroe-Ruston, LA",
           "County": {
@@ -12128,6 +22583,9 @@
           "CBSA Code": 33740,
           "Metropolitan Division Code": null,
           "CSA Code": 384,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Monroe-Ruston, LA",
           "County": {
@@ -12146,6 +22604,9 @@
           "CBSA Code": 33780,
           "Metropolitan Division Code": null,
           "CSA Code": 220,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Detroit-Warren-Ann Arbor, MI",
           "County": {
@@ -12164,6 +22625,9 @@
           "CBSA Code": 33860,
           "Metropolitan Division Code": null,
           "CSA Code": 388,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Montgomery-Selma-Alexander City, AL",
           "County": {
@@ -12180,6 +22644,9 @@
           "CBSA Code": 33860,
           "Metropolitan Division Code": null,
           "CSA Code": 388,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Montgomery-Selma-Alexander City, AL",
           "County": {
@@ -12196,6 +22663,9 @@
           "CBSA Code": 33860,
           "Metropolitan Division Code": null,
           "CSA Code": 388,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Montgomery-Selma-Alexander City, AL",
           "County": {
@@ -12212,6 +22682,9 @@
           "CBSA Code": 33860,
           "Metropolitan Division Code": null,
           "CSA Code": 388,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Montgomery-Selma-Alexander City, AL",
           "County": {
@@ -12225,11 +22698,96 @@
           }
        }
     ],
+    "Montrose, CO": [
+       {
+          "CBSA Code": 33940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Montrose County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 85,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 33940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Ouray County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 91,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Morehead City, NC": [
+       {
+          "CBSA Code": 33980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 404,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "New Bern-Morehead City, NC",
+          "County": {
+             "County Equivalent": "Carteret County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 31,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Morgan City, LA": [
+       {
+          "CBSA Code": 34020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 318,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lafayette-Opelousas-Morgan City, LA",
+          "County": {
+             "County Equivalent": "St. Mary Parish"
+          },
+          "State Name": "Louisiana",
+          "FIPS State Code": 22,
+          "FIPS County Code": 101,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Morgantown, WV": [
        {
           "CBSA Code": 34060,
           "Metropolitan Division Code": null,
           "CSA Code": 390,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Morgantown-Fairmont, WV",
           "County": {
@@ -12246,6 +22804,9 @@
           "CBSA Code": 34060,
           "Metropolitan Division Code": null,
           "CSA Code": 390,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Morgantown-Fairmont, WV",
           "County": {
@@ -12264,6 +22825,9 @@
           "CBSA Code": 34100,
           "Metropolitan Division Code": null,
           "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Knoxville-Morristown-Sevierville, TN",
           "County": {
@@ -12280,6 +22844,9 @@
           "CBSA Code": 34100,
           "Metropolitan Division Code": null,
           "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Knoxville-Morristown-Sevierville, TN",
           "County": {
@@ -12296,6 +22863,9 @@
           "CBSA Code": 34100,
           "Metropolitan Division Code": null,
           "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Knoxville-Morristown-Sevierville, TN",
           "County": {
@@ -12309,11 +22879,323 @@
           }
        }
     ],
+    "Moscow, ID": [
+       {
+          "CBSA Code": 34140,
+          "Metropolitan Division Code": null,
+          "CSA Code": 446,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Pullman-Moscow, WA-ID",
+          "County": {
+             "County Equivalent": "Latah County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 57,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Moses Lake, WA": [
+       {
+          "CBSA Code": 34180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 393,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Moses Lake-Othello, WA",
+          "County": {
+             "County Equivalent": "Grant County"
+          },
+          "State Name": "Washington",
+          "FIPS State Code": 53,
+          "FIPS County Code": 25,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Moultrie, GA": [
+       {
+          "CBSA Code": 34220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Colquitt County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 71,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mountain Home, AR": [
+       {
+          "CBSA Code": 34260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Baxter County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mountain Home, ID": [
+       {
+          "CBSA Code": 34300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 147,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Boise City-Mountain Home-Ontario, ID-OR",
+          "County": {
+             "County Equivalent": "Elmore County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 39,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mount Airy, NC": [
+       {
+          "CBSA Code": 34340,
+          "Metropolitan Division Code": null,
+          "CSA Code": 268,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Greensboro--Winston-Salem--High Point, NC",
+          "County": {
+             "County Equivalent": "Surry County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 171,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mount Gay-Shamrock, WV": [
+       {
+          "CBSA Code": 34350,
+          "Metropolitan Division Code": null,
+          "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
+          "County": {
+             "County Equivalent": "Logan County"
+          },
+          "State Name": "West Virginia",
+          "FIPS State Code": 54,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mount Pleasant, MI": [
+       {
+          "CBSA Code": 34380,
+          "Metropolitan Division Code": null,
+          "CSA Code": 394,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Mount Pleasant-Alma, MI",
+          "County": {
+             "County Equivalent": "Isabella County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 73,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mount Pleasant, TX": [
+       {
+          "CBSA Code": 34420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Camp County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 63,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 34420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Titus County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 449,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mount Sterling, KY": [
+       {
+          "CBSA Code": 34460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
+          "County": {
+             "County Equivalent": "Bath County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 34460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
+          "County": {
+             "County Equivalent": "Menifee County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 165,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 34460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
+          "County": {
+             "County Equivalent": "Montgomery County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 173,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mount Vernon, IL": [
+       {
+          "CBSA Code": 34500,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Jefferson County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 81,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Mount Vernon, OH": [
+       {
+          "CBSA Code": 34540,
+          "Metropolitan Division Code": null,
+          "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbus-Marion-Zanesville, OH",
+          "County": {
+             "County Equivalent": "Knox County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 83,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Mount Vernon-Anacortes, WA": [
        {
           "CBSA Code": 34580,
           "Metropolitan Division Code": null,
           "CSA Code": 500,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Seattle-Tacoma, WA",
           "County": {
@@ -12332,6 +23214,9 @@
           "CBSA Code": 34620,
           "Metropolitan Division Code": null,
           "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Indianapolis-Carmel-Muncie, IN",
           "County": {
@@ -12345,11 +23230,56 @@
           }
        }
     ],
+    "Murray, KY": [
+       {
+          "CBSA Code": 34660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Calloway County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 35,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Muscatine, IA": [
+       {
+          "CBSA Code": 34700,
+          "Metropolitan Division Code": null,
+          "CSA Code": 209,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Davenport-Moline, IA-IL",
+          "County": {
+             "County Equivalent": "Muscatine County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 139,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Muskegon, MI": [
        {
           "CBSA Code": 34740,
           "Metropolitan Division Code": null,
           "CSA Code": 266,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Grand Rapids-Kentwood-Muskegon, MI",
           "County": {
@@ -12363,11 +23293,35 @@
           }
        }
     ],
+    "Muskogee, OK": [
+       {
+          "CBSA Code": 34780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 538,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Tulsa-Muskogee-Bartlesville, OK",
+          "County": {
+             "County Equivalent": "Muskogee County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 101,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Myrtle Beach-Conway-North Myrtle Beach, SC-NC": [
        {
           "CBSA Code": 34820,
           "Metropolitan Division Code": null,
           "CSA Code": 396,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Myrtle Beach-Conway, SC-NC",
           "County": {
@@ -12384,6 +23338,9 @@
           "CBSA Code": 34820,
           "Metropolitan Division Code": null,
           "CSA Code": 396,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Myrtle Beach-Conway, SC-NC",
           "County": {
@@ -12397,11 +23354,35 @@
           }
        }
     ],
+    "Nacogdoches, TX": [
+       {
+          "CBSA Code": 34860,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Nacogdoches County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 347,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Napa, CA": [
        {
           "CBSA Code": 34900,
           "Metropolitan Division Code": null,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -12420,6 +23401,9 @@
           "CBSA Code": 34940,
           "Metropolitan Division Code": null,
           "CSA Code": 163,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Cape Coral-Fort Myers-Naples, FL",
           "County": {
@@ -12438,6 +23422,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12454,6 +23441,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12470,6 +23460,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12486,6 +23479,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12502,6 +23498,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12518,6 +23517,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12534,6 +23536,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12550,6 +23555,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12566,6 +23574,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12582,6 +23593,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12598,6 +23612,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12614,6 +23631,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12630,6 +23650,9 @@
           "CBSA Code": 34980,
           "Metropolitan Division Code": null,
           "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
           "County": {
@@ -12643,11 +23666,75 @@
           }
        }
     ],
+    "Natchez, MS-LA": [
+       {
+          "CBSA Code": 35020,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Concordia Parish"
+          },
+          "State Name": "Louisiana",
+          "FIPS State Code": 22,
+          "FIPS County Code": 29,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 35020,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Adams County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 1,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Natchitoches, LA": [
+       {
+          "CBSA Code": 35060,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Natchitoches Parish"
+          },
+          "State Name": "Louisiana",
+          "FIPS State Code": 22,
+          "FIPS County Code": 69,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "New Bern, NC": [
        {
           "CBSA Code": 35100,
           "Metropolitan Division Code": null,
           "CSA Code": 404,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Bern-Morehead City, NC",
           "County": {
@@ -12664,6 +23751,9 @@
           "CBSA Code": 35100,
           "Metropolitan Division Code": null,
           "CSA Code": 404,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Bern-Morehead City, NC",
           "County": {
@@ -12680,6 +23770,9 @@
           "CBSA Code": 35100,
           "Metropolitan Division Code": null,
           "CSA Code": 404,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Bern-Morehead City, NC",
           "County": {
@@ -12693,11 +23786,77 @@
           }
        }
     ],
+    "Newberry, SC": [
+       {
+          "CBSA Code": 35140,
+          "Metropolitan Division Code": null,
+          "CSA Code": 192,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbia-Orangeburg-Newberry, SC",
+          "County": {
+             "County Equivalent": "Newberry County"
+          },
+          "State Name": "South Carolina",
+          "FIPS State Code": 45,
+          "FIPS County Code": 71,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "New Castle, IN": [
+       {
+          "CBSA Code": 35220,
+          "Metropolitan Division Code": null,
+          "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Indianapolis-Carmel-Muncie, IN",
+          "County": {
+             "County Equivalent": "Henry County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 65,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "New Castle, PA": [
+       {
+          "CBSA Code": 35260,
+          "Metropolitan Division Code": null,
+          "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
+          "County": {
+             "County Equivalent": "Lawrence County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 73,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "New Haven-Milford, CT": [
        {
           "CBSA Code": 35300,
           "Metropolitan Division Code": null,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -12716,6 +23875,9 @@
           "CBSA Code": 35380,
           "Metropolitan Division Code": null,
           "CSA Code": 406,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Orleans-Metairie-Hammond, LA-MS",
           "County": {
@@ -12732,6 +23894,9 @@
           "CBSA Code": 35380,
           "Metropolitan Division Code": null,
           "CSA Code": 406,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Orleans-Metairie-Hammond, LA-MS",
           "County": {
@@ -12748,6 +23913,9 @@
           "CBSA Code": 35380,
           "Metropolitan Division Code": null,
           "CSA Code": 406,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Orleans-Metairie-Hammond, LA-MS",
           "County": {
@@ -12764,6 +23932,9 @@
           "CBSA Code": 35380,
           "Metropolitan Division Code": null,
           "CSA Code": 406,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Orleans-Metairie-Hammond, LA-MS",
           "County": {
@@ -12780,6 +23951,9 @@
           "CBSA Code": 35380,
           "Metropolitan Division Code": null,
           "CSA Code": 406,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Orleans-Metairie-Hammond, LA-MS",
           "County": {
@@ -12796,6 +23970,9 @@
           "CBSA Code": 35380,
           "Metropolitan Division Code": null,
           "CSA Code": 406,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Orleans-Metairie-Hammond, LA-MS",
           "County": {
@@ -12812,6 +23989,9 @@
           "CBSA Code": 35380,
           "Metropolitan Division Code": null,
           "CSA Code": 406,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Orleans-Metairie-Hammond, LA-MS",
           "County": {
@@ -12828,6 +24008,9 @@
           "CBSA Code": 35380,
           "Metropolitan Division Code": null,
           "CSA Code": 406,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New Orleans-Metairie-Hammond, LA-MS",
           "County": {
@@ -12841,11 +24024,98 @@
           }
        }
     ],
+    "New Philadelphia-Dover, OH": [
+       {
+          "CBSA Code": 35420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Cleveland-Akron-Canton, OH",
+          "County": {
+             "County Equivalent": "Tuscarawas County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 157,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Newport, OR": [
+       {
+          "CBSA Code": 35440,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lincoln County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 41,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Newport, TN": [
+       {
+          "CBSA Code": 35460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Knoxville-Morristown-Sevierville, TN",
+          "County": {
+             "County Equivalent": "Cocke County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 29,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "New Ulm, MN": [
+       {
+          "CBSA Code": 35580,
+          "Metropolitan Division Code": null,
+          "CSA Code": 359,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Mankato-New Ulm, MN",
+          "County": {
+             "County Equivalent": "Brown County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 15,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "New York-Newark-Jersey City, NY-NJ-PA": [
        {
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35004,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Nassau County-Suffolk County, NY",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -12862,6 +24132,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35004,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Nassau County-Suffolk County, NY",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -12878,6 +24151,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35084,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Newark, NJ-PA",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -12894,6 +24170,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35084,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Newark, NJ-PA",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -12910,6 +24189,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35084,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Newark, NJ-PA",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -12926,6 +24208,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35084,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Newark, NJ-PA",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -12942,6 +24227,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35084,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Newark, NJ-PA",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -12958,6 +24246,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35084,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Newark, NJ-PA",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -12974,6 +24265,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35154,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New Brunswick-Lakewood, NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -12990,6 +24284,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35154,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New Brunswick-Lakewood, NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13006,6 +24303,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35154,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New Brunswick-Lakewood, NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13022,6 +24322,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35154,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New Brunswick-Lakewood, NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13038,6 +24341,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35614,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New York-Jersey City-White Plains, NY-NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13054,6 +24360,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35614,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New York-Jersey City-White Plains, NY-NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13070,6 +24379,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35614,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New York-Jersey City-White Plains, NY-NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13086,6 +24398,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35614,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New York-Jersey City-White Plains, NY-NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13102,6 +24417,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35614,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New York-Jersey City-White Plains, NY-NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13118,6 +24436,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35614,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New York-Jersey City-White Plains, NY-NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13134,6 +24455,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35614,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New York-Jersey City-White Plains, NY-NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13150,6 +24474,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35614,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New York-Jersey City-White Plains, NY-NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13166,6 +24493,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35614,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New York-Jersey City-White Plains, NY-NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13182,6 +24512,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35614,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New York-Jersey City-White Plains, NY-NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13198,6 +24531,9 @@
           "CBSA Code": 35620,
           "Metropolitan Division Code": 35614,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "New York-Jersey City-White Plains, NY-NJ",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -13216,6 +24552,9 @@
           "CBSA Code": 35660,
           "Metropolitan Division Code": null,
           "CSA Code": 515,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "South Bend-Elkhart-Mishawaka, IN-MI",
           "County": {
@@ -13229,11 +24568,153 @@
           }
        }
     ],
+    "Nogales, AZ": [
+       {
+          "CBSA Code": 35700,
+          "Metropolitan Division Code": null,
+          "CSA Code": 536,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Tucson-Nogales, AZ",
+          "County": {
+             "County Equivalent": "Santa Cruz County"
+          },
+          "State Name": "Arizona",
+          "FIPS State Code": 4,
+          "FIPS County Code": 23,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Norfolk, NE": [
+       {
+          "CBSA Code": 35740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Madison County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 119,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 35740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pierce County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 139,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 35740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Stanton County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 167,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "North Platte, NE": [
+       {
+          "CBSA Code": 35820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lincoln County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 111,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 35820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Logan County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 113,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 35820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "McPherson County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 117,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "North Port-Sarasota-Bradenton, FL": [
        {
           "CBSA Code": 35840,
           "Metropolitan Division Code": null,
           "CSA Code": 412,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "North Port-Sarasota, FL",
           "County": {
@@ -13250,6 +24731,9 @@
           "CBSA Code": 35840,
           "Metropolitan Division Code": null,
           "CSA Code": 412,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "North Port-Sarasota, FL",
           "County": {
@@ -13263,11 +24747,77 @@
           }
        }
     ],
+    "North Vernon, IN": [
+       {
+          "CBSA Code": 35860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Indianapolis-Carmel-Muncie, IN",
+          "County": {
+             "County Equivalent": "Jennings County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 79,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "North Wilkesboro, NC": [
+       {
+          "CBSA Code": 35900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Wilkes County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 193,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Norwalk, OH": [
+       {
+          "CBSA Code": 35940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Cleveland-Akron-Canton, OH",
+          "County": {
+             "County Equivalent": "Huron County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 77,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Norwich-New London, CT": [
        {
           "CBSA Code": 35980,
           "Metropolitan Division Code": null,
           "CSA Code": 278,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Hartford-East Hartford, CT",
           "County": {
@@ -13281,11 +24831,35 @@
           }
        }
     ],
+    "Oak Harbor, WA": [
+       {
+          "CBSA Code": 36020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 500,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Seattle-Tacoma, WA",
+          "County": {
+             "County Equivalent": "Island County"
+          },
+          "State Name": "Washington",
+          "FIPS State Code": 53,
+          "FIPS County Code": 29,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Ocala, FL": [
        {
           "CBSA Code": 36100,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -13304,6 +24878,9 @@
           "CBSA Code": 36140,
           "Metropolitan Division Code": null,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -13322,6 +24899,9 @@
           "CBSA Code": 36220,
           "Metropolitan Division Code": null,
           "CSA Code": 372,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Midland-Odessa, TX",
           "County": {
@@ -13340,6 +24920,9 @@
           "CBSA Code": 36260,
           "Metropolitan Division Code": null,
           "CSA Code": 482,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salt Lake City-Provo-Orem, UT",
           "County": {
@@ -13356,6 +24939,9 @@
           "CBSA Code": 36260,
           "Metropolitan Division Code": null,
           "CSA Code": 482,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salt Lake City-Provo-Orem, UT",
           "County": {
@@ -13372,6 +24958,9 @@
           "CBSA Code": 36260,
           "Metropolitan Division Code": null,
           "CSA Code": 482,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salt Lake City-Provo-Orem, UT",
           "County": {
@@ -13388,6 +24977,9 @@
           "CBSA Code": 36260,
           "Metropolitan Division Code": null,
           "CSA Code": 482,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salt Lake City-Provo-Orem, UT",
           "County": {
@@ -13401,11 +24993,77 @@
           }
        }
     ],
+    "Ogdensburg-Massena, NY": [
+       {
+          "CBSA Code": 36300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "St. Lawrence County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 89,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Oil City, PA": [
+       {
+          "CBSA Code": 36340,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Venango County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 121,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Okeechobee, FL": [
+       {
+          "CBSA Code": 36380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Okeechobee County"
+          },
+          "State Name": "Florida",
+          "FIPS State Code": 12,
+          "FIPS County Code": 93,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Oklahoma City, OK": [
        {
           "CBSA Code": 36420,
           "Metropolitan Division Code": null,
           "CSA Code": 416,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Oklahoma City-Shawnee, OK",
           "County": {
@@ -13422,6 +25080,9 @@
           "CBSA Code": 36420,
           "Metropolitan Division Code": null,
           "CSA Code": 416,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Oklahoma City-Shawnee, OK",
           "County": {
@@ -13438,6 +25099,9 @@
           "CBSA Code": 36420,
           "Metropolitan Division Code": null,
           "CSA Code": 416,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Oklahoma City-Shawnee, OK",
           "County": {
@@ -13454,6 +25118,9 @@
           "CBSA Code": 36420,
           "Metropolitan Division Code": null,
           "CSA Code": 416,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Oklahoma City-Shawnee, OK",
           "County": {
@@ -13470,6 +25137,9 @@
           "CBSA Code": 36420,
           "Metropolitan Division Code": null,
           "CSA Code": 416,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Oklahoma City-Shawnee, OK",
           "County": {
@@ -13486,6 +25156,9 @@
           "CBSA Code": 36420,
           "Metropolitan Division Code": null,
           "CSA Code": 416,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Oklahoma City-Shawnee, OK",
           "County": {
@@ -13502,6 +25175,9 @@
           "CBSA Code": 36420,
           "Metropolitan Division Code": null,
           "CSA Code": 416,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Oklahoma City-Shawnee, OK",
           "County": {
@@ -13515,11 +25191,35 @@
           }
        }
     ],
+    "Olean, NY": [
+       {
+          "CBSA Code": 36460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 160,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Buffalo-Cheektowaga-Olean, NY",
+          "County": {
+             "County Equivalent": "Cattaraugus County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 9,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Olympia-Lacey-Tumwater, WA": [
        {
           "CBSA Code": 36500,
           "Metropolitan Division Code": null,
           "CSA Code": 500,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Seattle-Tacoma, WA",
           "County": {
@@ -13538,6 +25238,9 @@
           "CBSA Code": 36540,
           "Metropolitan Division Code": null,
           "CSA Code": 420,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Omaha-Council Bluffs-Fremont, NE-IA",
           "County": {
@@ -13554,6 +25257,9 @@
           "CBSA Code": 36540,
           "Metropolitan Division Code": null,
           "CSA Code": 420,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Omaha-Council Bluffs-Fremont, NE-IA",
           "County": {
@@ -13570,6 +25276,9 @@
           "CBSA Code": 36540,
           "Metropolitan Division Code": null,
           "CSA Code": 420,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Omaha-Council Bluffs-Fremont, NE-IA",
           "County": {
@@ -13586,6 +25295,9 @@
           "CBSA Code": 36540,
           "Metropolitan Division Code": null,
           "CSA Code": 420,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Omaha-Council Bluffs-Fremont, NE-IA",
           "County": {
@@ -13602,6 +25314,9 @@
           "CBSA Code": 36540,
           "Metropolitan Division Code": null,
           "CSA Code": 420,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Omaha-Council Bluffs-Fremont, NE-IA",
           "County": {
@@ -13618,6 +25333,9 @@
           "CBSA Code": 36540,
           "Metropolitan Division Code": null,
           "CSA Code": 420,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Omaha-Council Bluffs-Fremont, NE-IA",
           "County": {
@@ -13634,6 +25352,9 @@
           "CBSA Code": 36540,
           "Metropolitan Division Code": null,
           "CSA Code": 420,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Omaha-Council Bluffs-Fremont, NE-IA",
           "County": {
@@ -13650,6 +25371,9 @@
           "CBSA Code": 36540,
           "Metropolitan Division Code": null,
           "CSA Code": 420,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Omaha-Council Bluffs-Fremont, NE-IA",
           "County": {
@@ -13663,11 +25387,117 @@
           }
        }
     ],
+    "Oneonta, NY": [
+       {
+          "CBSA Code": 36580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Otsego County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 77,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Ontario, OR-ID": [
+       {
+          "CBSA Code": 36620,
+          "Metropolitan Division Code": null,
+          "CSA Code": 147,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Boise City-Mountain Home-Ontario, ID-OR",
+          "County": {
+             "County Equivalent": "Payette County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 75,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 36620,
+          "Metropolitan Division Code": null,
+          "CSA Code": 147,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Boise City-Mountain Home-Ontario, ID-OR",
+          "County": {
+             "County Equivalent": "Malheur County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Opelousas, LA": [
+       {
+          "CBSA Code": 36660,
+          "Metropolitan Division Code": null,
+          "CSA Code": 318,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lafayette-Opelousas-Morgan City, LA",
+          "County": {
+             "County Equivalent": "St. Landry Parish"
+          },
+          "State Name": "Louisiana",
+          "FIPS State Code": 22,
+          "FIPS County Code": 97,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Orangeburg, SC": [
+       {
+          "CBSA Code": 36700,
+          "Metropolitan Division Code": null,
+          "CSA Code": 192,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbia-Orangeburg-Newberry, SC",
+          "County": {
+             "County Equivalent": "Orangeburg County"
+          },
+          "State Name": "South Carolina",
+          "FIPS State Code": 45,
+          "FIPS County Code": 75,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Orlando-Kissimmee-Sanford, FL": [
        {
           "CBSA Code": 36740,
           "Metropolitan Division Code": null,
           "CSA Code": 422,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Orlando-Lakeland-Deltona, FL",
           "County": {
@@ -13684,6 +25514,9 @@
           "CBSA Code": 36740,
           "Metropolitan Division Code": null,
           "CSA Code": 422,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Orlando-Lakeland-Deltona, FL",
           "County": {
@@ -13700,6 +25533,9 @@
           "CBSA Code": 36740,
           "Metropolitan Division Code": null,
           "CSA Code": 422,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Orlando-Lakeland-Deltona, FL",
           "County": {
@@ -13716,6 +25552,9 @@
           "CBSA Code": 36740,
           "Metropolitan Division Code": null,
           "CSA Code": 422,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Orlando-Lakeland-Deltona, FL",
           "County": {
@@ -13734,6 +25573,9 @@
           "CBSA Code": 36780,
           "Metropolitan Division Code": null,
           "CSA Code": 118,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Appleton-Oshkosh-Neenah, WI",
           "County": {
@@ -13747,11 +25589,178 @@
           }
        }
     ],
+    "Oskaloosa, IA": [
+       {
+          "CBSA Code": 36820,
+          "Metropolitan Division Code": null,
+          "CSA Code": 218,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Des Moines-Ames-West Des Moines, IA",
+          "County": {
+             "County Equivalent": "Mahaska County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 123,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Othello, WA": [
+       {
+          "CBSA Code": 36830,
+          "Metropolitan Division Code": null,
+          "CSA Code": 393,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Moses Lake-Othello, WA",
+          "County": {
+             "County Equivalent": "Adams County"
+          },
+          "State Name": "Washington",
+          "FIPS State Code": 53,
+          "FIPS County Code": 1,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Ottawa, IL": [
+       {
+          "CBSA Code": 36837,
+          "Metropolitan Division Code": null,
+          "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Chicago-Naperville, IL-IN-WI",
+          "County": {
+             "County Equivalent": "Bureau County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 36837,
+          "Metropolitan Division Code": null,
+          "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Chicago-Naperville, IL-IN-WI",
+          "County": {
+             "County Equivalent": "LaSalle County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 99,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 36837,
+          "Metropolitan Division Code": null,
+          "CSA Code": 176,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Chicago-Naperville, IL-IN-WI",
+          "County": {
+             "County Equivalent": "Putnam County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 155,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Ottawa, KS": [
+       {
+          "CBSA Code": 36840,
+          "Metropolitan Division Code": null,
+          "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
+          "County": {
+             "County Equivalent": "Franklin County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 59,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Ottumwa, IA": [
+       {
+          "CBSA Code": 36900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Wapello County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 179,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Owatonna, MN": [
+       {
+          "CBSA Code": 36940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Minneapolis-St. Paul, MN-WI",
+          "County": {
+             "County Equivalent": "Steele County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 147,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Owensboro, KY": [
        {
           "CBSA Code": 36980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -13768,6 +25777,9 @@
           "CBSA Code": 36980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -13784,6 +25796,9 @@
           "CBSA Code": 36980,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -13797,11 +25812,35 @@
           }
        }
     ],
+    "Oxford, MS": [
+       {
+          "CBSA Code": 37060,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lafayette County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 71,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Oxnard-Thousand Oaks-Ventura, CA": [
        {
           "CBSA Code": 37100,
           "Metropolitan Division Code": null,
           "CSA Code": 348,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Los Angeles-Long Beach, CA",
           "County": {
@@ -13815,11 +25854,176 @@
           }
        }
     ],
+    "Ozark, AL": [
+       {
+          "CBSA Code": 37120,
+          "Metropolitan Division Code": null,
+          "CSA Code": 222,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dothan-Ozark, AL",
+          "County": {
+             "County Equivalent": "Dale County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Paducah, KY-IL": [
+       {
+          "CBSA Code": 37140,
+          "Metropolitan Division Code": null,
+          "CSA Code": 424,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Paducah-Mayfield, KY-IL",
+          "County": {
+             "County Equivalent": "Massac County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 127,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 37140,
+          "Metropolitan Division Code": null,
+          "CSA Code": 424,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Paducah-Mayfield, KY-IL",
+          "County": {
+             "County Equivalent": "Ballard County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 37140,
+          "Metropolitan Division Code": null,
+          "CSA Code": 424,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Paducah-Mayfield, KY-IL",
+          "County": {
+             "County Equivalent": "Livingston County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 139,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 37140,
+          "Metropolitan Division Code": null,
+          "CSA Code": 424,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Paducah-Mayfield, KY-IL",
+          "County": {
+             "County Equivalent": "McCracken County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 145,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Pahrump, NV": [
+       {
+          "CBSA Code": 37220,
+          "Metropolitan Division Code": null,
+          "CSA Code": 332,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Las Vegas-Henderson, NV",
+          "County": {
+             "County Equivalent": "Nye County"
+          },
+          "State Name": "Nevada",
+          "FIPS State Code": 32,
+          "FIPS County Code": 23,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Palatka, FL": [
+       {
+          "CBSA Code": 37260,
+          "Metropolitan Division Code": null,
+          "CSA Code": 300,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Jacksonville-St. Marys-Palatka, FL-GA",
+          "County": {
+             "County Equivalent": "Putnam County"
+          },
+          "State Name": "Florida",
+          "FIPS State Code": 12,
+          "FIPS County Code": 107,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Palestine, TX": [
+       {
+          "CBSA Code": 37300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Anderson County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 1,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Palm Bay-Melbourne-Titusville, FL": [
        {
           "CBSA Code": 37340,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -13833,11 +26037,54 @@
           }
        }
     ],
+    "Pampa, TX": [
+       {
+          "CBSA Code": 37420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 108,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Amarillo-Pampa-Borger, TX",
+          "County": {
+             "County Equivalent": "Gray County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 179,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 37420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 108,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Amarillo-Pampa-Borger, TX",
+          "County": {
+             "County Equivalent": "Roberts County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 393,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Panama City, FL": [
        {
           "CBSA Code": 37460,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -13851,11 +26098,77 @@
           }
        }
     ],
+    "Paragould, AR": [
+       {
+          "CBSA Code": 37500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 308,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Jonesboro-Paragould, AR",
+          "County": {
+             "County Equivalent": "Greene County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 55,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Paris, TN": [
+       {
+          "CBSA Code": 37540,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Henry County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 79,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Paris, TX": [
+       {
+          "CBSA Code": 37580,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lamar County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 277,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Parkersburg-Vienna, WV": [
        {
           "CBSA Code": 37620,
           "Metropolitan Division Code": null,
           "CSA Code": 425,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Parkersburg-Marietta-Vienna, WV-OH",
           "County": {
@@ -13872,6 +26185,9 @@
           "CBSA Code": 37620,
           "Metropolitan Division Code": null,
           "CSA Code": 425,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Parkersburg-Marietta-Vienna, WV-OH",
           "County": {
@@ -13885,11 +26201,138 @@
           }
        }
     ],
+    "Parsons, KS": [
+       {
+          "CBSA Code": 37660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Labette County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 99,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Payson, AZ": [
+       {
+          "CBSA Code": 37740,
+          "Metropolitan Division Code": null,
+          "CSA Code": 429,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Phoenix-Mesa, AZ",
+          "County": {
+             "County Equivalent": "Gila County"
+          },
+          "State Name": "Arizona",
+          "FIPS State Code": 4,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Pearsall, TX": [
+       {
+          "CBSA Code": 37770,
+          "Metropolitan Division Code": null,
+          "CSA Code": 484,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "San Antonio-New Braunfels-Pearsall, TX",
+          "County": {
+             "County Equivalent": "Frio County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 163,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Pecos, TX": [
+       {
+          "CBSA Code": 37780,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Loving County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 301,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 37780,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Reeves County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 389,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Pella, IA": [
+       {
+          "CBSA Code": 37800,
+          "Metropolitan Division Code": null,
+          "CSA Code": 218,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Des Moines-Ames-West Des Moines, IA",
+          "County": {
+             "County Equivalent": "Marion County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 125,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Pensacola-Ferry Pass-Brent, FL": [
        {
           "CBSA Code": 37860,
           "Metropolitan Division Code": null,
           "CSA Code": 426,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pensacola-Ferry Pass, FL-AL",
           "County": {
@@ -13906,6 +26349,9 @@
           "CBSA Code": 37860,
           "Metropolitan Division Code": null,
           "CSA Code": 426,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pensacola-Ferry Pass, FL-AL",
           "County": {
@@ -13924,6 +26370,9 @@
           "CBSA Code": 37900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -13940,6 +26389,9 @@
           "CBSA Code": 37900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -13956,6 +26408,9 @@
           "CBSA Code": 37900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -13972,6 +26427,9 @@
           "CBSA Code": 37900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -13988,6 +26446,9 @@
           "CBSA Code": 37900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -14004,6 +26465,9 @@
           "CBSA Code": 37900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -14017,11 +26481,35 @@
           }
        }
     ],
+    "Peru, IN": [
+       {
+          "CBSA Code": 37940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 316,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Kokomo-Peru, IN",
+          "County": {
+             "County Equivalent": "Miami County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 103,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Philadelphia-Camden-Wilmington, PA-NJ-DE-MD": [
        {
           "CBSA Code": 37980,
           "Metropolitan Division Code": 15804,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Camden, NJ",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -14038,6 +26526,9 @@
           "CBSA Code": 37980,
           "Metropolitan Division Code": 15804,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Camden, NJ",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -14054,6 +26545,9 @@
           "CBSA Code": 37980,
           "Metropolitan Division Code": 15804,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Camden, NJ",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -14070,6 +26564,9 @@
           "CBSA Code": 37980,
           "Metropolitan Division Code": 33874,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Montgomery County-Bucks County-Chester County, PA",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -14086,6 +26583,9 @@
           "CBSA Code": 37980,
           "Metropolitan Division Code": 33874,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Montgomery County-Bucks County-Chester County, PA",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -14102,6 +26602,9 @@
           "CBSA Code": 37980,
           "Metropolitan Division Code": 33874,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Montgomery County-Bucks County-Chester County, PA",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -14118,6 +26621,9 @@
           "CBSA Code": 37980,
           "Metropolitan Division Code": 37964,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Philadelphia, PA",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -14134,6 +26640,9 @@
           "CBSA Code": 37980,
           "Metropolitan Division Code": 37964,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Philadelphia, PA",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -14150,6 +26659,9 @@
           "CBSA Code": 37980,
           "Metropolitan Division Code": 48864,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Wilmington, DE-MD-NJ",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -14166,6 +26678,9 @@
           "CBSA Code": 37980,
           "Metropolitan Division Code": 48864,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Wilmington, DE-MD-NJ",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -14182,6 +26697,9 @@
           "CBSA Code": 37980,
           "Metropolitan Division Code": 48864,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Wilmington, DE-MD-NJ",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -14200,6 +26718,9 @@
           "CBSA Code": 38060,
           "Metropolitan Division Code": null,
           "CSA Code": 429,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Phoenix-Mesa, AZ",
           "County": {
@@ -14216,6 +26737,9 @@
           "CBSA Code": 38060,
           "Metropolitan Division Code": null,
           "CSA Code": 429,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Phoenix-Mesa, AZ",
           "County": {
@@ -14229,11 +26753,75 @@
           }
        }
     ],
+    "Picayune, MS": [
+       {
+          "CBSA Code": 38100,
+          "Metropolitan Division Code": null,
+          "CSA Code": 406,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "New Orleans-Metairie-Hammond, LA-MS",
+          "County": {
+             "County Equivalent": "Pearl River County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 109,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Pierre, SD": [
+       {
+          "CBSA Code": 38180,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Hughes County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 65,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 38180,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Stanley County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 117,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Pine Bluff, AR": [
        {
           "CBSA Code": 38220,
           "Metropolitan Division Code": null,
           "CSA Code": 340,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Little Rock-North Little Rock, AR",
           "County": {
@@ -14250,6 +26838,9 @@
           "CBSA Code": 38220,
           "Metropolitan Division Code": null,
           "CSA Code": 340,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Little Rock-North Little Rock, AR",
           "County": {
@@ -14266,6 +26857,9 @@
           "CBSA Code": 38220,
           "Metropolitan Division Code": null,
           "CSA Code": 340,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Little Rock-North Little Rock, AR",
           "County": {
@@ -14279,11 +26873,56 @@
           }
        }
     ],
+    "Pinehurst-Southern Pines, NC": [
+       {
+          "CBSA Code": 38240,
+          "Metropolitan Division Code": null,
+          "CSA Code": 246,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Fayetteville-Sanford-Lumberton, NC",
+          "County": {
+             "County Equivalent": "Moore County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 125,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Pittsburg, KS": [
+       {
+          "CBSA Code": 38260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Crawford County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 37,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Pittsburgh, PA": [
        {
           "CBSA Code": 38300,
           "Metropolitan Division Code": null,
           "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
           "County": {
@@ -14300,6 +26939,9 @@
           "CBSA Code": 38300,
           "Metropolitan Division Code": null,
           "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
           "County": {
@@ -14316,6 +26958,9 @@
           "CBSA Code": 38300,
           "Metropolitan Division Code": null,
           "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
           "County": {
@@ -14332,6 +26977,9 @@
           "CBSA Code": 38300,
           "Metropolitan Division Code": null,
           "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
           "County": {
@@ -14348,6 +26996,9 @@
           "CBSA Code": 38300,
           "Metropolitan Division Code": null,
           "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
           "County": {
@@ -14364,6 +27015,9 @@
           "CBSA Code": 38300,
           "Metropolitan Division Code": null,
           "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
           "County": {
@@ -14380,6 +27034,9 @@
           "CBSA Code": 38300,
           "Metropolitan Division Code": null,
           "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
           "County": {
@@ -14398,6 +27055,9 @@
           "CBSA Code": 38340,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -14411,11 +27071,98 @@
           }
        }
     ],
+    "Plainview, TX": [
+       {
+          "CBSA Code": 38380,
+          "Metropolitan Division Code": null,
+          "CSA Code": 352,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lubbock-Plainview-Levelland, TX",
+          "County": {
+             "County Equivalent": "Hale County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 189,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Platteville, WI": [
+       {
+          "CBSA Code": 38420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Grant County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 43,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Plattsburgh, NY": [
+       {
+          "CBSA Code": 38460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Clinton County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 19,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Plymouth, IN": [
+       {
+          "CBSA Code": 38500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 515,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "South Bend-Elkhart-Mishawaka, IN-MI",
+          "County": {
+             "County Equivalent": "Marshall County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 99,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Pocatello, ID": [
        {
           "CBSA Code": 38540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -14432,6 +27179,9 @@
           "CBSA Code": 38540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -14445,11 +27195,75 @@
           }
        }
     ],
+    "Point Pleasant, WV-OH": [
+       {
+          "CBSA Code": 38580,
+          "Metropolitan Division Code": null,
+          "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
+          "County": {
+             "County Equivalent": "Gallia County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 53,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 38580,
+          "Metropolitan Division Code": null,
+          "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
+          "County": {
+             "County Equivalent": "Mason County"
+          },
+          "State Name": "West Virginia",
+          "FIPS State Code": 54,
+          "FIPS County Code": 53,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Ponca City, OK": [
+       {
+          "CBSA Code": 38620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Kay County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 71,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Ponce, PR": [
        {
           "CBSA Code": 38660,
           "Metropolitan Division Code": null,
           "CSA Code": 434,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Ponce-Yauco-Coamo, PR",
           "County": {
@@ -14466,10 +27280,13 @@
           "CBSA Code": 38660,
           "Metropolitan Division Code": null,
           "CSA Code": 434,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Ponce-Yauco-Coamo, PR",
           "County": {
-             "County Equivalent": "Juana Díaz Municipio"
+             "County Equivalent": "Juana D�az Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -14482,6 +27299,9 @@
           "CBSA Code": 38660,
           "Metropolitan Division Code": null,
           "CSA Code": 434,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Ponce-Yauco-Coamo, PR",
           "County": {
@@ -14498,6 +27318,9 @@
           "CBSA Code": 38660,
           "Metropolitan Division Code": null,
           "CSA Code": 434,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Ponce-Yauco-Coamo, PR",
           "County": {
@@ -14511,11 +27334,117 @@
           }
        }
     ],
+    "Pontiac, IL": [
+       {
+          "CBSA Code": 38700,
+          "Metropolitan Division Code": null,
+          "CSA Code": 145,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Bloomington-Pontiac, IL",
+          "County": {
+             "County Equivalent": "Livingston County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 105,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Poplar Bluff, MO": [
+       {
+          "CBSA Code": 38740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Butler County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 23,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 38740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Ripley County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 181,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Portales, NM": [
+       {
+          "CBSA Code": 38780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 188,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Clovis-Portales, NM",
+          "County": {
+             "County Equivalent": "Roosevelt County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 41,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Port Angeles, WA": [
+       {
+          "CBSA Code": 38820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Clallam County"
+          },
+          "State Name": "Washington",
+          "FIPS State Code": 53,
+          "FIPS County Code": 9,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Portland-South Portland, ME": [
        {
           "CBSA Code": 38860,
           "Metropolitan Division Code": null,
           "CSA Code": 438,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Lewiston-South Portland, ME",
           "County": {
@@ -14532,6 +27461,9 @@
           "CBSA Code": 38860,
           "Metropolitan Division Code": null,
           "CSA Code": 438,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Lewiston-South Portland, ME",
           "County": {
@@ -14548,6 +27480,9 @@
           "CBSA Code": 38860,
           "Metropolitan Division Code": null,
           "CSA Code": 438,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Lewiston-South Portland, ME",
           "County": {
@@ -14566,6 +27501,9 @@
           "CBSA Code": 38900,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -14582,6 +27520,9 @@
           "CBSA Code": 38900,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -14598,6 +27539,9 @@
           "CBSA Code": 38900,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -14614,6 +27558,9 @@
           "CBSA Code": 38900,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -14630,6 +27577,9 @@
           "CBSA Code": 38900,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -14646,6 +27596,9 @@
           "CBSA Code": 38900,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -14662,6 +27615,9 @@
           "CBSA Code": 38900,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -14675,11 +27631,35 @@
           }
        }
     ],
+    "Port Lavaca, TX": [
+       {
+          "CBSA Code": 38920,
+          "Metropolitan Division Code": null,
+          "CSA Code": 544,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Victoria-Port Lavaca, TX",
+          "County": {
+             "County Equivalent": "Calhoun County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 57,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Port St. Lucie, FL": [
        {
           "CBSA Code": 38940,
           "Metropolitan Division Code": null,
           "CSA Code": 370,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Miami-Port St. Lucie-Fort Lauderdale, FL",
           "County": {
@@ -14696,6 +27676,9 @@
           "CBSA Code": 38940,
           "Metropolitan Division Code": null,
           "CSA Code": 370,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Miami-Port St. Lucie-Fort Lauderdale, FL",
           "County": {
@@ -14709,11 +27692,56 @@
           }
        }
     ],
+    "Portsmouth, OH": [
+       {
+          "CBSA Code": 39020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 170,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Charleston-Huntington-Ashland, WV-OH-KY",
+          "County": {
+             "County Equivalent": "Scioto County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 145,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Pottsville, PA": [
+       {
+          "CBSA Code": 39060,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Schuylkill County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 107,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Poughkeepsie-Newburgh-Middletown, NY": [
        {
           "CBSA Code": 39100,
           "Metropolitan Division Code": null,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -14730,6 +27758,9 @@
           "CBSA Code": 39100,
           "Metropolitan Division Code": null,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -14748,6 +27779,9 @@
           "CBSA Code": 39150,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -14761,11 +27795,56 @@
           }
        }
     ],
+    "Price, UT": [
+       {
+          "CBSA Code": 39220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Carbon County"
+          },
+          "State Name": "Utah",
+          "FIPS State Code": 49,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Prineville, OR": [
+       {
+          "CBSA Code": 39260,
+          "Metropolitan Division Code": null,
+          "CSA Code": 140,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Bend-Prineville, OR",
+          "County": {
+             "County Equivalent": "Crook County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Providence-Warwick, RI-MA": [
        {
           "CBSA Code": 39300,
           "Metropolitan Division Code": null,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -14782,6 +27861,9 @@
           "CBSA Code": 39300,
           "Metropolitan Division Code": null,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -14798,6 +27880,9 @@
           "CBSA Code": 39300,
           "Metropolitan Division Code": null,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -14814,6 +27899,9 @@
           "CBSA Code": 39300,
           "Metropolitan Division Code": null,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -14830,6 +27918,9 @@
           "CBSA Code": 39300,
           "Metropolitan Division Code": null,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -14846,6 +27937,9 @@
           "CBSA Code": 39300,
           "Metropolitan Division Code": null,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -14864,6 +27958,9 @@
           "CBSA Code": 39340,
           "Metropolitan Division Code": null,
           "CSA Code": 482,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salt Lake City-Provo-Orem, UT",
           "County": {
@@ -14880,6 +27977,9 @@
           "CBSA Code": 39340,
           "Metropolitan Division Code": null,
           "CSA Code": 482,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salt Lake City-Provo-Orem, UT",
           "County": {
@@ -14898,8 +27998,11 @@
           "CBSA Code": 39380,
           "Metropolitan Division Code": null,
           "CSA Code": 444,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "Pueblo-Cañon City, CO",
+          "CSA Title": "Pueblo-Ca�on City, CO",
           "County": {
              "County Equivalent": "Pueblo County"
           },
@@ -14911,11 +28014,35 @@
           }
        }
     ],
+    "Pullman, WA": [
+       {
+          "CBSA Code": 39420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 446,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Pullman-Moscow, WA-ID",
+          "County": {
+             "County Equivalent": "Whitman County"
+          },
+          "State Name": "Washington",
+          "FIPS State Code": 53,
+          "FIPS County Code": 75,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Punta Gorda, FL": [
        {
           "CBSA Code": 39460,
           "Metropolitan Division Code": null,
           "CSA Code": 412,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "North Port-Sarasota, FL",
           "County": {
@@ -14929,11 +28056,54 @@
           }
        }
     ],
+    "Quincy, IL-MO": [
+       {
+          "CBSA Code": 39500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 448,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Quincy-Hannibal, IL-MO",
+          "County": {
+             "County Equivalent": "Adams County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 1,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 39500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 448,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Quincy-Hannibal, IL-MO",
+          "County": {
+             "County Equivalent": "Lewis County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 111,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Racine, WI": [
        {
           "CBSA Code": 39540,
           "Metropolitan Division Code": null,
           "CSA Code": 376,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Milwaukee-Racine-Waukesha, WI",
           "County": {
@@ -14952,6 +28122,9 @@
           "CBSA Code": 39580,
           "Metropolitan Division Code": null,
           "CSA Code": 450,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Raleigh-Durham-Cary, NC",
           "County": {
@@ -14968,6 +28141,9 @@
           "CBSA Code": 39580,
           "Metropolitan Division Code": null,
           "CSA Code": 450,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Raleigh-Durham-Cary, NC",
           "County": {
@@ -14984,6 +28160,9 @@
           "CBSA Code": 39580,
           "Metropolitan Division Code": null,
           "CSA Code": 450,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Raleigh-Durham-Cary, NC",
           "County": {
@@ -15002,6 +28181,9 @@
           "CBSA Code": 39660,
           "Metropolitan Division Code": null,
           "CSA Code": 452,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rapid City-Spearfish, SD",
           "County": {
@@ -15018,6 +28200,9 @@
           "CBSA Code": 39660,
           "Metropolitan Division Code": null,
           "CSA Code": 452,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rapid City-Spearfish, SD",
           "County": {
@@ -15031,11 +28216,35 @@
           }
        }
     ],
+    "Raymondville, TX": [
+       {
+          "CBSA Code": 39700,
+          "Metropolitan Division Code": null,
+          "CSA Code": 154,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Brownsville-Harlingen-Raymondville, TX",
+          "County": {
+             "County Equivalent": "Willacy County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 489,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Reading, PA": [
        {
           "CBSA Code": 39740,
           "Metropolitan Division Code": null,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -15049,11 +28258,35 @@
           }
        }
     ],
+    "Red Bluff, CA": [
+       {
+          "CBSA Code": 39780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 454,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Redding-Red Bluff, CA",
+          "County": {
+             "County Equivalent": "Tehama County"
+          },
+          "State Name": "California",
+          "FIPS State Code": 6,
+          "FIPS County Code": 103,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Redding, CA": [
        {
           "CBSA Code": 39820,
           "Metropolitan Division Code": null,
           "CSA Code": 454,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Redding-Red Bluff, CA",
           "County": {
@@ -15067,11 +28300,35 @@
           }
        }
     ],
+    "Red Wing, MN": [
+       {
+          "CBSA Code": 39860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Minneapolis-St. Paul, MN-WI",
+          "County": {
+             "County Equivalent": "Goodhue County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 49,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Reno, NV": [
        {
           "CBSA Code": 39900,
           "Metropolitan Division Code": null,
           "CSA Code": 456,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Reno-Carson City-Fernley, NV",
           "County": {
@@ -15088,6 +28345,9 @@
           "CBSA Code": 39900,
           "Metropolitan Division Code": null,
           "CSA Code": 456,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Reno-Carson City-Fernley, NV",
           "County": {
@@ -15101,11 +28361,75 @@
           }
        }
     ],
+    "Rexburg, ID": [
+       {
+          "CBSA Code": 39940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 292,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Idaho Falls-Rexburg-Blackfoot, ID",
+          "County": {
+             "County Equivalent": "Fremont County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 43,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 39940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 292,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Idaho Falls-Rexburg-Blackfoot, ID",
+          "County": {
+             "County Equivalent": "Madison County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 65,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Richmond, IN": [
+       {
+          "CBSA Code": 39980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 458,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Richmond-Connersville, IN",
+          "County": {
+             "County Equivalent": "Wayne County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 177,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Richmond, VA": [
        {
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15122,6 +28446,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15138,6 +28465,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15154,6 +28484,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15170,6 +28503,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15186,6 +28522,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15202,6 +28541,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15218,6 +28560,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15234,6 +28579,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15250,6 +28598,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15266,6 +28617,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15282,6 +28636,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15298,6 +28655,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15314,6 +28674,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15330,6 +28693,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15346,6 +28712,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15362,6 +28731,9 @@
           "CBSA Code": 40060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15375,11 +28747,75 @@
           }
        }
     ],
+    "Richmond-Berea, KY": [
+       {
+          "CBSA Code": 40080,
+          "Metropolitan Division Code": null,
+          "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
+          "County": {
+             "County Equivalent": "Estill County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 65,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 40080,
+          "Metropolitan Division Code": null,
+          "CSA Code": 336,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lexington-Fayette--Richmond--Frankfort, KY",
+          "County": {
+             "County Equivalent": "Madison County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 151,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Rio Grande City-Roma, TX": [
+       {
+          "CBSA Code": 40100,
+          "Metropolitan Division Code": null,
+          "CSA Code": 365,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "McAllen-Edinburg, TX",
+          "County": {
+             "County Equivalent": "Starr County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 427,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Riverside-San Bernardino-Ontario, CA": [
        {
           "CBSA Code": 40140,
           "Metropolitan Division Code": null,
           "CSA Code": 348,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Los Angeles-Long Beach, CA",
           "County": {
@@ -15396,6 +28832,9 @@
           "CBSA Code": 40140,
           "Metropolitan Division Code": null,
           "CSA Code": 348,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Los Angeles-Long Beach, CA",
           "County": {
@@ -15409,11 +28848,35 @@
           }
        }
     ],
+    "Riverton, WY": [
+       {
+          "CBSA Code": 40180,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Fremont County"
+          },
+          "State Name": "Wyoming",
+          "FIPS State Code": 56,
+          "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Roanoke, VA": [
        {
           "CBSA Code": 40220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15430,6 +28893,9 @@
           "CBSA Code": 40220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15446,6 +28912,9 @@
           "CBSA Code": 40220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15462,6 +28931,9 @@
           "CBSA Code": 40220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15478,6 +28950,9 @@
           "CBSA Code": 40220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15494,6 +28969,9 @@
           "CBSA Code": 40220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15507,11 +28985,75 @@
           }
        }
     ],
+    "Roanoke Rapids, NC": [
+       {
+          "CBSA Code": 40260,
+          "Metropolitan Division Code": null,
+          "CSA Code": 468,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Rocky Mount-Wilson-Roanoke Rapids, NC",
+          "County": {
+             "County Equivalent": "Halifax County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 83,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 40260,
+          "Metropolitan Division Code": null,
+          "CSA Code": 468,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Rocky Mount-Wilson-Roanoke Rapids, NC",
+          "County": {
+             "County Equivalent": "Northampton County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 131,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Rochelle, IL": [
+       {
+          "CBSA Code": 40300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 466,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Rockford-Freeport-Rochelle, IL",
+          "County": {
+             "County Equivalent": "Ogle County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 141,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Rochester, MN": [
        {
           "CBSA Code": 40340,
           "Metropolitan Division Code": null,
           "CSA Code": 462,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rochester-Austin, MN",
           "County": {
@@ -15528,6 +29070,9 @@
           "CBSA Code": 40340,
           "Metropolitan Division Code": null,
           "CSA Code": 462,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rochester-Austin, MN",
           "County": {
@@ -15544,6 +29089,9 @@
           "CBSA Code": 40340,
           "Metropolitan Division Code": null,
           "CSA Code": 462,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rochester-Austin, MN",
           "County": {
@@ -15560,6 +29108,9 @@
           "CBSA Code": 40340,
           "Metropolitan Division Code": null,
           "CSA Code": 462,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rochester-Austin, MN",
           "County": {
@@ -15578,6 +29129,9 @@
           "CBSA Code": 40380,
           "Metropolitan Division Code": null,
           "CSA Code": 464,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rochester-Batavia-Seneca Falls, NY",
           "County": {
@@ -15594,6 +29148,9 @@
           "CBSA Code": 40380,
           "Metropolitan Division Code": null,
           "CSA Code": 464,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rochester-Batavia-Seneca Falls, NY",
           "County": {
@@ -15610,6 +29167,9 @@
           "CBSA Code": 40380,
           "Metropolitan Division Code": null,
           "CSA Code": 464,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rochester-Batavia-Seneca Falls, NY",
           "County": {
@@ -15626,6 +29186,9 @@
           "CBSA Code": 40380,
           "Metropolitan Division Code": null,
           "CSA Code": 464,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rochester-Batavia-Seneca Falls, NY",
           "County": {
@@ -15642,6 +29205,9 @@
           "CBSA Code": 40380,
           "Metropolitan Division Code": null,
           "CSA Code": 464,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rochester-Batavia-Seneca Falls, NY",
           "County": {
@@ -15658,6 +29224,9 @@
           "CBSA Code": 40380,
           "Metropolitan Division Code": null,
           "CSA Code": 464,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rochester-Batavia-Seneca Falls, NY",
           "County": {
@@ -15676,6 +29245,9 @@
           "CBSA Code": 40420,
           "Metropolitan Division Code": null,
           "CSA Code": 466,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rockford-Freeport-Rochelle, IL",
           "County": {
@@ -15692,6 +29264,9 @@
           "CBSA Code": 40420,
           "Metropolitan Division Code": null,
           "CSA Code": 466,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rockford-Freeport-Rochelle, IL",
           "County": {
@@ -15705,11 +29280,77 @@
           }
        }
     ],
+    "Rockingham, NC": [
+       {
+          "CBSA Code": 40460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Richmond County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 153,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Rockport, TX": [
+       {
+          "CBSA Code": 40530,
+          "Metropolitan Division Code": null,
+          "CSA Code": 204,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Corpus Christi-Kingsville-Alice, TX",
+          "County": {
+             "County Equivalent": "Aransas County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Rock Springs, WY": [
+       {
+          "CBSA Code": 40540,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Sweetwater County"
+          },
+          "State Name": "Wyoming",
+          "FIPS State Code": 56,
+          "FIPS County Code": 37,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Rocky Mount, NC": [
        {
           "CBSA Code": 40580,
           "Metropolitan Division Code": null,
           "CSA Code": 468,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rocky Mount-Wilson-Roanoke Rapids, NC",
           "County": {
@@ -15726,6 +29367,9 @@
           "CBSA Code": 40580,
           "Metropolitan Division Code": null,
           "CSA Code": 468,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Rocky Mount-Wilson-Roanoke Rapids, NC",
           "County": {
@@ -15739,11 +29383,35 @@
           }
        }
     ],
+    "Rolla, MO": [
+       {
+          "CBSA Code": 40620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Phelps County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 161,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Rome, GA": [
        {
           "CBSA Code": 40660,
           "Metropolitan Division Code": null,
           "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
           "County": {
@@ -15757,11 +29425,159 @@
           }
        }
     ],
+    "Roseburg, OR": [
+       {
+          "CBSA Code": 40700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Douglas County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 19,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Roswell, NM": [
+       {
+          "CBSA Code": 40740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Chaves County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Ruidoso, NM": [
+       {
+          "CBSA Code": 40760,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lincoln County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Russellville, AR": [
+       {
+          "CBSA Code": 40780,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pope County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 115,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 40780,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Yell County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 149,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Ruston, LA": [
+       {
+          "CBSA Code": 40820,
+          "Metropolitan Division Code": null,
+          "CSA Code": 384,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Monroe-Ruston, LA",
+          "County": {
+             "County Equivalent": "Lincoln Parish"
+          },
+          "State Name": "Louisiana",
+          "FIPS State Code": 22,
+          "FIPS County Code": 61,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Rutland, VT": [
+       {
+          "CBSA Code": 40860,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Rutland County"
+          },
+          "State Name": "Vermont",
+          "FIPS State Code": 50,
+          "FIPS County Code": 21,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Sacramento-Roseville-Folsom, CA": [
        {
           "CBSA Code": 40900,
           "Metropolitan Division Code": null,
           "CSA Code": 472,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Sacramento-Roseville, CA",
           "County": {
@@ -15778,6 +29594,9 @@
           "CBSA Code": 40900,
           "Metropolitan Division Code": null,
           "CSA Code": 472,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Sacramento-Roseville, CA",
           "County": {
@@ -15794,6 +29613,9 @@
           "CBSA Code": 40900,
           "Metropolitan Division Code": null,
           "CSA Code": 472,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Sacramento-Roseville, CA",
           "County": {
@@ -15810,6 +29632,9 @@
           "CBSA Code": 40900,
           "Metropolitan Division Code": null,
           "CSA Code": 472,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Sacramento-Roseville, CA",
           "County": {
@@ -15823,11 +29648,35 @@
           }
        }
     ],
+    "Safford, AZ": [
+       {
+          "CBSA Code": 40940,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Graham County"
+          },
+          "State Name": "Arizona",
+          "FIPS State Code": 4,
+          "FIPS County Code": 9,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Saginaw, MI": [
        {
           "CBSA Code": 40980,
           "Metropolitan Division Code": null,
           "CSA Code": 474,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Saginaw-Midland-Bay City, MI",
           "County": {
@@ -15846,6 +29695,9 @@
           "CBSA Code": 41060,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -15862,6 +29714,9 @@
           "CBSA Code": 41060,
           "Metropolitan Division Code": null,
           "CSA Code": 378,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Minneapolis-St. Paul, MN-WI",
           "County": {
@@ -15880,6 +29735,9 @@
           "CBSA Code": 41100,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -15898,6 +29756,9 @@
           "CBSA Code": 41140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -15914,6 +29775,9 @@
           "CBSA Code": 41140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -15930,6 +29794,9 @@
           "CBSA Code": 41140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -15946,6 +29813,9 @@
           "CBSA Code": 41140,
           "Metropolitan Division Code": null,
           "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
           "County": {
@@ -15964,6 +29834,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -15980,6 +29853,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -15996,6 +29872,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16012,6 +29891,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16028,6 +29910,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16044,6 +29929,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16060,6 +29948,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16076,6 +29967,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16092,6 +29986,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16108,6 +30005,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16124,6 +30024,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16140,6 +30043,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16156,6 +30062,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16172,6 +30081,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16188,6 +30100,9 @@
           "CBSA Code": 41180,
           "Metropolitan Division Code": null,
           "CSA Code": 476,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "St. Louis-St. Charles-Farmington, MO-IL",
           "County": {
@@ -16201,11 +30116,77 @@
           }
        }
     ],
+    "St. Marys, GA": [
+       {
+          "CBSA Code": 41220,
+          "Metropolitan Division Code": null,
+          "CSA Code": 300,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Jacksonville-St. Marys-Palatka, FL-GA",
+          "County": {
+             "County Equivalent": "Camden County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 39,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "St. Marys, PA": [
+       {
+          "CBSA Code": 41260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Elk County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 47,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Salem, OH": [
+       {
+          "CBSA Code": 41400,
+          "Metropolitan Division Code": null,
+          "CSA Code": 566,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Youngstown-Warren, OH-PA",
+          "County": {
+             "County Equivalent": "Columbiana County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 29,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Salem, OR": [
        {
           "CBSA Code": 41420,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -16222,6 +30203,9 @@
           "CBSA Code": 41420,
           "Metropolitan Division Code": null,
           "CSA Code": 440,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Portland-Vancouver-Salem, OR-WA",
           "County": {
@@ -16235,11 +30219,54 @@
           }
        }
     ],
+    "Salina, KS": [
+       {
+          "CBSA Code": 41460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Ottawa County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 143,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 41460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Saline County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 169,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Salinas, CA": [
        {
           "CBSA Code": 41500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -16258,6 +30285,9 @@
           "CBSA Code": 41540,
           "Metropolitan Division Code": null,
           "CSA Code": 480,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salisbury-Cambridge, MD-DE",
           "County": {
@@ -16274,6 +30304,9 @@
           "CBSA Code": 41540,
           "Metropolitan Division Code": null,
           "CSA Code": 480,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salisbury-Cambridge, MD-DE",
           "County": {
@@ -16290,6 +30323,9 @@
           "CBSA Code": 41540,
           "Metropolitan Division Code": null,
           "CSA Code": 480,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salisbury-Cambridge, MD-DE",
           "County": {
@@ -16306,6 +30342,9 @@
           "CBSA Code": 41540,
           "Metropolitan Division Code": null,
           "CSA Code": 480,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salisbury-Cambridge, MD-DE",
           "County": {
@@ -16324,6 +30363,9 @@
           "CBSA Code": 41620,
           "Metropolitan Division Code": null,
           "CSA Code": 482,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salt Lake City-Provo-Orem, UT",
           "County": {
@@ -16340,6 +30382,9 @@
           "CBSA Code": 41620,
           "Metropolitan Division Code": null,
           "CSA Code": 482,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Salt Lake City-Provo-Orem, UT",
           "County": {
@@ -16358,6 +30403,9 @@
           "CBSA Code": 41660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -16374,6 +30422,9 @@
           "CBSA Code": 41660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -16390,6 +30441,9 @@
           "CBSA Code": 41660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -16408,6 +30462,9 @@
           "CBSA Code": 41700,
           "Metropolitan Division Code": null,
           "CSA Code": 484,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Antonio-New Braunfels-Pearsall, TX",
           "County": {
@@ -16424,6 +30481,9 @@
           "CBSA Code": 41700,
           "Metropolitan Division Code": null,
           "CSA Code": 484,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Antonio-New Braunfels-Pearsall, TX",
           "County": {
@@ -16440,6 +30500,9 @@
           "CBSA Code": 41700,
           "Metropolitan Division Code": null,
           "CSA Code": 484,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Antonio-New Braunfels-Pearsall, TX",
           "County": {
@@ -16456,6 +30519,9 @@
           "CBSA Code": 41700,
           "Metropolitan Division Code": null,
           "CSA Code": 484,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Antonio-New Braunfels-Pearsall, TX",
           "County": {
@@ -16472,6 +30538,9 @@
           "CBSA Code": 41700,
           "Metropolitan Division Code": null,
           "CSA Code": 484,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Antonio-New Braunfels-Pearsall, TX",
           "County": {
@@ -16488,6 +30557,9 @@
           "CBSA Code": 41700,
           "Metropolitan Division Code": null,
           "CSA Code": 484,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Antonio-New Braunfels-Pearsall, TX",
           "County": {
@@ -16504,6 +30576,9 @@
           "CBSA Code": 41700,
           "Metropolitan Division Code": null,
           "CSA Code": 484,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Antonio-New Braunfels-Pearsall, TX",
           "County": {
@@ -16520,6 +30595,9 @@
           "CBSA Code": 41700,
           "Metropolitan Division Code": null,
           "CSA Code": 484,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Antonio-New Braunfels-Pearsall, TX",
           "County": {
@@ -16538,6 +30616,9 @@
           "CBSA Code": 41740,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -16551,11 +30632,77 @@
           }
        }
     ],
+    "Sandpoint, ID": [
+       {
+          "CBSA Code": 41760,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Bonner County"
+          },
+          "State Name": "Idaho",
+          "FIPS State Code": 16,
+          "FIPS County Code": 17,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Sandusky, OH": [
+       {
+          "CBSA Code": 41780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Cleveland-Akron-Canton, OH",
+          "County": {
+             "County Equivalent": "Erie County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 43,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Sanford, NC": [
+       {
+          "CBSA Code": 41820,
+          "Metropolitan Division Code": null,
+          "CSA Code": 246,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Fayetteville-Sanford-Lumberton, NC",
+          "County": {
+             "County Equivalent": "Lee County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 105,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "San Francisco-Oakland-Berkeley, CA": [
        {
           "CBSA Code": 41860,
           "Metropolitan Division Code": 36084,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Oakland-Berkeley-Livermore, CA",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -16572,6 +30719,9 @@
           "CBSA Code": 41860,
           "Metropolitan Division Code": 36084,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Oakland-Berkeley-Livermore, CA",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -16588,6 +30738,9 @@
           "CBSA Code": 41860,
           "Metropolitan Division Code": 41884,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "San Francisco-San Mateo-Redwood City, CA",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -16604,6 +30757,9 @@
           "CBSA Code": 41860,
           "Metropolitan Division Code": 41884,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "San Francisco-San Mateo-Redwood City, CA",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -16620,6 +30776,9 @@
           "CBSA Code": 41860,
           "Metropolitan Division Code": 42034,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "San Rafael, CA",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -16633,13 +30792,16 @@
           }
        }
     ],
-    "San Germán, PR": [
+    "San Germ�n, PR": [
        {
           "CBSA Code": 41900,
           "Metropolitan Division Code": null,
           "CSA Code": 364,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "Mayagüez-San Germán, PR",
+          "CSA Title": "Mayag�ez-San Germ�n, PR",
           "County": {
              "County Equivalent": "Cabo Rojo Municipio"
           },
@@ -16654,8 +30816,11 @@
           "CBSA Code": 41900,
           "Metropolitan Division Code": null,
           "CSA Code": 364,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "Mayagüez-San Germán, PR",
+          "CSA Title": "Mayag�ez-San Germ�n, PR",
           "County": {
              "County Equivalent": "Lajas Municipio"
           },
@@ -16670,8 +30835,11 @@
           "CBSA Code": 41900,
           "Metropolitan Division Code": null,
           "CSA Code": 364,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "Mayagüez-San Germán, PR",
+          "CSA Title": "Mayag�ez-San Germ�n, PR",
           "County": {
              "County Equivalent": "Sabana Grande Municipio"
           },
@@ -16686,10 +30854,13 @@
           "CBSA Code": 41900,
           "Metropolitan Division Code": null,
           "CSA Code": 364,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "Mayagüez-San Germán, PR",
+          "CSA Title": "Mayag�ez-San Germ�n, PR",
           "County": {
-             "County Equivalent": "San Germán Municipio"
+             "County Equivalent": "San Germ�n Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -16704,6 +30875,9 @@
           "CBSA Code": 41940,
           "Metropolitan Division Code": null,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -16720,6 +30894,9 @@
           "CBSA Code": 41940,
           "Metropolitan Division Code": null,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -16733,13 +30910,16 @@
           }
        }
     ],
-    "San Juan-Bayamón-Caguas, PR": [
+    "San Juan-Bayam�n-Caguas, PR": [
        {
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Aguas Buenas Municipio"
           },
@@ -16754,8 +30934,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Aibonito Municipio"
           },
@@ -16770,8 +30953,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Barceloneta Municipio"
           },
@@ -16786,8 +30972,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Barranquitas Municipio"
           },
@@ -16802,10 +30991,13 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
-             "County Equivalent": "Bayamón Municipio"
+             "County Equivalent": "Bayam�n Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -16818,8 +31010,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Caguas Municipio"
           },
@@ -16834,10 +31029,13 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
-             "County Equivalent": "Canóvanas Municipio"
+             "County Equivalent": "Can�vanas Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -16850,8 +31048,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Carolina Municipio"
           },
@@ -16866,10 +31067,13 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
-             "County Equivalent": "Cataño Municipio"
+             "County Equivalent": "Cata�o Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -16882,8 +31086,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Cayey Municipio"
           },
@@ -16898,8 +31105,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Ceiba Municipio"
           },
@@ -16914,8 +31124,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Ciales Municipio"
           },
@@ -16930,8 +31143,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Cidra Municipio"
           },
@@ -16946,10 +31162,13 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
-             "County Equivalent": "Comerío Municipio"
+             "County Equivalent": "Comer�o Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -16962,8 +31181,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Corozal Municipio"
           },
@@ -16978,8 +31200,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Dorado Municipio"
           },
@@ -16994,8 +31219,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Fajardo Municipio"
           },
@@ -17010,8 +31238,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Florida Municipio"
           },
@@ -17026,8 +31257,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Guaynabo Municipio"
           },
@@ -17042,8 +31276,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Gurabo Municipio"
           },
@@ -17058,8 +31295,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Humacao Municipio"
           },
@@ -17074,8 +31314,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Juncos Municipio"
           },
@@ -17090,8 +31333,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Las Piedras Municipio"
           },
@@ -17106,10 +31352,13 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
-             "County Equivalent": "Loíza Municipio"
+             "County Equivalent": "Lo�za Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -17122,8 +31371,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Luquillo Municipio"
           },
@@ -17138,10 +31390,13 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
-             "County Equivalent": "Manatí Municipio"
+             "County Equivalent": "Manat� Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -17154,8 +31409,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Maunabo Municipio"
           },
@@ -17170,8 +31428,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Morovis Municipio"
           },
@@ -17186,8 +31447,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Naguabo Municipio"
           },
@@ -17202,8 +31466,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Naranjito Municipio"
           },
@@ -17218,8 +31485,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Orocovis Municipio"
           },
@@ -17234,10 +31504,13 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
-             "County Equivalent": "Río Grande Municipio"
+             "County Equivalent": "R�o Grande Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -17250,8 +31523,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "San Juan Municipio"
           },
@@ -17266,8 +31542,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "San Lorenzo Municipio"
           },
@@ -17282,8 +31561,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Toa Alta Municipio"
           },
@@ -17298,8 +31580,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Toa Baja Municipio"
           },
@@ -17314,8 +31599,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Trujillo Alto Municipio"
           },
@@ -17330,8 +31618,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Vega Alta Municipio"
           },
@@ -17346,8 +31637,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Vega Baja Municipio"
           },
@@ -17362,8 +31656,11 @@
           "CBSA Code": 41980,
           "Metropolitan Division Code": null,
           "CSA Code": 490,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
-          "CSA Title": "San Juan-Bayamón, PR",
+          "CSA Title": "San Juan-Bayam�n, PR",
           "County": {
              "County Equivalent": "Yabucoa Municipio"
           },
@@ -17380,6 +31677,9 @@
           "CBSA Code": 42020,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17398,6 +31698,9 @@
           "CBSA Code": 42100,
           "Metropolitan Division Code": null,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -17416,6 +31719,9 @@
           "CBSA Code": 42140,
           "Metropolitan Division Code": null,
           "CSA Code": 106,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Albuquerque-Santa Fe-Las Vegas, NM",
           "County": {
@@ -17429,11 +31735,35 @@
           }
        }
     ],
+    "Santa Isabel, PR": [
+       {
+          "CBSA Code": 42180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 434,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Ponce-Yauco-Coamo, PR",
+          "County": {
+             "County Equivalent": "Santa Isabel Municipio"
+          },
+          "State Name": "Puerto Rico",
+          "FIPS State Code": 72,
+          "FIPS County Code": 133,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Santa Maria-Santa Barbara, CA": [
        {
           "CBSA Code": 42200,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17452,6 +31782,9 @@
           "CBSA Code": 42220,
           "Metropolitan Division Code": null,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -17465,11 +31798,35 @@
           }
        }
     ],
+    "Sault Ste. Marie, MI": [
+       {
+          "CBSA Code": 42300,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Chippewa County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 33,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Savannah, GA": [
        {
           "CBSA Code": 42340,
           "Metropolitan Division Code": null,
           "CSA Code": 496,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Savannah-Hinesville-Statesboro, GA",
           "County": {
@@ -17486,6 +31843,9 @@
           "CBSA Code": 42340,
           "Metropolitan Division Code": null,
           "CSA Code": 496,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Savannah-Hinesville-Statesboro, GA",
           "County": {
@@ -17502,6 +31862,9 @@
           "CBSA Code": 42340,
           "Metropolitan Division Code": null,
           "CSA Code": 496,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Savannah-Hinesville-Statesboro, GA",
           "County": {
@@ -17515,11 +31878,136 @@
           }
        }
     ],
+    "Sayre, PA": [
+       {
+          "CBSA Code": 42380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Bradford County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 15,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Scottsbluff, NE": [
+       {
+          "CBSA Code": 42420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Banner County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 42420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Scotts Bluff County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 157,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 42420,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Sioux County"
+          },
+          "State Name": "Nebraska",
+          "FIPS State Code": 31,
+          "FIPS County Code": 165,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Scottsboro, AL": [
+       {
+          "CBSA Code": 42460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 497,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Scottsboro-Fort Payne, AL",
+          "County": {
+             "County Equivalent": "Jackson County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 71,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Scottsburg, IN": [
+       {
+          "CBSA Code": 42500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 350,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Louisville/Jefferson County--Elizabethtown--Bardstown, KY-IN",
+          "County": {
+             "County Equivalent": "Scott County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 143,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Scranton--Wilkes-Barre, PA": [
        {
           "CBSA Code": 42540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17536,6 +32024,9 @@
           "CBSA Code": 42540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17552,6 +32043,9 @@
           "CBSA Code": 42540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17565,11 +32059,35 @@
           }
        }
     ],
+    "Searcy, AR": [
+       {
+          "CBSA Code": 42620,
+          "Metropolitan Division Code": null,
+          "CSA Code": 340,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Little Rock-North Little Rock, AR",
+          "County": {
+             "County Equivalent": "White County"
+          },
+          "State Name": "Arkansas",
+          "FIPS State Code": 5,
+          "FIPS County Code": 145,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Seattle-Tacoma-Bellevue, WA": [
        {
           "CBSA Code": 42660,
           "Metropolitan Division Code": 42644,
           "CSA Code": 500,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Seattle-Bellevue-Kent, WA",
           "CSA Title": "Seattle-Tacoma, WA",
           "County": {
@@ -17586,6 +32104,9 @@
           "CBSA Code": 42660,
           "Metropolitan Division Code": 42644,
           "CSA Code": 500,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Seattle-Bellevue-Kent, WA",
           "CSA Title": "Seattle-Tacoma, WA",
           "County": {
@@ -17602,6 +32123,9 @@
           "CBSA Code": 42660,
           "Metropolitan Division Code": 45104,
           "CSA Code": 500,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Tacoma-Lakewood, WA",
           "CSA Title": "Seattle-Tacoma, WA",
           "County": {
@@ -17620,6 +32144,9 @@
           "CBSA Code": 42680,
           "Metropolitan Division Code": null,
           "CSA Code": 370,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Miami-Port St. Lucie-Fort Lauderdale, FL",
           "County": {
@@ -17638,6 +32165,9 @@
           "CBSA Code": 42700,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17651,11 +32181,222 @@
           }
        }
     ],
+    "Sedalia, MO": [
+       {
+          "CBSA Code": 42740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pettis County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 159,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Selinsgrove, PA": [
+       {
+          "CBSA Code": 42780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 146,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Bloomsburg-Berwick-Sunbury, PA",
+          "County": {
+             "County Equivalent": "Snyder County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 109,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Selma, AL": [
+       {
+          "CBSA Code": 42820,
+          "Metropolitan Division Code": null,
+          "CSA Code": 388,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Montgomery-Selma-Alexander City, AL",
+          "County": {
+             "County Equivalent": "Dallas County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 47,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Seneca, SC": [
+       {
+          "CBSA Code": 42860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 273,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Greenville-Spartanburg-Anderson, SC",
+          "County": {
+             "County Equivalent": "Oconee County"
+          },
+          "State Name": "South Carolina",
+          "FIPS State Code": 45,
+          "FIPS County Code": 73,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Seneca Falls, NY": [
+       {
+          "CBSA Code": 42900,
+          "Metropolitan Division Code": null,
+          "CSA Code": 464,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Rochester-Batavia-Seneca Falls, NY",
+          "County": {
+             "County Equivalent": "Seneca County"
+          },
+          "State Name": "New York",
+          "FIPS State Code": 36,
+          "FIPS County Code": 99,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Sevierville, TN": [
+       {
+          "CBSA Code": 42940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 315,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Knoxville-Morristown-Sevierville, TN",
+          "County": {
+             "County Equivalent": "Sevier County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 155,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Seymour, IN": [
+       {
+          "CBSA Code": 42980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 294,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Indianapolis-Carmel-Muncie, IN",
+          "County": {
+             "County Equivalent": "Jackson County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 71,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Shawano, WI": [
+       {
+          "CBSA Code": 43020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 267,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Green Bay-Shawano, WI",
+          "County": {
+             "County Equivalent": "Menominee County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 78,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 43020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 267,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Green Bay-Shawano, WI",
+          "County": {
+             "County Equivalent": "Shawano County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 115,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Shawnee, OK": [
+       {
+          "CBSA Code": 43060,
+          "Metropolitan Division Code": null,
+          "CSA Code": 416,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Oklahoma City-Shawnee, OK",
+          "County": {
+             "County Equivalent": "Pottawatomie County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 125,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Sheboygan, WI": [
        {
           "CBSA Code": 43100,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17669,11 +32410,98 @@
           }
        }
     ],
+    "Shelby, NC": [
+       {
+          "CBSA Code": 43140,
+          "Metropolitan Division Code": null,
+          "CSA Code": 172,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Charlotte-Concord, NC-SC",
+          "County": {
+             "County Equivalent": "Cleveland County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Shelbyville, TN": [
+       {
+          "CBSA Code": 43180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 400,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Nashville-Davidson--Murfreesboro, TN",
+          "County": {
+             "County Equivalent": "Bedford County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 3,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Shelton, WA": [
+       {
+          "CBSA Code": 43220,
+          "Metropolitan Division Code": null,
+          "CSA Code": 500,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Seattle-Tacoma, WA",
+          "County": {
+             "County Equivalent": "Mason County"
+          },
+          "State Name": "Washington",
+          "FIPS State Code": 53,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Sheridan, WY": [
+       {
+          "CBSA Code": 43260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Sheridan County"
+          },
+          "State Name": "Wyoming",
+          "FIPS State Code": 56,
+          "FIPS County Code": 33,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Sherman-Denison, TX": [
        {
           "CBSA Code": 43300,
           "Metropolitan Division Code": null,
           "CSA Code": 206,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Dallas-Fort Worth, TX-OK",
           "County": {
@@ -17687,11 +32515,35 @@
           }
        }
     ],
+    "Show Low, AZ": [
+       {
+          "CBSA Code": 43320,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Navajo County"
+          },
+          "State Name": "Arizona",
+          "FIPS State Code": 4,
+          "FIPS County Code": 17,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Shreveport-Bossier City, LA": [
        {
           "CBSA Code": 43340,
           "Metropolitan Division Code": null,
           "CSA Code": 508,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Shreveport-Bossier City-Minden, LA",
           "County": {
@@ -17708,6 +32560,9 @@
           "CBSA Code": 43340,
           "Metropolitan Division Code": null,
           "CSA Code": 508,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Shreveport-Bossier City-Minden, LA",
           "County": {
@@ -17724,6 +32579,9 @@
           "CBSA Code": 43340,
           "Metropolitan Division Code": null,
           "CSA Code": 508,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Shreveport-Bossier City-Minden, LA",
           "County": {
@@ -17737,11 +32595,35 @@
           }
        }
     ],
+    "Sidney, OH": [
+       {
+          "CBSA Code": 43380,
+          "Metropolitan Division Code": null,
+          "CSA Code": 212,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dayton-Springfield-Kettering, OH",
+          "County": {
+             "County Equivalent": "Shelby County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 149,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Sierra Vista-Douglas, AZ": [
        {
           "CBSA Code": 43420,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17755,11 +32637,56 @@
           }
        }
     ],
+    "Sikeston, MO": [
+       {
+          "CBSA Code": 43460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 164,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Cape Girardeau-Sikeston, MO-IL",
+          "County": {
+             "County Equivalent": "Scott County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 201,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Silver City, NM": [
+       {
+          "CBSA Code": 43500,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Grant County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 17,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Sioux City, IA-NE-SD": [
        {
           "CBSA Code": 43580,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17776,6 +32703,9 @@
           "CBSA Code": 43580,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17792,6 +32722,9 @@
           "CBSA Code": 43580,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17808,6 +32741,9 @@
           "CBSA Code": 43580,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17826,6 +32762,9 @@
           "CBSA Code": 43620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17842,6 +32781,9 @@
           "CBSA Code": 43620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17858,6 +32800,9 @@
           "CBSA Code": 43620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17874,6 +32819,9 @@
           "CBSA Code": 43620,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -17887,11 +32835,98 @@
           }
        }
     ],
+    "Snyder, TX": [
+       {
+          "CBSA Code": 43660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Scurry County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 415,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Somerset, KY": [
+       {
+          "CBSA Code": 43700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pulaski County"
+          },
+          "State Name": "Kentucky",
+          "FIPS State Code": 21,
+          "FIPS County Code": 199,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Somerset, PA": [
+       {
+          "CBSA Code": 43740,
+          "Metropolitan Division Code": null,
+          "CSA Code": 306,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Johnstown-Somerset, PA",
+          "County": {
+             "County Equivalent": "Somerset County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 111,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Sonora, CA": [
+       {
+          "CBSA Code": 43760,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Tuolumne County"
+          },
+          "State Name": "California",
+          "FIPS State Code": 6,
+          "FIPS County Code": 109,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "South Bend-Mishawaka, IN-MI": [
        {
           "CBSA Code": 43780,
           "Metropolitan Division Code": null,
           "CSA Code": 515,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "South Bend-Elkhart-Mishawaka, IN-MI",
           "County": {
@@ -17908,6 +32943,9 @@
           "CBSA Code": 43780,
           "Metropolitan Division Code": null,
           "CSA Code": 515,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "South Bend-Elkhart-Mishawaka, IN-MI",
           "County": {
@@ -17926,6 +32964,9 @@
           "CBSA Code": 43900,
           "Metropolitan Division Code": null,
           "CSA Code": 273,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greenville-Spartanburg-Anderson, SC",
           "County": {
@@ -17939,11 +32980,77 @@
           }
        }
     ],
+    "Spearfish, SD": [
+       {
+          "CBSA Code": 43940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 452,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Rapid City-Spearfish, SD",
+          "County": {
+             "County Equivalent": "Lawrence County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 81,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Spencer, IA": [
+       {
+          "CBSA Code": 43980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 517,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Spencer-Spirit Lake, IA",
+          "County": {
+             "County Equivalent": "Clay County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 41,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Spirit Lake, IA": [
+       {
+          "CBSA Code": 44020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 517,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Spencer-Spirit Lake, IA",
+          "County": {
+             "County Equivalent": "Dickinson County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 59,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Spokane-Spokane Valley, WA": [
        {
           "CBSA Code": 44060,
           "Metropolitan Division Code": null,
           "CSA Code": 518,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Spokane-Spokane Valley-Coeur d'Alene, WA-ID",
           "County": {
@@ -17960,6 +33067,9 @@
           "CBSA Code": 44060,
           "Metropolitan Division Code": null,
           "CSA Code": 518,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Spokane-Spokane Valley-Coeur d'Alene, WA-ID",
           "County": {
@@ -17978,6 +33088,9 @@
           "CBSA Code": 44100,
           "Metropolitan Division Code": null,
           "CSA Code": 522,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Springfield-Jacksonville-Lincoln, IL",
           "County": {
@@ -17994,6 +33107,9 @@
           "CBSA Code": 44100,
           "Metropolitan Division Code": null,
           "CSA Code": 522,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Springfield-Jacksonville-Lincoln, IL",
           "County": {
@@ -18012,6 +33128,9 @@
           "CBSA Code": 44140,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18028,6 +33147,9 @@
           "CBSA Code": 44140,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18044,6 +33166,9 @@
           "CBSA Code": 44140,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18062,6 +33187,9 @@
           "CBSA Code": 44180,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18078,6 +33206,9 @@
           "CBSA Code": 44180,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18094,6 +33225,9 @@
           "CBSA Code": 44180,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18110,6 +33244,9 @@
           "CBSA Code": 44180,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18126,6 +33263,9 @@
           "CBSA Code": 44180,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18144,6 +33284,9 @@
           "CBSA Code": 44220,
           "Metropolitan Division Code": null,
           "CSA Code": 212,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Dayton-Springfield-Kettering, OH",
           "County": {
@@ -18157,11 +33300,54 @@
           }
        }
     ],
+    "Starkville, MS": [
+       {
+          "CBSA Code": 44260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Oktibbeha County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 105,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 44260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Webster County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 155,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "State College, PA": [
        {
           "CBSA Code": 44300,
           "Metropolitan Division Code": null,
           "CSA Code": 524,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "State College-DuBois, PA",
           "County": {
@@ -18175,11 +33361,35 @@
           }
        }
     ],
+    "Statesboro, GA": [
+       {
+          "CBSA Code": 44340,
+          "Metropolitan Division Code": null,
+          "CSA Code": 496,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Savannah-Hinesville-Statesboro, GA",
+          "County": {
+             "County Equivalent": "Bulloch County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 31,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Staunton, VA": [
        {
           "CBSA Code": 44420,
           "Metropolitan Division Code": null,
           "CSA Code": 277,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Harrisonburg-Staunton, VA",
           "County": {
@@ -18196,6 +33406,9 @@
           "CBSA Code": 44420,
           "Metropolitan Division Code": null,
           "CSA Code": 277,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Harrisonburg-Staunton, VA",
           "County": {
@@ -18212,6 +33425,9 @@
           "CBSA Code": 44420,
           "Metropolitan Division Code": null,
           "CSA Code": 277,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Harrisonburg-Staunton, VA",
           "County": {
@@ -18225,11 +33441,140 @@
           }
        }
     ],
+    "Steamboat Springs, CO": [
+       {
+          "CBSA Code": 44460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 525,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Steamboat Springs-Craig, CO",
+          "County": {
+             "County Equivalent": "Routt County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 107,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Stephenville, TX": [
+       {
+          "CBSA Code": 44500,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Erath County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 143,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Sterling, CO": [
+       {
+          "CBSA Code": 44540,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Logan County"
+          },
+          "State Name": "Colorado",
+          "FIPS State Code": 8,
+          "FIPS County Code": 75,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Sterling, IL": [
+       {
+          "CBSA Code": 44580,
+          "Metropolitan Division Code": null,
+          "CSA Code": 221,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dixon-Sterling, IL",
+          "County": {
+             "County Equivalent": "Whiteside County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 195,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Stevens Point, WI": [
+       {
+          "CBSA Code": 44620,
+          "Metropolitan Division Code": null,
+          "CSA Code": 554,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Wausau-Stevens Point-Wisconsin Rapids, WI",
+          "County": {
+             "County Equivalent": "Portage County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 97,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Stillwater, OK": [
+       {
+          "CBSA Code": 44660,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Payne County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 119,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Stockton, CA": [
        {
           "CBSA Code": 44700,
           "Metropolitan Division Code": null,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -18243,11 +33588,98 @@
           }
        }
     ],
+    "Storm Lake, IA": [
+       {
+          "CBSA Code": 44740,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Buena Vista County"
+          },
+          "State Name": "Iowa",
+          "FIPS State Code": 19,
+          "FIPS County Code": 21,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Sturgis, MI": [
+       {
+          "CBSA Code": 44780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 310,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Kalamazoo-Battle Creek-Portage, MI",
+          "County": {
+             "County Equivalent": "St. Joseph County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 149,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Sulphur Springs, TX": [
+       {
+          "CBSA Code": 44860,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Hopkins County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 223,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Summerville, GA": [
+       {
+          "CBSA Code": 44900,
+          "Metropolitan Division Code": null,
+          "CSA Code": 174,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Chattanooga-Cleveland-Dalton, TN-GA",
+          "County": {
+             "County Equivalent": "Chattooga County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 55,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Sumter, SC": [
        {
           "CBSA Code": 44940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18264,6 +33696,9 @@
           "CBSA Code": 44940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18277,11 +33712,77 @@
           }
        }
     ],
+    "Sunbury, PA": [
+       {
+          "CBSA Code": 44980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 146,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Bloomsburg-Berwick-Sunbury, PA",
+          "County": {
+             "County Equivalent": "Northumberland County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 97,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Susanville, CA": [
+       {
+          "CBSA Code": 45000,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Lassen County"
+          },
+          "State Name": "California",
+          "FIPS State Code": 6,
+          "FIPS County Code": 35,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Sweetwater, TX": [
+       {
+          "CBSA Code": 45020,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Nolan County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 353,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Syracuse, NY": [
        {
           "CBSA Code": 45060,
           "Metropolitan Division Code": null,
           "CSA Code": 532,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Syracuse-Auburn, NY",
           "County": {
@@ -18298,6 +33799,9 @@
           "CBSA Code": 45060,
           "Metropolitan Division Code": null,
           "CSA Code": 532,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Syracuse-Auburn, NY",
           "County": {
@@ -18314,6 +33818,9 @@
           "CBSA Code": 45060,
           "Metropolitan Division Code": null,
           "CSA Code": 532,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Syracuse-Auburn, NY",
           "County": {
@@ -18327,11 +33834,56 @@
           }
        }
     ],
+    "Tahlequah, OK": [
+       {
+          "CBSA Code": 45140,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Cherokee County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 21,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Talladega-Sylacauga, AL": [
+       {
+          "CBSA Code": 45180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 142,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Birmingham-Hoover-Talladega, AL",
+          "County": {
+             "County Equivalent": "Talladega County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 121,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Tallahassee, FL": [
        {
           "CBSA Code": 45220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18348,6 +33900,9 @@
           "CBSA Code": 45220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18364,6 +33919,9 @@
           "CBSA Code": 45220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18380,6 +33938,9 @@
           "CBSA Code": 45220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18398,6 +33959,9 @@
           "CBSA Code": 45300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18414,6 +33978,9 @@
           "CBSA Code": 45300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18430,6 +33997,9 @@
           "CBSA Code": 45300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18446,6 +34016,9 @@
           "CBSA Code": 45300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18459,11 +34032,56 @@
           }
        }
     ],
+    "Taos, NM": [
+       {
+          "CBSA Code": 45340,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Taos County"
+          },
+          "State Name": "New Mexico",
+          "FIPS State Code": 35,
+          "FIPS County Code": 55,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Taylorville, IL": [
+       {
+          "CBSA Code": 45380,
+          "Metropolitan Division Code": null,
+          "CSA Code": 522,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Springfield-Jacksonville-Lincoln, IL",
+          "County": {
+             "County Equivalent": "Christian County"
+          },
+          "State Name": "Illinois",
+          "FIPS State Code": 17,
+          "FIPS County Code": 21,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Terre Haute, IN": [
        {
           "CBSA Code": 45460,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18480,6 +34098,9 @@
           "CBSA Code": 45460,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18496,6 +34117,9 @@
           "CBSA Code": 45460,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18512,6 +34136,9 @@
           "CBSA Code": 45460,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18528,6 +34155,9 @@
           "CBSA Code": 45460,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18546,6 +34176,9 @@
           "CBSA Code": 45500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18562,6 +34195,9 @@
           "CBSA Code": 45500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18578,6 +34214,9 @@
           "CBSA Code": 45500,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18591,11 +34230,35 @@
           }
        }
     ],
+    "The Dalles, OR": [
+       {
+          "CBSA Code": 45520,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Wasco County"
+          },
+          "State Name": "Oregon",
+          "FIPS State Code": 41,
+          "FIPS County Code": 65,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "The Villages, FL": [
        {
           "CBSA Code": 45540,
           "Metropolitan Division Code": null,
           "CSA Code": 422,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Orlando-Lakeland-Deltona, FL",
           "County": {
@@ -18609,11 +34272,119 @@
           }
        }
     ],
+    "Thomaston, GA": [
+       {
+          "CBSA Code": 45580,
+          "Metropolitan Division Code": null,
+          "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
+          "County": {
+             "County Equivalent": "Upson County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 293,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Thomasville, GA": [
+       {
+          "CBSA Code": 45620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Thomas County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 275,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Tiffin, OH": [
+       {
+          "CBSA Code": 45660,
+          "Metropolitan Division Code": null,
+          "CSA Code": 534,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Toledo-Findlay-Tiffin, OH",
+          "County": {
+             "County Equivalent": "Seneca County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 147,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Tifton, GA": [
+       {
+          "CBSA Code": 45700,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Tift County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 277,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Toccoa, GA": [
+       {
+          "CBSA Code": 45740,
+          "Metropolitan Division Code": null,
+          "CSA Code": 122,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Atlanta--Athens-Clarke County--Sandy Springs, GA-AL",
+          "County": {
+             "County Equivalent": "Stephens County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 257,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Toledo, OH": [
        {
           "CBSA Code": 45780,
           "Metropolitan Division Code": null,
           "CSA Code": 534,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Toledo-Findlay-Tiffin, OH",
           "County": {
@@ -18630,6 +34401,9 @@
           "CBSA Code": 45780,
           "Metropolitan Division Code": null,
           "CSA Code": 534,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Toledo-Findlay-Tiffin, OH",
           "County": {
@@ -18646,6 +34420,9 @@
           "CBSA Code": 45780,
           "Metropolitan Division Code": null,
           "CSA Code": 534,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Toledo-Findlay-Tiffin, OH",
           "County": {
@@ -18662,6 +34439,9 @@
           "CBSA Code": 45780,
           "Metropolitan Division Code": null,
           "CSA Code": 534,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Toledo-Findlay-Tiffin, OH",
           "County": {
@@ -18680,6 +34460,9 @@
           "CBSA Code": 45820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18696,6 +34479,9 @@
           "CBSA Code": 45820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18712,6 +34498,9 @@
           "CBSA Code": 45820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18728,6 +34517,9 @@
           "CBSA Code": 45820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18744,6 +34536,9 @@
           "CBSA Code": 45820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18757,11 +34552,113 @@
           }
        }
     ],
+    "Torrington, CT": [
+       {
+          "CBSA Code": 45860,
+          "Metropolitan Division Code": null,
+          "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "New York-Newark, NY-NJ-CT-PA",
+          "County": {
+             "County Equivalent": "Litchfield County"
+          },
+          "State Name": "Connecticut",
+          "FIPS State Code": 9,
+          "FIPS County Code": 5,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Traverse City, MI": [
+       {
+          "CBSA Code": 45900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Benzie County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 19,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 45900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Grand Traverse County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 55,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 45900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Kalkaska County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 79,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 45900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Leelanau County"
+          },
+          "State Name": "Michigan",
+          "FIPS State Code": 26,
+          "FIPS County Code": 89,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Trenton-Princeton, NJ": [
        {
           "CBSA Code": 45940,
           "Metropolitan Division Code": null,
           "CSA Code": 408,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "New York-Newark, NY-NJ-CT-PA",
           "County": {
@@ -18775,11 +34672,56 @@
           }
        }
     ],
+    "Troy, AL": [
+       {
+          "CBSA Code": 45980,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pike County"
+          },
+          "State Name": "Alabama",
+          "FIPS State Code": 1,
+          "FIPS County Code": 109,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Truckee-Grass Valley, CA": [
+       {
+          "CBSA Code": 46020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 472,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Sacramento-Roseville, CA",
+          "County": {
+             "County Equivalent": "Nevada County"
+          },
+          "State Name": "California",
+          "FIPS State Code": 6,
+          "FIPS County Code": 57,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Tucson, AZ": [
        {
           "CBSA Code": 46060,
           "Metropolitan Division Code": null,
           "CSA Code": 536,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Tucson-Nogales, AZ",
           "County": {
@@ -18793,11 +34735,73 @@
           }
        }
     ],
+    "Tullahoma-Manchester, TN": [
+       {
+          "CBSA Code": 46100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Coffee County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 31,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 46100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Franklin County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 51,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 46100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Moore County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 127,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Tulsa, OK": [
        {
           "CBSA Code": 46140,
           "Metropolitan Division Code": null,
           "CSA Code": 538,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Tulsa-Muskogee-Bartlesville, OK",
           "County": {
@@ -18814,6 +34818,9 @@
           "CBSA Code": 46140,
           "Metropolitan Division Code": null,
           "CSA Code": 538,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Tulsa-Muskogee-Bartlesville, OK",
           "County": {
@@ -18830,6 +34837,9 @@
           "CBSA Code": 46140,
           "Metropolitan Division Code": null,
           "CSA Code": 538,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Tulsa-Muskogee-Bartlesville, OK",
           "County": {
@@ -18846,6 +34856,9 @@
           "CBSA Code": 46140,
           "Metropolitan Division Code": null,
           "CSA Code": 538,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Tulsa-Muskogee-Bartlesville, OK",
           "County": {
@@ -18862,6 +34875,9 @@
           "CBSA Code": 46140,
           "Metropolitan Division Code": null,
           "CSA Code": 538,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Tulsa-Muskogee-Bartlesville, OK",
           "County": {
@@ -18878,6 +34894,9 @@
           "CBSA Code": 46140,
           "Metropolitan Division Code": null,
           "CSA Code": 538,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Tulsa-Muskogee-Bartlesville, OK",
           "County": {
@@ -18894,6 +34913,9 @@
           "CBSA Code": 46140,
           "Metropolitan Division Code": null,
           "CSA Code": 538,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Tulsa-Muskogee-Bartlesville, OK",
           "County": {
@@ -18907,11 +34929,92 @@
           }
        }
     ],
+    "Tupelo, MS": [
+       {
+          "CBSA Code": 46180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 539,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Tupelo-Corinth, MS",
+          "County": {
+             "County Equivalent": "Itawamba County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 57,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 46180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 539,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Tupelo-Corinth, MS",
+          "County": {
+             "County Equivalent": "Lee County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 81,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 46180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 539,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Tupelo-Corinth, MS",
+          "County": {
+             "County Equivalent": "Pontotoc County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 115,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 46180,
+          "Metropolitan Division Code": null,
+          "CSA Code": 539,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Tupelo-Corinth, MS",
+          "County": {
+             "County Equivalent": "Prentiss County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 117,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
     "Tuscaloosa, AL": [
        {
           "CBSA Code": 46220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18928,6 +35031,9 @@
           "CBSA Code": 46220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18944,6 +35050,9 @@
           "CBSA Code": 46220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18960,6 +35069,9 @@
           "CBSA Code": 46220,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18978,6 +35090,9 @@
           "CBSA Code": 46300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -18994,6 +35109,9 @@
           "CBSA Code": 46300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -19012,6 +35130,9 @@
           "CBSA Code": 46340,
           "Metropolitan Division Code": null,
           "CSA Code": 540,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Tyler-Jacksonville, TX",
           "County": {
@@ -19025,11 +35146,98 @@
           }
        }
     ],
+    "Ukiah, CA": [
+       {
+          "CBSA Code": 46380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Mendocino County"
+          },
+          "State Name": "California",
+          "FIPS State Code": 6,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Union, SC": [
+       {
+          "CBSA Code": 46420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 273,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Greenville-Spartanburg-Anderson, SC",
+          "County": {
+             "County Equivalent": "Union County"
+          },
+          "State Name": "South Carolina",
+          "FIPS State Code": 45,
+          "FIPS County Code": 87,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Union City, TN": [
+       {
+          "CBSA Code": 46460,
+          "Metropolitan Division Code": null,
+          "CSA Code": 362,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Martin-Union City, TN",
+          "County": {
+             "County Equivalent": "Obion County"
+          },
+          "State Name": "Tennessee",
+          "FIPS State Code": 47,
+          "FIPS County Code": 131,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Urbana, OH": [
+       {
+          "CBSA Code": 46500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 212,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Dayton-Springfield-Kettering, OH",
+          "County": {
+             "County Equivalent": "Champaign County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 21,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Urban Honolulu, HI": [
        {
           "CBSA Code": 46520,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -19048,6 +35256,9 @@
           "CBSA Code": 46540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -19064,6 +35275,9 @@
           "CBSA Code": 46540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -19077,11 +35291,35 @@
           }
        }
     ],
+    "Uvalde, TX": [
+       {
+          "CBSA Code": 46620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Uvalde County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 463,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Valdosta, GA": [
        {
           "CBSA Code": 46660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -19098,6 +35336,9 @@
           "CBSA Code": 46660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -19114,6 +35355,9 @@
           "CBSA Code": 46660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -19130,6 +35374,9 @@
           "CBSA Code": 46660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -19148,6 +35395,9 @@
           "CBSA Code": 46700,
           "Metropolitan Division Code": null,
           "CSA Code": 488,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "San Jose-San Francisco-Oakland, CA",
           "County": {
@@ -19161,11 +35411,119 @@
           }
        }
     ],
+    "Van Wert, OH": [
+       {
+          "CBSA Code": 46780,
+          "Metropolitan Division Code": null,
+          "CSA Code": 338,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lima-Van Wert-Celina, OH",
+          "County": {
+             "County Equivalent": "Van Wert County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 161,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Vermillion, SD": [
+       {
+          "CBSA Code": 46820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Clay County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Vernal, UT": [
+       {
+          "CBSA Code": 46860,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Uintah County"
+          },
+          "State Name": "Utah",
+          "FIPS State Code": 49,
+          "FIPS County Code": 47,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Vernon, TX": [
+       {
+          "CBSA Code": 46900,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Wilbarger County"
+          },
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 487,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Vicksburg, MS": [
+       {
+          "CBSA Code": 46980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 298,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Jackson-Vicksburg-Brookhaven, MS",
+          "County": {
+             "County Equivalent": "Warren County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 149,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Victoria, TX": [
        {
           "CBSA Code": 47020,
           "Metropolitan Division Code": null,
           "CSA Code": 544,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Victoria-Port Lavaca, TX",
           "County": {
@@ -19182,6 +35540,9 @@
           "CBSA Code": 47020,
           "Metropolitan Division Code": null,
           "CSA Code": 544,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Victoria-Port Lavaca, TX",
           "County": {
@@ -19195,11 +35556,75 @@
           }
        }
     ],
+    "Vidalia, GA": [
+       {
+          "CBSA Code": 47080,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Montgomery County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 209,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 47080,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Toombs County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 279,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Vincennes, IN": [
+       {
+          "CBSA Code": 47180,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Knox County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 83,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Vineland-Bridgeton, NJ": [
        {
           "CBSA Code": 47220,
           "Metropolitan Division Code": null,
           "CSA Code": 428,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Philadelphia-Reading-Camden, PA-NJ-DE-MD",
           "County": {
@@ -19213,11 +35638,35 @@
           }
        }
     ],
+    "Vineyard Haven, MA": [
+       {
+          "CBSA Code": 47240,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Dukes County"
+          },
+          "State Name": "Massachusetts",
+          "FIPS State Code": 25,
+          "FIPS County Code": 7,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Virginia Beach-Norfolk-Newport News, VA-NC": [
        {
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19234,6 +35683,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19250,6 +35702,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19266,6 +35721,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19282,6 +35740,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19298,6 +35759,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19314,6 +35778,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19330,6 +35797,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19346,6 +35816,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19362,6 +35835,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19378,6 +35854,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19394,6 +35873,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19410,6 +35892,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19426,6 +35911,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19442,6 +35930,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19458,6 +35949,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19474,6 +35968,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19490,6 +35987,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19506,6 +36006,9 @@
           "CBSA Code": 47260,
           "Metropolitan Division Code": null,
           "CSA Code": 545,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Virginia Beach-Norfolk, VA-NC",
           "County": {
@@ -19524,6 +36027,9 @@
           "CBSA Code": 47300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -19537,11 +36043,35 @@
           }
        }
     ],
+    "Wabash, IN": [
+       {
+          "CBSA Code": 47340,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Wabash County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 169,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Waco, TX": [
        {
           "CBSA Code": 47380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -19558,6 +36088,9 @@
           "CBSA Code": 47380,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -19571,11 +36104,54 @@
           }
        }
     ],
+    "Wahpeton, ND-MN": [
+       {
+          "CBSA Code": 47420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 244,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Fargo-Wahpeton, ND-MN",
+          "County": {
+             "County Equivalent": "Wilkin County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 167,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 47420,
+          "Metropolitan Division Code": null,
+          "CSA Code": 244,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Fargo-Wahpeton, ND-MN",
+          "County": {
+             "County Equivalent": "Richland County"
+          },
+          "State Name": "North Dakota",
+          "FIPS State Code": 38,
+          "FIPS County Code": 77,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Walla Walla, WA": [
        {
           "CBSA Code": 47460,
           "Metropolitan Division Code": null,
           "CSA Code": 313,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Kennewick-Richland-Walla Walla, WA",
           "County": {
@@ -19589,11 +36165,35 @@
           }
        }
     ],
+    "Wapakoneta, OH": [
+       {
+          "CBSA Code": 47540,
+          "Metropolitan Division Code": null,
+          "CSA Code": 338,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Lima-Van Wert-Celina, OH",
+          "County": {
+             "County Equivalent": "Auglaize County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 11,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Warner Robins, GA": [
        {
           "CBSA Code": 47580,
           "Metropolitan Division Code": null,
           "CSA Code": 356,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Macon-Bibb County--Warner Robins, GA",
           "County": {
@@ -19610,6 +36210,9 @@
           "CBSA Code": 47580,
           "Metropolitan Division Code": null,
           "CSA Code": 356,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Macon-Bibb County--Warner Robins, GA",
           "County": {
@@ -19623,11 +36226,119 @@
           }
        }
     ],
+    "Warren, PA": [
+       {
+          "CBSA Code": 47620,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Warren County"
+          },
+          "State Name": "Pennsylvania",
+          "FIPS State Code": 42,
+          "FIPS County Code": 123,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Warrensburg, MO": [
+       {
+          "CBSA Code": 47660,
+          "Metropolitan Division Code": null,
+          "CSA Code": 312,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Kansas City-Overland Park-Kansas City, MO-KS",
+          "County": {
+             "County Equivalent": "Johnson County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 101,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Warsaw, IN": [
+       {
+          "CBSA Code": 47700,
+          "Metropolitan Division Code": null,
+          "CSA Code": 515,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "South Bend-Elkhart-Mishawaka, IN-MI",
+          "County": {
+             "County Equivalent": "Kosciusko County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 85,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Washington, IN": [
+       {
+          "CBSA Code": 47780,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Daviess County"
+          },
+          "State Name": "Indiana",
+          "FIPS State Code": 18,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Washington, NC": [
+       {
+          "CBSA Code": 47820,
+          "Metropolitan Division Code": null,
+          "CSA Code": 272,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Greenville-Kinston-Washington, NC",
+          "County": {
+             "County Equivalent": "Beaufort County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Washington-Arlington-Alexandria, DC-VA-MD-WV": [
        {
           "CBSA Code": 47900,
           "Metropolitan Division Code": 23224,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Frederick-Gaithersburg-Rockville, MD",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19644,6 +36355,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 23224,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Frederick-Gaithersburg-Rockville, MD",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19660,6 +36374,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19676,6 +36393,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19692,6 +36412,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19708,6 +36431,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19724,6 +36450,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19740,6 +36469,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19756,6 +36488,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19772,6 +36507,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19788,6 +36526,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19804,6 +36545,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19820,6 +36564,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19836,6 +36583,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19852,6 +36602,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19868,6 +36621,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19884,6 +36640,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19900,6 +36659,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19916,6 +36678,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19932,6 +36697,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19948,6 +36716,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19964,6 +36735,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19980,6 +36754,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -19996,6 +36773,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -20012,6 +36792,9 @@
           "CBSA Code": 47900,
           "Metropolitan Division Code": 47894,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "Washington-Arlington-Alexandria, DC-VA-MD-WV",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -20025,11 +36808,35 @@
           }
        }
     ],
+    "Washington Court House, OH": [
+       {
+          "CBSA Code": 47920,
+          "Metropolitan Division Code": null,
+          "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbus-Marion-Zanesville, OH",
+          "County": {
+             "County Equivalent": "Fayette County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 47,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Waterloo-Cedar Falls, IA": [
        {
           "CBSA Code": 47940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20046,6 +36853,9 @@
           "CBSA Code": 47940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20062,6 +36872,9 @@
           "CBSA Code": 47940,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20075,11 +36888,75 @@
           }
        }
     ],
+    "Watertown, SD": [
+       {
+          "CBSA Code": 47980,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Codington County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 29,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       },
+       {
+          "CBSA Code": 47980,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Hamlin County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 57,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       }
+    ],
+    "Watertown-Fort Atkinson, WI": [
+       {
+          "CBSA Code": 48020,
+          "Metropolitan Division Code": null,
+          "CSA Code": 376,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Milwaukee-Racine-Waukesha, WI",
+          "County": {
+             "County Equivalent": "Jefferson County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 55,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Watertown-Fort Drum, NY": [
        {
           "CBSA Code": 48060,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20093,11 +36970,35 @@
           }
        }
     ],
+    "Wauchula, FL": [
+       {
+          "CBSA Code": 48100,
+          "Metropolitan Division Code": null,
+          "CSA Code": 422,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Orlando-Lakeland-Deltona, FL",
+          "County": {
+             "County Equivalent": "Hardee County"
+          },
+          "State Name": "Florida",
+          "FIPS State Code": 12,
+          "FIPS County Code": 49,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Wausau-Weston, WI": [
        {
           "CBSA Code": 48140,
           "Metropolitan Division Code": null,
           "CSA Code": 554,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Wausau-Stevens Point-Wisconsin Rapids, WI",
           "County": {
@@ -20114,6 +37015,9 @@
           "CBSA Code": 48140,
           "Metropolitan Division Code": null,
           "CSA Code": 554,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Wausau-Stevens Point-Wisconsin Rapids, WI",
           "County": {
@@ -20127,11 +37031,75 @@
           }
        }
     ],
+    "Waycross, GA": [
+       {
+          "CBSA Code": 48180,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Pierce County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 229,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 48180,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Ware County"
+          },
+          "State Name": "Georgia",
+          "FIPS State Code": 13,
+          "FIPS County Code": 299,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Weatherford, OK": [
+       {
+          "CBSA Code": 48220,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Custer County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 39,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Weirton-Steubenville, WV-OH": [
        {
           "CBSA Code": 48260,
           "Metropolitan Division Code": null,
           "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
           "County": {
@@ -20148,6 +37116,9 @@
           "CBSA Code": 48260,
           "Metropolitan Division Code": null,
           "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
           "County": {
@@ -20164,6 +37135,9 @@
           "CBSA Code": 48260,
           "Metropolitan Division Code": null,
           "CSA Code": 430,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Pittsburgh-New Castle-Weirton, PA-OH-WV",
           "County": {
@@ -20182,6 +37156,9 @@
           "CBSA Code": 48300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20198,6 +37175,9 @@
           "CBSA Code": 48300,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20211,11 +37191,56 @@
           }
        }
     ],
+    "West Plains, MO": [
+       {
+          "CBSA Code": 48460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Howell County"
+          },
+          "State Name": "Missouri",
+          "FIPS State Code": 29,
+          "FIPS County Code": 91,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "West Point, MS": [
+       {
+          "CBSA Code": 48500,
+          "Metropolitan Division Code": null,
+          "CSA Code": 200,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbus-West Point, MS",
+          "County": {
+             "County Equivalent": "Clay County"
+          },
+          "State Name": "Mississippi",
+          "FIPS State Code": 28,
+          "FIPS County Code": 25,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Wheeling, WV-OH": [
        {
           "CBSA Code": 48540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20232,6 +37257,9 @@
           "CBSA Code": 48540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20248,6 +37276,9 @@
           "CBSA Code": 48540,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20261,11 +37292,35 @@
           }
        }
     ],
+    "Whitewater, WI": [
+       {
+          "CBSA Code": 48580,
+          "Metropolitan Division Code": null,
+          "CSA Code": 376,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Milwaukee-Racine-Waukesha, WI",
+          "County": {
+             "County Equivalent": "Walworth County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 127,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Wichita, KS": [
        {
           "CBSA Code": 48620,
           "Metropolitan Division Code": null,
           "CSA Code": 556,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Wichita-Winfield, KS",
           "County": {
@@ -20282,6 +37337,9 @@
           "CBSA Code": 48620,
           "Metropolitan Division Code": null,
           "CSA Code": 556,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Wichita-Winfield, KS",
           "County": {
@@ -20298,6 +37356,9 @@
           "CBSA Code": 48620,
           "Metropolitan Division Code": null,
           "CSA Code": 556,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Wichita-Winfield, KS",
           "County": {
@@ -20314,6 +37375,9 @@
           "CBSA Code": 48620,
           "Metropolitan Division Code": null,
           "CSA Code": 556,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Wichita-Winfield, KS",
           "County": {
@@ -20332,6 +37396,9 @@
           "CBSA Code": 48660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20348,6 +37415,9 @@
           "CBSA Code": 48660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20364,6 +37434,9 @@
           "CBSA Code": 48660,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20382,6 +37455,9 @@
           "CBSA Code": 48700,
           "Metropolitan Division Code": null,
           "CSA Code": 558,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Williamsport-Lock Haven, PA",
           "County": {
@@ -20395,11 +37471,56 @@
           }
        }
     ],
+    "Williston, ND": [
+       {
+          "CBSA Code": 48780,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Williams County"
+          },
+          "State Name": "North Dakota",
+          "FIPS State Code": 38,
+          "FIPS County Code": 105,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Willmar, MN": [
+       {
+          "CBSA Code": 48820,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Kandiyohi County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 67,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Wilmington, NC": [
        {
           "CBSA Code": 48900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20416,6 +37537,9 @@
           "CBSA Code": 48900,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20429,11 +37553,56 @@
           }
        }
     ],
+    "Wilmington, OH": [
+       {
+          "CBSA Code": 48940,
+          "Metropolitan Division Code": null,
+          "CSA Code": 178,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Cincinnati-Wilmington-Maysville, OH-KY-IN",
+          "County": {
+             "County Equivalent": "Clinton County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 27,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Wilson, NC": [
+       {
+          "CBSA Code": 48980,
+          "Metropolitan Division Code": null,
+          "CSA Code": 468,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Rocky Mount-Wilson-Roanoke Rapids, NC",
+          "County": {
+             "County Equivalent": "Wilson County"
+          },
+          "State Name": "North Carolina",
+          "FIPS State Code": 37,
+          "FIPS County Code": 195,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Winchester, VA-WV": [
        {
           "CBSA Code": 49020,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -20450,6 +37619,9 @@
           "CBSA Code": 49020,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -20466,6 +37638,9 @@
           "CBSA Code": 49020,
           "Metropolitan Division Code": null,
           "CSA Code": 548,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Washington-Baltimore-Arlington, DC-MD-VA-WV-PA",
           "County": {
@@ -20479,11 +37654,77 @@
           }
        }
     ],
+    "Winfield, KS": [
+       {
+          "CBSA Code": 49060,
+          "Metropolitan Division Code": null,
+          "CSA Code": 556,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Wichita-Winfield, KS",
+          "County": {
+             "County Equivalent": "Cowley County"
+          },
+          "State Name": "Kansas",
+          "FIPS State Code": 20,
+          "FIPS County Code": 35,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Winnemucca, NV": [
+       {
+          "CBSA Code": 49080,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Humboldt County"
+          },
+          "State Name": "Nevada",
+          "FIPS State Code": 32,
+          "FIPS County Code": 13,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Winona, MN": [
+       {
+          "CBSA Code": 49100,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Winona County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 169,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Winston-Salem, NC": [
        {
           "CBSA Code": 49180,
           "Metropolitan Division Code": null,
           "CSA Code": 268,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greensboro--Winston-Salem--High Point, NC",
           "County": {
@@ -20500,6 +37741,9 @@
           "CBSA Code": 49180,
           "Metropolitan Division Code": null,
           "CSA Code": 268,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greensboro--Winston-Salem--High Point, NC",
           "County": {
@@ -20516,6 +37760,9 @@
           "CBSA Code": 49180,
           "Metropolitan Division Code": null,
           "CSA Code": 268,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greensboro--Winston-Salem--High Point, NC",
           "County": {
@@ -20532,6 +37779,9 @@
           "CBSA Code": 49180,
           "Metropolitan Division Code": null,
           "CSA Code": 268,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greensboro--Winston-Salem--High Point, NC",
           "County": {
@@ -20548,6 +37798,9 @@
           "CBSA Code": 49180,
           "Metropolitan Division Code": null,
           "CSA Code": 268,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Greensboro--Winston-Salem--High Point, NC",
           "County": {
@@ -20561,11 +37814,96 @@
           }
        }
     ],
+    "Wisconsin Rapids-Marshfield, WI": [
+       {
+          "CBSA Code": 49220,
+          "Metropolitan Division Code": null,
+          "CSA Code": 554,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Wausau-Stevens Point-Wisconsin Rapids, WI",
+          "County": {
+             "County Equivalent": "Wood County"
+          },
+          "State Name": "Wisconsin",
+          "FIPS State Code": 55,
+          "FIPS County Code": 141,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Woodward, OK": [
+       {
+          "CBSA Code": 49260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Ellis County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 45,
+          "Central": {
+             "Outlying County": "Outlying"
+          }
+       },
+       {
+          "CBSA Code": 49260,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Woodward County"
+          },
+          "State Name": "Oklahoma",
+          "FIPS State Code": 40,
+          "FIPS County Code": 153,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
+    "Wooster, OH": [
+       {
+          "CBSA Code": 49300,
+          "Metropolitan Division Code": null,
+          "CSA Code": 184,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "Cleveland-Akron-Canton, OH",
+          "County": {
+             "County Equivalent": "Wayne County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 169,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Worcester, MA-CT": [
        {
           "CBSA Code": 49340,
           "Metropolitan Division Code": null,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -20582,6 +37920,9 @@
           "CBSA Code": 49340,
           "Metropolitan Division Code": null,
           "CSA Code": 148,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Boston-Worcester-Providence, MA-RI-NH-CT",
           "County": {
@@ -20595,11 +37936,35 @@
           }
        }
     ],
+    "Worthington, MN": [
+       {
+          "CBSA Code": 49380,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Nobles County"
+          },
+          "State Name": "Minnesota",
+          "FIPS State Code": 27,
+          "FIPS County Code": 105,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Yakima, WA": [
        {
           "CBSA Code": 49420,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20613,15 +37978,39 @@
           }
        }
     ],
+    "Yankton, SD": [
+       {
+          "CBSA Code": 49460,
+          "Metropolitan Division Code": null,
+          "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
+          "Metropolitan Division Title": "",
+          "CSA Title": "",
+          "County": {
+             "County Equivalent": "Yankton County"
+          },
+          "State Name": "South Dakota",
+          "FIPS State Code": 46,
+          "FIPS County Code": 135,
+          "Central": {
+             "Outlying County": "Central"
+          }
+       }
+    ],
     "Yauco, PR": [
        {
           "CBSA Code": 49500,
           "Metropolitan Division Code": null,
           "CSA Code": 434,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Ponce-Yauco-Coamo, PR",
           "County": {
-             "County Equivalent": "Guánica Municipio"
+             "County Equivalent": "Gu�nica Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -20634,6 +38023,9 @@
           "CBSA Code": 49500,
           "Metropolitan Division Code": null,
           "CSA Code": 434,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Ponce-Yauco-Coamo, PR",
           "County": {
@@ -20650,10 +38042,13 @@
           "CBSA Code": 49500,
           "Metropolitan Division Code": null,
           "CSA Code": 434,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Ponce-Yauco-Coamo, PR",
           "County": {
-             "County Equivalent": "Peñuelas Municipio"
+             "County Equivalent": "Pe�uelas Municipio"
           },
           "State Name": "Puerto Rico",
           "FIPS State Code": 72,
@@ -20666,6 +38061,9 @@
           "CBSA Code": 49500,
           "Metropolitan Division Code": null,
           "CSA Code": 434,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Ponce-Yauco-Coamo, PR",
           "County": {
@@ -20684,6 +38082,9 @@
           "CBSA Code": 49620,
           "Metropolitan Division Code": null,
           "CSA Code": 276,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Harrisburg-York-Lebanon, PA",
           "County": {
@@ -20702,6 +38103,9 @@
           "CBSA Code": 49660,
           "Metropolitan Division Code": null,
           "CSA Code": 566,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Youngstown-Warren, OH-PA",
           "County": {
@@ -20718,6 +38122,9 @@
           "CBSA Code": 49660,
           "Metropolitan Division Code": null,
           "CSA Code": 566,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Youngstown-Warren, OH-PA",
           "County": {
@@ -20734,6 +38141,9 @@
           "CBSA Code": 49660,
           "Metropolitan Division Code": null,
           "CSA Code": 566,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Youngstown-Warren, OH-PA",
           "County": {
@@ -20752,6 +38162,9 @@
           "CBSA Code": 49700,
           "Metropolitan Division Code": null,
           "CSA Code": 472,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Sacramento-Roseville, CA",
           "County": {
@@ -20768,6 +38181,9 @@
           "CBSA Code": 49700,
           "Metropolitan Division Code": null,
           "CSA Code": 472,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "Sacramento-Roseville, CA",
           "County": {
@@ -20786,6 +38202,9 @@
           "CBSA Code": 49740,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Metropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
@@ -20799,53 +38218,45 @@
           }
        }
     ],
-    "": [
+    "Zanesville, OH": [
        {
-          "CBSA Code": null,
+          "CBSA Code": 49780,
           "Metropolitan Division Code": null,
-          "CSA Code": null,
-          "Metropolitan Division Title": "",
-          "CSA Title": "",
-          "County": {
-             "County Equivalent": ""
+          "CSA Code": 198,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
           },
-          "State Name": "",
-          "FIPS State Code": null,
-          "FIPS County Code": null,
+          "Metropolitan Division Title": "",
+          "CSA Title": "Columbus-Marion-Zanesville, OH",
+          "County": {
+             "County Equivalent": "Muskingum County"
+          },
+          "State Name": "Ohio",
+          "FIPS State Code": 39,
+          "FIPS County Code": 119,
           "Central": {
-             "Outlying County": ""
+             "Outlying County": "Central"
           }
-       },
+       }
+    ],
+    "Zapata, TX": [
        {
-          "CBSA Code": null,
+          "CBSA Code": 49820,
           "Metropolitan Division Code": null,
           "CSA Code": null,
+          "Metropolitan": {
+             "Micropolitan Statistical Area": "Micropolitan Statistical Area"
+          },
           "Metropolitan Division Title": "",
           "CSA Title": "",
           "County": {
-             "County Equivalent": ""
+             "County Equivalent": "Zapata County"
           },
-          "State Name": "",
-          "FIPS State Code": null,
-          "FIPS County Code": null,
+          "State Name": "Texas",
+          "FIPS State Code": 48,
+          "FIPS County Code": 505,
           "Central": {
-             "Outlying County": ""
-          }
-       },
-       {
-          "CBSA Code": null,
-          "Metropolitan Division Code": null,
-          "CSA Code": null,
-          "Metropolitan Division Title": "",
-          "CSA Title": "",
-          "County": {
-             "County Equivalent": ""
-          },
-          "State Name": "",
-          "FIPS State Code": null,
-          "FIPS County Code": null,
-          "Central": {
-             "Outlying County": ""
+             "Outlying County": "Central"
           }
        }
     ]


### PR DESCRIPTION
New JSON format has CBSA names as indices rather than CBSA ID's, so changes reflect that. Filtering no longer uses Obj.values -- it's possible in the future that we need to convert our dictionary/map format into explicit key-value pairs if there is additional filtering to be done. 